### PR TITLE
got rid of regexp in guards

### DIFF
--- a/guards/guards.go
+++ b/guards/guards.go
@@ -6,7 +6,6 @@ import (
 	"github.com/iotaledger/iota.go/curl"
 	. "github.com/iotaledger/iota.go/trinary"
 
-	"regexp"
 )
 
 // IsTrytes checks if input is correct trytes consisting of [9A-Z]
@@ -14,17 +13,25 @@ func IsTrytes(trytes Trytes) bool {
 	if len(trytes) < 1 {
 		return false
 	}
-	match, _ := regexp.MatchString("^[9A-Z]+$", string(trytes))
-	return match
+	for _, runeVal := range trytes {
+		if (runeVal < 'A' || runeVal > 'Z') && runeVal != '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // IsTrytesOfExactLength checks if input is correct trytes consisting of [9A-Z] and given length
 func IsTrytesOfExactLength(trytes Trytes, length int) bool {
-	if len(trytes) != length {
+	if len(trytes) != length || len(trytes) == 0 {
 		return false
 	}
-	match, _ := regexp.MatchString("^[9A-Z]+$", string(trytes))
-	return match
+        for _, runeVal := range trytes {
+                if (runeVal < 'A' || runeVal > 'Z') && runeVal != '9' {
+                        return false
+                }
+        }
+        return true
 }
 
 // IsTrytesOfMaxLength checks if input is correct trytes consisting of [9A-Z] and length <= maxLength
@@ -32,15 +39,23 @@ func IsTrytesOfMaxLength(trytes Trytes, max int) bool {
 	if len(trytes) > max || len(trytes) < 1 {
 		return false
 	}
-	match, _ := regexp.MatchString("^[9A-Z]+$", string(trytes))
-	return match
+        for _, runeVal := range trytes {
+                if (runeVal < 'A' || runeVal > 'Z') && runeVal != '9' {
+                        return false
+                }
+        }
+        return true
 }
-
-var onlyNinesRegex = regexp.MustCompile("^[9]+$")
 
 // IsEmptyTrytes checks if input is null (all 9s trytes)
 func IsEmptyTrytes(trytes Trytes) bool {
-	return onlyNinesRegex.MatchString(string(trytes))
+        for _, runeVal := range trytes {
+                if runeVal != '9' {
+                        return false
+                }
+        }
+
+        return true
 }
 
 // IsHash checks if input is correct hash (81 trytes or 90)


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up to smaller PRs. This will help getting it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split to several PRs!!!!!
4. It will be helpful if you make additional comments on the code via github PR review to explain the choices you made
-->

# Description

Following the same logic as in https://github.com/iotaledger/iota.go/pull/122
Regular expressions in regexp were causing problems with cross-compiled apps.
@siziyman has done a good job in replacing regexp in `trinary.ValidTrytes()` implementation, so I believe the same could be done to a few functions in the guards package, namely:
 - `guard.IsTrytes()`
 - `guard.IsTrytesOfExactLength()`
 - `guard.IsTrytesOfMaxLength()`
 - `guard.IsEmptyTrytes()`

This PR Partially Fixes https://github.com/iotaledger/iota.go/issues/128 (a few broken apps require additional work, which is still to be done).

## Type of change

Please delete options that are not relevant.

- [ ] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

All tests for guards package pass:
```
bernardoaraujo@Desktop0092:~/dev/iota.go/guards$ git rev-parse HEAD
c0fb10afb2a40cb709ee180e86b05418e8195e2f
bernardoaraujo@Desktop0092:~/dev/iota.go/guards$ go test
Running Suite: Guards Suite
===========================
Random Seed: 1573578224
Will run 28 of 28 specs

••••••••••••••••••••••••••••
Ran 28 of 28 Specs in 0.004 seconds
SUCCESS! -- 28 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/iotaledger/iota.go/guards	0.007s
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes