### PR TITLE
Add conversion to and from bytes and Trytes

### DIFF
--- a/trinary.go
+++ b/trinary.go
@@ -342,8 +342,8 @@ func ToTrytes(t string) (Trytes, error) {
 func ToString(t Trytes) string {
 	var output string
 	for i := 0; i < len(t); i += 2 {
-		v1 := t[i]
-		v2 := t[i+1]
+		v1 := strings.IndexRune(TryteAlphabet, rune(t[i]))
+		v2 := strings.IndexRune(TryteAlphabet, rune(t[i+1]))
 		decimal := v1 + v2*27
 		c := rune(decimal)
 		output += string(c)

--- a/trinary.go
+++ b/trinary.go
@@ -339,6 +339,32 @@ func ToTrytes(t string) (Trytes, error) {
 	return tr, err
 }
 
+const alphabet = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func ToString(t Trytes) string {
+	var output string
+	for i := 0; i < len(t); i += 2 {
+		v1 := t[i]
+		v2 := t[i+1]
+		decimal := v1 + v2*27
+		c := rune(decimal)
+		output += string(c)
+	}
+	return output
+}
+
+func FromString(s string) Trytes {
+	var output string
+	chars := []rune(s)
+
+	for _, c := range chars {
+		v1 := c % 27
+		v2 := (c - v1) / 27
+		output += string(alphabet[v1]) + string(alphabet[v2])
+	}
+	return Trytes(output)
+}
+
 // Trits converts a slice of trytes into trits,
 func (t Trytes) Trits() Trits {
 	trits := make(Trits, len(t)*3)

--- a/trinary.go
+++ b/trinary.go
@@ -339,8 +339,6 @@ func ToTrytes(t string) (Trytes, error) {
 	return tr, err
 }
 
-const alphabet = "9ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
 func ToString(t Trytes) string {
 	var output string
 	for i := 0; i < len(t); i += 2 {
@@ -353,16 +351,19 @@ func ToString(t Trytes) string {
 	return output
 }
 
-func FromString(s string) Trytes {
+func FromString(s string) (Trytes, error) {
 	var output string
 	chars := []rune(s)
 
 	for _, c := range chars {
+		if c > 127 {
+			return "", errors.New("Input string contains non-ASCII characters")
+		}
 		v1 := c % 27
 		v2 := (c - v1) / 27
-		output += string(alphabet[v1]) + string(alphabet[v2])
+		output += string(TryteAlphabet[v1]) + string(TryteAlphabet[v2])
 	}
-	return Trytes(output)
+	return Trytes(output), nil
 }
 
 // Trits converts a slice of trytes into trits,

--- a/trinary.go
+++ b/trinary.go
@@ -339,31 +339,26 @@ func ToTrytes(t string) (Trytes, error) {
 	return tr, err
 }
 
-func ToString(t Trytes) string {
-	var output string
+func ToBytes(t Trytes) []byte {
+	var output []byte
 	for i := 0; i < len(t); i += 2 {
 		v1 := strings.IndexRune(TryteAlphabet, rune(t[i]))
 		v2 := strings.IndexRune(TryteAlphabet, rune(t[i+1]))
 		decimal := v1 + v2*27
-		c := rune(decimal)
-		output += string(c)
+		c := byte(decimal)
+		output = append(output, c)
 	}
 	return output
 }
 
-func FromString(s string) (Trytes, error) {
+func FromBytes(b []byte) Trytes {
 	var output string
-	chars := []rune(s)
-
-	for _, c := range chars {
-		if c > 127 {
-			return "", errors.New("Input string contains non-ASCII characters")
-		}
+	for _, c := range b {
 		v1 := c % 27
 		v2 := (c - v1) / 27
 		output += string(TryteAlphabet[v1]) + string(TryteAlphabet[v2])
 	}
-	return Trytes(output), nil
+	return Trytes(output)
 }
 
 // Trits converts a slice of trytes into trits,

--- a/trinary_test.go
+++ b/trinary_test.go
@@ -52,26 +52,24 @@ func TestValidTryte(t *testing.T) {
 	}
 }
 
-func TestValidStringToTrytes(t *testing.T) {
-	type tryteStringConversion struct {
-		s string
-		t Trytes
-	}
+type tryteByteConversion struct {
+	s []byte
+	t Trytes
+}
 
-	var stringConvCases = []tryteStringConversion{
-		{s: "Z", t: Trytes("IC")},
-		{s: "this is a test", t: Trytes("HDWCXCGDEAXCGDEAPCEAHDTCGDHD")},
-		{s: "Golang is the best lang!", t: Trytes("QBCD9DPCBDVCEAXCGDEAHDWCTCEAQCTCGDHDEA9DPCBDVCFA")},
+var stringConvCases = []tryteByteConversion{
+	{s: []byte("Z"), t: Trytes("IC")},
+	{s: []byte("this is a test"), t: Trytes("HDWCXCGDEAXCGDEAPCEAHDTCGDHD")},
+	{s: []byte("Golang is the best lang!"),
+		t: Trytes("QBCD9DPCBDVCEAXCGDEAHDWCTCEAQCTCGDHDEA9DPCBDVCFA")},
+	{s: []byte("Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen"),
+		t: "9CIDXCNDSCTC9DHDPCVCTCFDBDTCEAGDDDXCGDHDTCEAYCCDFDSCQCFGDFFDEAADTCSCEAUC9DFGVFSCTCQAEAADTCBDGDEARCXCFDZCIDGDZC9DCDJDBDTCBD"},
+	{s: []byte(""), t: ""},
+}
 
-		{s: "", t: ""},
-		// Returns error
-		{s: "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen", t: ""},
-	}
+func TestValidBytesToTrytes(t *testing.T) {
 	for _, tc := range stringConvCases {
-		result, err := FromString(tc.s)
-		if err != nil && tc.t != "" {
-			t.Fatalf("FromString(%q) returned error: %s", tc.s, err)
-		}
+		result := FromBytes([]byte(tc.s))
 		if result != tc.t {
 			t.Fatalf("FromString(%q) should be %#v but returned %s",
 				tc.s, tc.t, result)
@@ -79,23 +77,11 @@ func TestValidStringToTrytes(t *testing.T) {
 	}
 }
 
-func TestValidTrytesToString(t *testing.T) {
-	type tryteStringConversion struct {
-		s string
-		t Trytes
-	}
-
-	var stringConvCases = []tryteStringConversion{
-		{s: "Z", t: Trytes("IC")},
-		{s: "this is a test", t: Trytes("HDWCXCGDEAXCGDEAPCEAHDTCGDHD")},
-		{s: "Golang is the best lang!", t: Trytes("QBCD9DPCBDVCEAXCGDEAHDWCTCEAQCTCGDHDEA9DPCBDVCFA")},
-
-		{s: "", t: ""},
-	}
+func TestValidTrytesToBytes(t *testing.T) {
 	for _, tc := range stringConvCases {
-		if ToString(tc.t) != tc.s {
+		if string(ToBytes(tc.t)) != string(tc.s) {
 			t.Fatalf("ToString(%q) should be %#v but returned %s",
-				tc.t, tc.s, ToString(tc.t))
+				tc.t, tc.s, ToBytes(tc.t))
 		}
 	}
 }

--- a/trinary_test.go
+++ b/trinary_test.go
@@ -52,22 +52,21 @@ func TestValidTryte(t *testing.T) {
 	}
 }
 
-type tryteStringConversion struct {
-	s string
-	t Trytes
-}
-
-var stringConvCases = []tryteStringConversion{
-	{s: "Z", t: Trytes("IC")},
-	{s: "this is a test", t: Trytes("HDWCXCGDEAXCGDEAPCEAHDTCGDHD")},
-	{s: "Golang is the best lang!", t: Trytes("QBCD9DPCBDVCEAXCGDEAHDWCTCEAQCTCGDHDEA9DPCBDVCFA")},
-
-	{s: "", t: ""},
-	// Returns error
-	{s: "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen", t: ""},
-}
-
 func TestValidStringToTrytes(t *testing.T) {
+	type tryteStringConversion struct {
+		s string
+		t Trytes
+	}
+
+	var stringConvCases = []tryteStringConversion{
+		{s: "Z", t: Trytes("IC")},
+		{s: "this is a test", t: Trytes("HDWCXCGDEAXCGDEAPCEAHDTCGDHD")},
+		{s: "Golang is the best lang!", t: Trytes("QBCD9DPCBDVCEAXCGDEAHDWCTCEAQCTCGDHDEA9DPCBDVCFA")},
+
+		{s: "", t: ""},
+		// Returns error
+		{s: "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen", t: ""},
+	}
 	for _, tc := range stringConvCases {
 		result, err := FromString(tc.s)
 		if err != nil && tc.t != "" {
@@ -81,6 +80,18 @@ func TestValidStringToTrytes(t *testing.T) {
 }
 
 func TestValidTrytesToString(t *testing.T) {
+	type tryteStringConversion struct {
+		s string
+		t Trytes
+	}
+
+	var stringConvCases = []tryteStringConversion{
+		{s: "Z", t: Trytes("IC")},
+		{s: "this is a test", t: Trytes("HDWCXCGDEAXCGDEAPCEAHDTCGDHD")},
+		{s: "Golang is the best lang!", t: Trytes("QBCD9DPCBDVCEAXCGDEAHDWCTCEAQCTCGDHDEA9DPCBDVCFA")},
+
+		{s: "", t: ""},
+	}
 	for _, tc := range stringConvCases {
 		if ToString(tc.t) != tc.s {
 			t.Fatalf("ToString(%q) should be %#v but returned %s",

--- a/trinary_test.go
+++ b/trinary_test.go
@@ -61,13 +61,21 @@ var stringConvCases = []tryteStringConversion{
 	{s: "Z", t: Trytes("IC")},
 	{s: "this is a test", t: Trytes("HDWCXCGDEAXCGDEAPCEAHDTCGDHD")},
 	{s: "Golang is the best lang!", t: Trytes("QBCD9DPCBDVCEAXCGDEAHDWCTCEAQCTCGDHDEA9DPCBDVCFA")},
+
+	{s: "", t: ""},
+	// Returns error
+	{s: "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen", t: ""},
 }
 
 func TestValidStringToTrytes(t *testing.T) {
 	for _, tc := range stringConvCases {
-		if FromString(tc.s) != tc.t {
-			t.Fatalf("FromString(%q) should be %#v but returnd %s",
-				tc.s, tc.t, FromString(tc.s))
+		result, err := FromString(tc.s)
+		if err != nil && tc.t != "" {
+			t.Fatalf("FromString(%q) returned error: %s", tc.s, err)
+		}
+		if result != tc.t {
+			t.Fatalf("FromString(%q) should be %#v but returned %s",
+				tc.s, tc.t, result)
 		}
 	}
 }
@@ -75,7 +83,7 @@ func TestValidStringToTrytes(t *testing.T) {
 func TestValidTrytesToString(t *testing.T) {
 	for _, tc := range stringConvCases {
 		if ToString(tc.t) != tc.s {
-			t.Fatalf("ToString(%q) should be %#v but returnd %s",
+			t.Fatalf("ToString(%q) should be %#v but returned %s",
 				tc.t, tc.s, ToString(tc.t))
 		}
 	}

--- a/trinary_test.go
+++ b/trinary_test.go
@@ -52,6 +52,35 @@ func TestValidTryte(t *testing.T) {
 	}
 }
 
+type tryteStringConversion struct {
+	s string
+	t Trytes
+}
+
+var stringConvCases = []tryteStringConversion{
+	{s: "Z", t: Trytes("IC")},
+	{s: "this is a test", t: Trytes("HDWCXCGDEAXCGDEAPCEAHDTCGDHD")},
+	{s: "Golang is the best lang!", t: Trytes("QBCD9DPCBDVCEAXCGDEAHDWCTCEAQCTCGDHDEA9DPCBDVCFA")},
+}
+
+func TestValidStringToTrytes(t *testing.T) {
+	for _, tc := range stringConvCases {
+		if FromString(tc.s) != tc.t {
+			t.Fatalf("FromString(%q) should be %#v but returnd %s",
+				tc.s, tc.t, FromString(tc.s))
+		}
+	}
+}
+
+func TestValidTrytesToString(t *testing.T) {
+	for _, tc := range stringConvCases {
+		if ToString(tc.t) != tc.s {
+			t.Fatalf("ToString(%q) should be %#v but returnd %s",
+				tc.t, tc.s, ToString(tc.t))
+		}
+	}
+}
+
 func TestValidTrytes(t *testing.T) {
 	type validTryteTC struct {
 		in    Trytes


### PR DESCRIPTION
This adds functions for converting from ASCII to Trytes and back. I would have loved to used the method name `ToTrytes` but that is already taken and would introduce different behavior if changed. 

This is based off the javascript implementation: https://github.com/iotaledger/iota.lib.js/blob/37c5a1b10d8d6d7c6d688443f7c5b474e64d7679/lib/utils/asciiToTrytes.js 

