### PR TITLE
Improved ValidTrytes implementation - got rid of regexp

### DIFF
--- a/trinary/trinary.go
+++ b/trinary/trinary.go
@@ -3,7 +3,6 @@ package trinary
 
 import (
 	"math"
-	"regexp"
 	"strings"
 
 	. "github.com/iotaledger/iota.go/consts"
@@ -465,12 +464,15 @@ type Hash = Trytes
 // Hashes is a slice of Hash.
 type Hashes = []Hash
 
-var trytesRegex = regexp.MustCompile("^[9A-Z]+$")
-
 // ValidTrytes returns true if t is made of valid trytes.
 func ValidTrytes(trytes Trytes) error {
-	if !trytesRegex.MatchString(string(trytes)) {
+	if trytes == "" {
 		return ErrInvalidTrytes
+	}
+	for _, runeVal := range trytes {
+		if (runeVal < 'A' || runeVal > 'Z') && runeVal != '9' {
+			return ErrInvalidTrytes
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

This pull request improves tryte validation function - `trinary.ValidTrytes`. It used regular expression, and it's relatively slow in Golang (benchmark gist will be provided further). Implementation provided in this pull request is much faster, that can be important for worse performing devices and/or higher load applications.

Fixes #121 

## Type of change

- [x] Enhancement (non-breaking change)

# How Has This Been Tested?

- [ x ] `iota.go` project test suite
- [ x ] Benchmark to verify performance improvement and additional test to verify consistency of behavior.
Benchmark, test and all the necessary code (i.e. both function implementations with necessary types, global variable for regexp, error, benchmarks and test themselves as well as couple of setup functions for them) were condensed into a single gist: https://gist.github.com/siziyman/52a8a2f16a5ad38bf4474f4f6c28b9a1
On my current PC (Ryzen 3700X, 16 GB DDR4-3600 RAM, Windows 10 Pro) benchmark results are following:
```
$go test -bench=.
goos: windows
goarch: amd64
pkg: github.com/iotaledger/iota.go
BenchmarkValidTrytesRegex-16             1000000              1497 ns/op
BenchmarkValidTrytesLoop-16             20000000                74.6 ns/op
PASS
ok      github.com/iotaledger/iota.go   3.921s
```

On my work laptop (Lenovo Thinkpad T570, IIRC it's Intel i5-6500U, 16 GB DDR4 RAM, Windows 10) and under higher overall system load results were around 2900 ns/op for regex implementation and 135 ns/op for loop implementation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes