### PR TITLE
Make MAM channel exported

### DIFF
--- a/mam/v1/channel.go
+++ b/mam/v1/channel.go
@@ -5,38 +5,38 @@ import (
 	"github.com/iotaledger/iota.go/trinary"
 )
 
-type channel struct {
-	mode          ChannelMode
-	sideKey       trinary.Trytes
-	nextRoot      trinary.Trits
-	securityLevel consts.SecurityLevel
-	start         uint64
-	count         uint64
-	nextCount     uint64
-	index         uint64
+type Channel struct {
+	Mode          ChannelMode          `json:"mode"`
+	SideKey       trinary.Trytes       `json:"side_key"`
+	NextRoot      trinary.Trits        `json:"next_root"`
+	SecurityLevel consts.SecurityLevel `json:"security_level"`
+	Start         uint64               `json:"start"`
+	Count         uint64               `json:"count"`
+	NextCount     uint64               `json:"next_count"`
+	Index         uint64               `json:"index"`
 }
 
-func newChannel(securityLevel consts.SecurityLevel) *channel {
-	return &channel{
-		mode:          ChannelModePublic,
-		sideKey:       consts.NullHashTrytes,
-		securityLevel: securityLevel,
-		start:         0,
-		count:         1,
-		nextCount:     1,
-		index:         0,
+func NewChannel(securityLevel consts.SecurityLevel) *Channel {
+	return &Channel{
+		Mode:          ChannelModePublic,
+		SideKey:       consts.NullHashTrytes,
+		SecurityLevel: securityLevel,
+		Start:         0,
+		Count:         1,
+		NextCount:     1,
+		Index:         0,
 	}
 }
 
-func (c *channel) incIndex() {
-	if c.index == c.count-1 {
-		c.start += c.nextCount
-		c.index = 0
+func (c *Channel) incIndex() {
+	if c.Index == c.Count-1 {
+		c.Start += c.NextCount
+		c.Index = 0
 	} else {
-		c.index++
+		c.Index++
 	}
 }
 
-func (c *channel) nextStart() uint64 {
-	return c.start + c.count
+func (c *Channel) nextStart() uint64 {
+	return c.Start + c.Count
 }

--- a/mam/v1/channel_mode.go
+++ b/mam/v1/channel_mode.go
@@ -8,20 +8,20 @@ import (
 
 // Error definitions
 var (
-	ErrCouldNotParseChannelMode = errors.New("could not parse channel mode")
+	ErrCouldNotParseChannelMode = errors.New("could not parse Channel mode")
 )
 
-// ChannelMode is an enum of channel modes.
+// ChannelMode is an enum of Channel modes.
 type ChannelMode string
 
-// Definition of possible channel modes.
+// Definition of possible Channel modes.
 const (
 	ChannelModePublic     ChannelMode = "public"
 	ChannelModePrivate    ChannelMode = "private"
 	ChannelModeRestricted ChannelMode = "restricted"
 )
 
-// ParseChannelMode parses a channel mode from the given string.
+// ParseChannelMode parses a Channel mode from the given string.
 func ParseChannelMode(input string) (ChannelMode, error) {
 	switch cm := strings.TrimSpace(strings.ToLower(input)); cm {
 	case "public":

--- a/mam/v1/receiver.go
+++ b/mam/v1/receiver.go
@@ -24,7 +24,7 @@ func NewReceiver(api API) *Receiver {
 	}
 }
 
-// SetMode sets the channel mode.
+// SetMode sets the Channel mode.
 func (r *Receiver) SetMode(m ChannelMode, sideKey trinary.Trytes) error {
 	if m != ChannelModePublic && m != ChannelModePrivate && m != ChannelModeRestricted {
 		return ErrUnknownChannelMode
@@ -39,12 +39,12 @@ func (r *Receiver) SetMode(m ChannelMode, sideKey trinary.Trytes) error {
 	return nil
 }
 
-// Mode returns the channel mode.
+// Mode returns the Channel mode.
 func (r *Receiver) Mode() ChannelMode {
 	return r.mode
 }
 
-// SideKey returns the channel's side key.
+// SideKey returns the Channel's side key.
 func (r *Receiver) SideKey() trinary.Trytes {
 	return r.sideKey
 }

--- a/mam/v1/receiver_test.go
+++ b/mam/v1/receiver_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Receiver", func() {
 
 	Context("Receive", func() {
 
-		It("Should receive a message from a public channel", func() {
+		It("Should receive a message from a public Channel", func() {
 			fakeAPI := newFakeAPI()
 			fakeAPI.findTransactionObjects = func(query api.FindTransactionsQuery) (transaction.Transactions, error) {
 				Expect(query).To(Equal(api.FindTransactionsQuery{
@@ -67,7 +67,7 @@ var _ = Describe("Receiver", func() {
 			Expect(nextRoot).To(Equal("HTGAUZTBH9SIVJVREIXLGAPPVQOFZZCRWDYSDG9JLXLFREYRWBEOBPSCSFTV9XZNIVZNAZINBAFDEWUZ9"))
 		})
 
-		It("Should receive a message from a private channel", func() {
+		It("Should receive a message from a private Channel", func() {
 			fakeAPI := newFakeAPI()
 			fakeAPI.findTransactionObjects = func(query api.FindTransactionsQuery) (transaction.Transactions, error) {
 				Expect(query).To(Equal(api.FindTransactionsQuery{
@@ -120,7 +120,7 @@ var _ = Describe("Receiver", func() {
 			Expect(nextRoot).To(Equal("HTGAUZTBH9SIVJVREIXLGAPPVQOFZZCRWDYSDG9JLXLFREYRWBEOBPSCSFTV9XZNIVZNAZINBAFDEWUZ9"))
 		})
 
-		It("Should receive a message from a restricted channel", func() {
+		It("Should receive a message from a restricted Channel", func() {
 			fakeAPI := newFakeAPI()
 			fakeAPI.findTransactionObjects = func(query api.FindTransactionsQuery) (transaction.Transactions, error) {
 				Expect(query).To(Equal(api.FindTransactionsQuery{

--- a/mam/v1/transmitter.go
+++ b/mam/v1/transmitter.go
@@ -80,13 +80,18 @@ func (t *Transmitter) Channel() *Channel {
 
 // Transmit creates a MAM message using the given string and transmits it. On success, it returns
 // the addresses root.
-func (t *Transmitter) Transmit(message string) (trinary.Trytes, error) {
+func (t *Transmitter) Transmit(message string, params ...string) (trinary.Trytes, error) {
 	root, address, payload, err := t.createMessage(message)
 	if err != nil {
 		return "", errors.Wrapf(err, "create message")
 	}
 
-	if err := t.attachMessage(address, payload); err != nil {
+	var tag = ""
+	if len(params) > 0 {
+		tag = params[0]
+	}
+
+	if err := t.attachMessage(address, payload, tag); err != nil {
 		return "", errors.Wrapf(err, "attach message")
 	}
 
@@ -138,7 +143,7 @@ func (t *Transmitter) createMessage(message string) (trinary.Trytes, trinary.Try
 	return rootTrytes, address, payloadTrytes, nil
 }
 
-func (t *Transmitter) attachMessage(address, payload trinary.Trytes) error {
+func (t *Transmitter) attachMessage(address, payload trinary.Trytes, tag string) error {
 	if err := trinary.ValidTrytes(address); err != nil {
 		return errors.Wrapf(err, "invalid address")
 	}
@@ -147,7 +152,7 @@ func (t *Transmitter) attachMessage(address, payload trinary.Trytes) error {
 		Address: address,
 		Value:   0,
 		Message: payload,
-		Tag:     "",
+		Tag:     tag,
 	}}
 
 	trytes, err := t.api.PrepareTransfers(consts.NullHashTrytes, transfers, api.PrepareTransfersOptions{})

--- a/mam/v1/transmitter.go
+++ b/mam/v1/transmitter.go
@@ -14,14 +14,14 @@ import (
 
 // Some error definitions.
 var (
-	ErrUnknownChannelMode = errors.New("channel mode must be ChannelModePublic, ChannelModePrivate or ChannelModeRestricted")
+	ErrUnknownChannelMode = errors.New("Channel mode must be ChannelModePublic, ChannelModePrivate or ChannelModeRestricted")
 	ErrNoSideKey          = errors.New("A 81-trytes sideKey must be provided for the restricted mode")
 )
 
 // Transmitter defines the MAM facade transmitter.
 type Transmitter struct {
 	api     API
-	channel *channel
+	channel *Channel
 	seed    trinary.Trytes
 	mwm     uint64
 }
@@ -30,37 +30,52 @@ type Transmitter struct {
 func NewTransmitter(api API, seed trinary.Trytes, mwm uint64, securityLevel consts.SecurityLevel) *Transmitter {
 	return &Transmitter{
 		api:     api,
-		channel: newChannel(securityLevel),
+		channel: NewChannel(securityLevel),
 		seed:    seed,
 		mwm:     mwm,
 	}
 }
 
-// SetMode sets the channel mode.
+// NewTransmitterWithChannel returns a new transmitter with an existing channel.
+func NewTransmitterWithChannel(api API, seed trinary.Trytes, mwm uint64, channel *Channel) *Transmitter {
+	return &Transmitter{
+		api:     api,
+		channel: channel,
+		seed:    seed,
+		mwm:     mwm,
+	}
+}
+
+// SetMode sets the Channel mode.
 func (t *Transmitter) SetMode(m ChannelMode, sideKey trinary.Trytes) error {
 	switch m {
 	case ChannelModePublic, ChannelModePrivate:
-		t.channel.sideKey = consts.NullHashTrytes
+		t.channel.SideKey = consts.NullHashTrytes
 	case ChannelModeRestricted:
 		if l := len(sideKey); l != 81 {
 			return errors.Wrapf(ErrNoSideKey, "sidekey of length %d", l)
 		}
-		t.channel.sideKey = sideKey
+		t.channel.SideKey = sideKey
 	default:
-		return errors.Wrapf(ErrUnknownChannelMode, "channel mode [%s]", m)
+		return errors.Wrapf(ErrUnknownChannelMode, "Channel mode [%s]", m)
 	}
-	t.channel.mode = m
+	t.channel.Mode = m
 	return nil
 }
 
-// Mode returns the channel mode.
+// Mode returns the Channel mode.
 func (t *Transmitter) Mode() ChannelMode {
-	return t.channel.mode
+	return t.channel.Mode
 }
 
-// SideKey returns the channel's side key.
+// SideKey returns the Channel's side key.
 func (t *Transmitter) SideKey() trinary.Trytes {
-	return t.channel.sideKey
+	return t.channel.SideKey
+}
+
+// SideKey returns the underlying Channel of this Transmitter.
+func (t *Transmitter) Channel() *Channel {
+	return t.channel
 }
 
 // Transmit creates a MAM message using the given string and transmits it. On success, it returns
@@ -79,15 +94,15 @@ func (t *Transmitter) Transmit(message string) (trinary.Trytes, error) {
 }
 
 func (t *Transmitter) createMessage(message string) (trinary.Trytes, trinary.Trytes, trinary.Trytes, error) {
-	treeSize := merkle.MerkleSize(t.channel.count)
+	treeSize := merkle.MerkleSize(t.channel.Count)
 	messageTrytes, err := converter.ASCIIToTrytes(message)
 	if err != nil {
 		return "", "", "", err
 	}
 
-	payloadLength := PayloadMinLength(uint64(len(messageTrytes)*3), treeSize*uint64(consts.HashTrinarySize), t.channel.index, t.channel.securityLevel)
+	payloadLength := PayloadMinLength(uint64(len(messageTrytes)*3), treeSize*uint64(consts.HashTrinarySize), t.channel.Index, t.channel.SecurityLevel)
 
-	root, err := merkle.MerkleCreate(t.channel.count, t.seed, t.channel.start, t.channel.securityLevel, curl.NewCurlP27())
+	root, err := merkle.MerkleCreate(t.channel.Count, t.seed, t.channel.Start, t.channel.SecurityLevel, curl.NewCurlP27())
 	if err != nil {
 		return "", "", "", err
 	}
@@ -96,13 +111,13 @@ func (t *Transmitter) createMessage(message string) (trinary.Trytes, trinary.Try
 		return "", "", "", err
 	}
 
-	nextRoot, err := merkle.MerkleCreate(t.channel.nextCount, t.seed, t.channel.nextStart(), t.channel.securityLevel, curl.NewCurlP27())
+	nextRoot, err := merkle.MerkleCreate(t.channel.NextCount, t.seed, t.channel.nextStart(), t.channel.SecurityLevel, curl.NewCurlP27())
 	if err != nil {
 		return "", "", "", err
 	}
 
-	payload, payloadLength, err := MAMCreate(payloadLength, messageTrytes, t.channel.sideKey, root, treeSize*consts.HashTrinarySize,
-		t.channel.count, t.channel.index, nextRoot, t.channel.start, t.seed, t.channel.securityLevel)
+	payload, payloadLength, err := MAMCreate(payloadLength, messageTrytes, t.channel.SideKey, root, treeSize*consts.HashTrinarySize,
+		t.channel.Count, t.channel.Index, nextRoot, t.channel.Start, t.seed, t.channel.SecurityLevel)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -113,9 +128,9 @@ func (t *Transmitter) createMessage(message string) (trinary.Trytes, trinary.Try
 	}
 
 	t.channel.incIndex()
-	t.channel.nextRoot = nextRoot
+	t.channel.NextRoot = nextRoot
 
-	address, err := makeAddress(t.channel.mode, root, t.channel.sideKey)
+	address, err := makeAddress(t.channel.Mode, root, t.channel.SideKey)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/mam/v1/transmitter_test.go
+++ b/mam/v1/transmitter_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Transmitter", func() {
 
 		const seed = "TX9XRR9SRCOBMTYDTMKNEIJCSZIMEUPWCNLC9DPDZKKAEMEFVSTEVUFTRUZXEHLULEIYJIEOWIC9STAHW"
 
-		It("Should transmit the given message to a public channel", func() {
+		It("Should transmit the given message to a public Channel", func() {
 			fakeAPI := newFakeAPI()
 			fakeAPI.prepareTransfers = func(address trinary.Trytes, transfers bundle.Transfers, opts api.PrepareTransfersOptions) ([]trinary.Trytes, error) {
 				Expect(address).To(Equal("999999999999999999999999999999999999999999999999999999999999999999999999999999999"))
@@ -90,7 +90,7 @@ var _ = Describe("Transmitter", func() {
 			Expect(root).To(Equal("YKOLXUAMTJGGIVPEWHUCSKKJWIY9PWEFABXYHAWDBTMOPKWNXOOQCKNHADSZP9SOSDFEOXPVTWUWFDQNH"))
 		})
 
-		It("Should transmit the given message to a private channel", func() {
+		It("Should transmit the given message to a private Channel", func() {
 			fakeAPI := newFakeAPI()
 			fakeAPI.prepareTransfers = func(address trinary.Trytes, transfers bundle.Transfers, opts api.PrepareTransfersOptions) ([]trinary.Trytes, error) {
 				Expect(address).To(Equal("999999999999999999999999999999999999999999999999999999999999999999999999999999999"))
@@ -119,7 +119,7 @@ var _ = Describe("Transmitter", func() {
 			Expect(root).To(Equal("YKOLXUAMTJGGIVPEWHUCSKKJWIY9PWEFABXYHAWDBTMOPKWNXOOQCKNHADSZP9SOSDFEOXPVTWUWFDQNH"))
 		})
 
-		It("Should transmit the given message to a restricted channel", func() {
+		It("Should transmit the given message to a restricted Channel", func() {
 			fakeAPI := newFakeAPI()
 			fakeAPI.prepareTransfers = func(address trinary.Trytes, transfers bundle.Transfers, opts api.PrepareTransfersOptions) ([]trinary.Trytes, error) {
 				Expect(address).To(Equal("999999999999999999999999999999999999999999999999999999999999999999999999999999999"))


### PR DESCRIPTION
# Description

Makes the channel struct exported and its fields so that it can be serialized.