### PR TITLE
Cleanup of the SpongeFunction interface

### DIFF
--- a/account/deposit/deposit.go
+++ b/account/deposit/deposit.go
@@ -84,7 +84,7 @@ func (dc *CDA) Checksum() (Trytes, error) {
 	if err != nil {
 		return "", err
 	}
-	c := curl.NewCurl()
+	c := curl.NewCurlP81()
 	if err := c.Absorb(addrTrits); err != nil {
 		return "", err
 	}

--- a/curl/.examples/curl_examples_test.go
+++ b/curl/.examples/curl_examples_test.go
@@ -7,8 +7,15 @@ import (
 	"github.com/iotaledger/iota.go/trinary"
 )
 
-// o: *Curl, The new Curl instance.
+// i: rounds: The optional CurlRounds for hashing.
+// o: SpongeFunction, The SpongeFunction interface using Curl.
 func ExampleNewCurl() {}
+
+// o: SpongeFunction, The SpongeFunction interface using CurlP27.
+func ExampleNewCurlP27() {}
+
+// o: SpongeFunction, The SpongeFunction interface using CurlP81.
+func ExampleNewCurlP81() {}
 
 // i req: length, The length of the trits to squeeze out.
 // o: Trits, The Trits representation of the hash.

--- a/curl/curl.go
+++ b/curl/curl.go
@@ -210,3 +210,10 @@ func MustHashTrytes(t Trytes, rounds ...CurlRounds) Trytes {
 	}
 	return trytes
 }
+
+// Clone returns a deep copy of the current Curl
+func (c *Curl) Clone() SpongeFunction {
+	clone := NewCurl(c.Rounds).(*Curl)
+	copy(clone.State, c.State)
+	return clone
+}

--- a/curl/curl.go
+++ b/curl/curl.go
@@ -3,6 +3,7 @@ package curl
 
 import (
 	. "github.com/iotaledger/iota.go/consts"
+	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
 )
 
@@ -52,7 +53,7 @@ type Curl struct {
 }
 
 // NewCurl initializes a new instance with an empty State.
-func NewCurl(rounds ...CurlRounds) *Curl {
+func NewCurl(rounds ...CurlRounds) SpongeFunction {
 	curlRounds := NumberOfRounds
 
 	if len(rounds) > 0 {
@@ -64,6 +65,16 @@ func NewCurl(rounds ...CurlRounds) *Curl {
 		Rounds: curlRounds,
 	}
 	return c
+}
+
+// NewCurlP27 returns a new CurlP27.
+func NewCurlP27() SpongeFunction {
+	return NewCurl(CurlP27)
+}
+
+// NewCurlP81 returns a new CurlP81.
+func NewCurlP81() SpongeFunction {
+	return NewCurl(CurlP81)
 }
 
 // Squeeze squeezes out trits of the given length. Length has to be a multiple of HashTrinarySize.

--- a/kerl/.examples/kerl_examples_test.go
+++ b/kerl/.examples/kerl_examples_test.go
@@ -1,5 +1,6 @@
 package ker_examples_test
 
+// o: SpongeFunction, The SpongeFunction interface using Kerl.
 func ExampleNewKerl() {}
 
 // i req: length, The length of the Trits to squeeze out. Must be a multiple of 243.
@@ -7,11 +8,29 @@ func ExampleNewKerl() {}
 // o: error, Returned for invalid lengths and internal errors.
 func ExampleSqueeze() {}
 
+// i req: length, The length of the trits to squeeze out.
+// o: Trits, The Trits representation of the hash.
+func ExampleMustSqueeze() {}
+
+// i req: length, The length of the trits to squeeze out.
+// o: Trytes, The Trytes representation of the hash.
+// o: error, Returned for invalid lengths.
+func ExampleSqueezeTrytes() {}
+
+// i req: length, The length of the trits to squeeze out.
+// o: Trytes, The Trytes representation of the hash.
+func ExampleMustSqueezeTrytes() {}
+
 // i req: in, The Trits slice to absorb. Must be a multiple of 243 in length.
 // o: error, Returned for invalid slice lengths and internal errors.
 func ExampleAbsorb() {}
 
-func ExampleReset() {}
+// i req: inn, The Trytes to absorb.
+// o: error, Returned for internal errors.
+func ExampleAbsorbTrytes() {}
+
+// i req: inn, The Trytes to absorb.
+func ExampleMustAbsorbTrytes() {}
 
 // i req: trits, The Trits to convert to []byte.
 // o: []byte, The converted bytes.

--- a/kerl/kerl.go
+++ b/kerl/kerl.go
@@ -52,6 +52,31 @@ func (k *Kerl) Squeeze(length int) (Trits, error) {
 	return out, nil
 }
 
+// MustSqueeze squeezes out trits of the given length. Length has to be a multiple of HashTrinarySize.
+// It panics if the length is not valid.
+func (k *Kerl) MustSqueeze(length int) Trits {
+	out, err := k.Squeeze(length)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+// SqueezeTrytes squeezes out trytes of the given trit length. Length has to be a multiple of HashTrinarySize.
+func (k *Kerl) SqueezeTrytes(length int) (Trytes, error) {
+	trits, err := k.Squeeze(length)
+	if err != nil {
+		return "", err
+	}
+	return TritsToTrytes(trits)
+}
+
+// MustSqueezeTrytes squeezes out trytes of the given trit length. Length has to be a multiple of HashTrinarySize.
+// It panics if the trytes or the length are not valid.
+func (k *Kerl) MustSqueezeTrytes(length int) Trytes {
+	return MustTritsToTrytes(k.MustSqueeze(length))
+}
+
 // Absorb fills the internal state of the sponge with the given trits.
 // This is only defined for Trit slices that are a multiple of HashTrinarySize long.
 func (k *Kerl) Absorb(in Trits) error {
@@ -71,6 +96,31 @@ func (k *Kerl) Absorb(in Trits) error {
 	}
 
 	return nil
+}
+
+// AbsorbTrytes fills the internal State of the sponge with the given trytes.
+func (k *Kerl) AbsorbTrytes(inn Trytes) error {
+	var in Trits
+	var err error
+
+	if len(inn) == 0 {
+		in = Trits{0}
+	} else {
+		in, err = TrytesToTrits(inn)
+		if err != nil {
+			return err
+		}
+	}
+	return k.Absorb(in)
+}
+
+// AbsorbTrytes fills the internal State of the sponge with the given trytes.
+// It panics if the given trytes are not valid.
+func (k *Kerl) MustAbsorbTrytes(inn Trytes) {
+	err := k.AbsorbTrytes(inn)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Reset the internal state of the Kerl sponge.

--- a/kerl/kerl.go
+++ b/kerl/kerl.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/iotaledger/iota.go/consts"
 	keccak "github.com/iotaledger/iota.go/kerl/sha3"
+	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
 )
 
@@ -17,7 +18,7 @@ type Kerl struct {
 }
 
 // NewKerl returns a new Kerl
-func NewKerl() *Kerl {
+func NewKerl() SpongeFunction {
 	k := &Kerl{
 		s: keccak.New384(),
 	}

--- a/kerl/kerl.go
+++ b/kerl/kerl.go
@@ -127,3 +127,11 @@ func (k *Kerl) MustAbsorbTrytes(inn Trytes) {
 func (k *Kerl) Reset() {
 	k.s.Reset()
 }
+
+// Clone returns a deep copy of the current Kerl
+func (k *Kerl) Clone() SpongeFunction {
+	clone := NewKerl().(*Kerl)
+
+	clone.s = keccak.CloneState(k.s)
+	return clone
+}

--- a/kerl/kerl_test.go
+++ b/kerl/kerl_test.go
@@ -3,6 +3,7 @@ package kerl_test
 import (
 	. "github.com/iotaledger/iota.go/consts"
 	. "github.com/iotaledger/iota.go/kerl"
+	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -36,7 +37,7 @@ var _ = Describe("Kerl", func() {
 
 	Context("with invalid trytes", func() {
 
-		var k *Kerl
+		var k SpongeFunction
 
 		BeforeEach(func() {
 			k = NewKerl()

--- a/kerl/sha3/sha3.go
+++ b/kerl/sha3/sha3.go
@@ -4,6 +4,10 @@
 
 package sha3
 
+import (
+	"hash"
+)
+
 // spongeDirection indicates the direction bytes are flowing through the sponge.
 type spongeDirection int
 
@@ -189,4 +193,9 @@ func (d *state) Sum(in []byte) []byte {
 	hash := make([]byte, dup.outputLen)
 	dup.Read(hash)
 	return append(in, hash...)
+}
+
+// CloneState returns a clone of the state.
+func CloneState(s hash.Hash) *state {
+	return s.(*state).Clone().(*state)
 }

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	. "github.com/iotaledger/iota.go/consts"
+	"github.com/iotaledger/iota.go/curl"
 	"github.com/iotaledger/iota.go/signing/legacy"
 	"github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
@@ -106,7 +107,7 @@ func MerkleCreate(baseSize uint64, seed Trytes, offset uint64, security Security
 	treeMerkleSize := MerkleSize(baseSize)
 	tree := make(Trits, treeMerkleSize*HashTrinarySize)
 
-	h := sponge.GetSpongeFunc(spongeFunc)
+	h := sponge.GetSpongeFunc(spongeFunc, curl.NewCurlP27)
 
 	td := MerkleDepth(treeMerkleSize) - 1
 
@@ -230,7 +231,7 @@ func MerkleBranch(tree Trits, siblings Trits, treeLength, treeDepth, leafIndex, 
 //	leafIndex is the node index of the hash
 //	spongeFunc is the optional sponge function to use
 func MerkleRoot(hash Trits, siblings Trits, siblingsNumber uint64, leafIndex uint64, spongeFunc ...sponge.SpongeFunction) (Trits, error) {
-	h := sponge.GetSpongeFunc(spongeFunc)
+	h := sponge.GetSpongeFunc(spongeFunc, curl.NewCurlP27)
 
 	var j uint64 = 1
 	var err error

--- a/merkle/merkle_test.go
+++ b/merkle/merkle_test.go
@@ -2,8 +2,8 @@ package merkle_test
 
 import (
 	. "github.com/iotaledger/iota.go/consts"
+	. "github.com/iotaledger/iota.go/curl"
 	. "github.com/iotaledger/iota.go/merkle"
-	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
 
 	. "github.com/onsi/ginkgo"

--- a/pow/.cl/pow_cl.go
+++ b/pow/.cl/pow_cl.go
@@ -272,7 +272,7 @@ func PowCL(trytes trinary.Trytes, mwm int) (trinary.Trytes, error) {
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl()
+	c := curl.NewCurlP81().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_avx.go
+++ b/pow/pow_avx.go
@@ -339,7 +339,7 @@ func avxProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism ...i
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl()
+	c := curl.NewCurl().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_avx.go
+++ b/pow/pow_avx.go
@@ -339,7 +339,7 @@ func avxProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism ...i
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl().(*curl.Curl)
+	c := curl.NewCurlP81().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_c.go
+++ b/pow/pow_c.go
@@ -249,7 +249,7 @@ func cProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism ...int
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl().(*curl.Curl)
+	c := curl.NewCurlP81().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_c.go
+++ b/pow/pow_c.go
@@ -249,7 +249,7 @@ func cProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism ...int
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl()
+	c := curl.NewCurl().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_c128.go
+++ b/pow/pow_c128.go
@@ -317,7 +317,7 @@ func c128ProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism ...
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl()
+	c := curl.NewCurl().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_c128.go
+++ b/pow/pow_c128.go
@@ -317,7 +317,7 @@ func c128ProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism ...
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl().(*curl.Curl)
+	c := curl.NewCurlP81().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_c_arm64.go
+++ b/pow/pow_c_arm64.go
@@ -305,7 +305,7 @@ func cARM64ProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism .
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl()
+	c := curl.NewCurl().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_c_arm64.go
+++ b/pow/pow_c_arm64.go
@@ -305,7 +305,7 @@ func cARM64ProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism .
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl().(*curl.Curl)
+	c := curl.NewCurlP81().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_go.go
+++ b/pow/pow_go.go
@@ -330,7 +330,7 @@ func goProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism ...in
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl(curl.CurlP81).(*curl.Curl)
+	c := curl.NewCurlP81().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_go.go
+++ b/pow/pow_go.go
@@ -330,7 +330,7 @@ func goProofOfWork(trytes Trytes, mwm int, optRate chan int64, parallelism ...in
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl()
+	c := curl.NewCurl(curl.CurlP81).(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_sse.go
+++ b/pow/pow_sse.go
@@ -284,7 +284,7 @@ func sseProofOfwork(trytes Trytes, mwm int, optRate chan int64, parallelism ...i
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl().(*curl.Curl)
+	c := curl.NewCurlP81().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/pow/pow_sse.go
+++ b/pow/pow_sse.go
@@ -284,7 +284,7 @@ func sseProofOfwork(trytes Trytes, mwm int, optRate chan int64, parallelism ...i
 
 	tr := MustTrytesToTrits(trytes)
 
-	c := curl.NewCurl()
+	c := curl.NewCurl().(*curl.Curl)
 	c.Absorb(tr[:(TransactionTrinarySize - HashTrinarySize)])
 	copy(c.State, tr[TransactionTrinarySize-HashTrinarySize:])
 

--- a/signing/legacy/signing.go
+++ b/signing/legacy/signing.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	. "github.com/iotaledger/iota.go/consts"
+	"github.com/iotaledger/iota.go/kerl"
 	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
 )
@@ -27,7 +28,7 @@ func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, er
 
 	incrementedSeed := AddTrits(trits, IntToTrits(int64(index)))
 
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	err = h.Absorb(incrementedSeed)
@@ -45,7 +46,7 @@ func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, er
 // Key computes a new private key from the given subseed using the given security level.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Key(subseed Trits, securityLevel SecurityLevel, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	keyLength := KeyFragmentLength * int(securityLevel)
@@ -88,7 +89,7 @@ func Digests(key Trits, spongeFunc ...SpongeFunction) (Trits, error) {
 	digests := make(Trits, HashTrinarySize)
 	buf := make(Trits, HashTrinarySize)
 
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	// iterate through each key fragment
@@ -135,7 +136,7 @@ func Digests(key Trits, spongeFunc ...SpongeFunction) (Trits, error) {
 // Address generates the address trits from the given digests.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Address(digests Trits, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	if err := h.Absorb(digests); err != nil {
@@ -172,7 +173,7 @@ func SignatureFragment(bundleHash Trits, keyFragment Trits, startOffset int, spo
 	keyLength := int(secLvl) * int(ISSKeyLength)
 	sigFrag := make(Trits, keyLength)
 
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	sig := make(Trits, HashTrinarySize)
@@ -219,7 +220,7 @@ func Digest(bundleHash []int8, signatureFragment Trits, startOffset int, spongeF
 	sigFrag := make(Trits, sigLength)
 	copy(sigFrag, signatureFragment[:sigLength])
 
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	dig := make(Trits, HashTrinarySize)

--- a/signing/legacy/signing_test.go
+++ b/signing/legacy/signing_test.go
@@ -2,8 +2,8 @@ package signing_test
 
 import (
 	. "github.com/iotaledger/iota.go/consts"
+	. "github.com/iotaledger/iota.go/curl"
 	. "github.com/iotaledger/iota.go/signing/legacy"
-	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/signing/signing.go
+++ b/signing/signing.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	. "github.com/iotaledger/iota.go/consts"
+	"github.com/iotaledger/iota.go/kerl"
 	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
 )
@@ -26,7 +27,7 @@ func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, er
 
 	incrementedSeed := AddTrits(trits, IntToTrits(int64(index)))
 
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	err = h.Absorb(incrementedSeed)
@@ -44,7 +45,7 @@ func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, er
 // Key computes a new private key from the given subseed using the given security level.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Key(subseed Trits, securityLevel SecurityLevel, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	if err := h.Absorb(subseed); err != nil {
@@ -74,7 +75,7 @@ func Digests(key Trits, spongeFunc ...SpongeFunction) (Trits, error) {
 	digests := make(Trits, fragments*HashTrinarySize)
 	buf := make(Trits, HashTrinarySize)
 
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	// iterate through each key fragment
@@ -119,7 +120,7 @@ func Digests(key Trits, spongeFunc ...SpongeFunction) (Trits, error) {
 // Address generates the address trits from the given digests.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Address(digests Trits, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	if err := h.Absorb(digests); err != nil {
@@ -168,7 +169,7 @@ func SignatureFragment(normalizedBundleHashFragment Trits, keyFragment Trits, sp
 	sigFrag := make(Trits, len(keyFragment))
 	copy(sigFrag, keyFragment)
 
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	for i := 0; i < KeySegmentsPerFragment; i++ {
@@ -196,7 +197,7 @@ func SignatureFragment(normalizedBundleHashFragment Trits, keyFragment Trits, sp
 // Digest computes the digest derived from the signature fragment and normalized bundle hash.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Digest(normalizedBundleHashFragment []int8, signatureFragment Trits, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc)
+	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
 	defer h.Reset()
 
 	buf := make(Trits, HashTrinarySize)

--- a/signing/signing_milestone_test.go
+++ b/signing/signing_milestone_test.go
@@ -2,9 +2,9 @@ package signing_test
 
 import (
 	"github.com/iotaledger/iota.go/consts"
+	. "github.com/iotaledger/iota.go/curl"
 	"github.com/iotaledger/iota.go/merkle"
 	. "github.com/iotaledger/iota.go/signing"
-	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/transaction"
 	. "github.com/iotaledger/iota.go/trinary"
 	. "github.com/onsi/ginkgo"

--- a/signing/utils/.examples/sponge_examples_test.go
+++ b/signing/utils/.examples/sponge_examples_test.go
@@ -1,14 +1,5 @@
 package sponge_examples_test
 
-// o: SpongeFunction, The SpongeFunction interface using CurlP27.
-func ExampleNewCurlP27() {}
-
-// o: SpongeFunction, The SpongeFunction interface using CurlP81.
-func ExampleNewCurlP81() {}
-
-// o: SpongeFunction, The SpongeFunction interface using Kerl.
-func ExampleNewKerl() {}
-
 // i req: spongeFunc, The sponge function to use. If none is given, the defaultSpongeFuncCreator will be used.
 // i: defaultSpongeFuncCreator, The optional sponge function creator to use. If no spongeFunc and no defaultSpongeFuncCreator is given, Kerl will be used.
 // o: SpongeFunction, The SpongeFunction interface.

--- a/signing/utils/sponge.go
+++ b/signing/utils/sponge.go
@@ -1,10 +1,7 @@
-// Package signing provides functions for creating and validating essential cryptographic
-// components in IOTA, such as subseeds, keys, digests and signatures.
+// Package sponge provides an interface for the sponge functions in IOTA.
 package sponge
 
 import (
-	"github.com/iotaledger/iota.go/curl"
-	"github.com/iotaledger/iota.go/kerl"
 	. "github.com/iotaledger/iota.go/trinary"
 )
 
@@ -17,22 +14,7 @@ type SpongeFunction interface {
 	Reset()
 }
 
-// NewCurlP27 returns a new CurlP27.
-func NewCurlP27() SpongeFunction {
-	return curl.NewCurl(curl.CurlP27)
-}
-
-// NewCurlP81 returns a new CurlP81.
-func NewCurlP81() SpongeFunction {
-	return curl.NewCurl(curl.CurlP81)
-}
-
-// NewKerl returns a new Kerl.
-func NewKerl() SpongeFunction {
-	return kerl.NewKerl()
-}
-
-// GetSpongeFunc checks if a hash function was given, otherwise uses defaultSpongeFuncCreator, or Kerl.
+// GetSpongeFunc checks if a hash function was given, otherwise uses defaultSpongeFuncCreator. Panics if none given.
 func GetSpongeFunc(spongeFunc []SpongeFunction, defaultSpongeFuncCreator ...SpongeFunctionCreator) SpongeFunction {
 	if len(spongeFunc) > 0 {
 		return spongeFunc[0]
@@ -40,5 +22,5 @@ func GetSpongeFunc(spongeFunc []SpongeFunction, defaultSpongeFuncCreator ...Spon
 	if len(defaultSpongeFuncCreator) > 0 {
 		return defaultSpongeFuncCreator[0]()
 	}
-	return NewKerl()
+	panic("No sponge function given")
 }

--- a/signing/utils/sponge.go
+++ b/signing/utils/sponge.go
@@ -9,8 +9,13 @@ type SpongeFunctionCreator func() SpongeFunction
 
 // SpongeFunction is a hash function using the sponge construction.
 type SpongeFunction interface {
-	Absorb(in Trits) error
 	Squeeze(length int) (Trits, error)
+	MustSqueeze(length int) Trits
+	SqueezeTrytes(length int) (Trytes, error)
+	MustSqueezeTrytes(length int) Trytes
+	Absorb(in Trits) error
+	AbsorbTrytes(in Trytes) error
+	MustAbsorbTrytes(in Trytes)
 	Reset()
 }
 

--- a/signing/utils/sponge.go
+++ b/signing/utils/sponge.go
@@ -17,6 +17,7 @@ type SpongeFunction interface {
 	AbsorbTrytes(in Trytes) error
 	MustAbsorbTrytes(in Trytes)
 	Reset()
+	Clone() SpongeFunction
 }
 
 // GetSpongeFunc checks if a hash function was given, otherwise uses defaultSpongeFuncCreator. Panics if none given.


### PR DESCRIPTION
# Description

This PR adds functionality to the SpongeFunction Interface and does some code cleanups / removes unnecessary package references.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)
- [x] Documentation Fix

# How Has This Been Tested?

```ginkgo -tags="pow_avx pow_sse pow_c pow_c128" -r --skipPackage=mongo --randomizeSuites --failOnPending --progress```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have written example code according to the contribution guidelines
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes