### PR TITLE
Added platform specific bytesToTryteValues

### DIFF
--- a/kerl/bytes_to_trytes_32bit.go
+++ b/kerl/bytes_to_trytes_32bit.go
@@ -1,0 +1,52 @@
+// +build 386 arm mips
+
+// Package kerl implements the Kerl hashing function.
+package kerl
+
+import (
+	"unsafe"
+
+	. "github.com/iotaledger/iota.go/consts"
+	"github.com/iotaledger/iota.go/kerl/bigint"
+)
+
+func bytesToTryteValues(bytes []byte) []int8 {
+	// copy and convert bytes to bigint
+	rb := make([]byte, len(bytes))
+	copy(rb, bytes)
+	bigint.Reverse(rb)
+	b := (*(*[]uint32)(unsafe.Pointer(&rb)))[0:IntLength]
+	c := (*(*[]uint16)(unsafe.Pointer(&rb)))[0 : IntLength*2]
+
+	// the two's complement representation is only correct, if the number fits
+	// into 48 bytes, i.e. has the 243th trit set to 0
+	bigintZeroLastTrit(b)
+
+	// convert to the unsigned bigint representing non-balanced ternary
+	bigint.MustAdd(b, halfThree)
+
+	vs := make([]int8, HashTrytesSize)
+
+	// initially, all words of the bigint are non-zero
+	nzIndex := IntLength*2 - 1
+	for i := 0; i < HashTrytesSize-1; i++ {
+		// divide the bigint by the radix
+		var rem uint16
+		for i := nzIndex; i >= 0; i-- {
+			v := (uint32(rem) << 16) | uint32(c[i])
+			c[i], rem = uint16(v/tryteRadix), uint16(v%tryteRadix)
+		}
+		// the tryte value is the remainder converted back to balanced ternary
+		vs[i] = int8(rem) - halfTryte
+
+		// decrement index, if the highest considered word of the bigint turned zero
+		if nzIndex > 0 && c[nzIndex] == 0 {
+			nzIndex--
+		}
+	}
+
+	// special case for the last tryte, where no further division is necessary
+	vs[HashTrytesSize-1] = tryteZeroLastTrit(int8(b[0]) - halfTryte)
+
+	return vs
+}

--- a/kerl/bytes_to_trytes_64bit.go
+++ b/kerl/bytes_to_trytes_64bit.go
@@ -1,0 +1,51 @@
+// +build amd64 arm64 mips64
+
+// Package kerl implements the Kerl hashing function.
+package kerl
+
+import (
+	"unsafe"
+
+	. "github.com/iotaledger/iota.go/consts"
+	"github.com/iotaledger/iota.go/kerl/bigint"
+)
+
+func bytesToTryteValues(bytes []byte) []int8 {
+	// copy and convert bytes to bigint
+	rb := make([]byte, len(bytes))
+	copy(rb, bytes)
+	bigint.Reverse(rb)
+	b := (*(*[]uint32)(unsafe.Pointer(&rb)))[0:IntLength]
+
+	// the two's complement representation is only correct, if the number fits
+	// into 48 bytes, i.e. has the 243th trit set to 0
+	bigintZeroLastTrit(b)
+
+	// convert to the unsigned bigint representing non-balanced ternary
+	bigint.MustAdd(b, halfThree)
+
+	vs := make([]int8, HashTrytesSize)
+
+	// initially, all words of the bigint are non-zero
+	nzIndex := IntLength - 1
+	for i := 0; i < HashTrytesSize-1; i++ {
+		// divide the bigint by the radix
+		var rem uint32
+		for i := nzIndex; i >= 0; i-- {
+			v := (uint64(rem) << 32) | uint64(b[i])
+			b[i], rem = uint32(v/tryteRadix), uint32(v%tryteRadix)
+		}
+		// the tryte value is the remainder converted back to balanced ternary
+		vs[i] = int8(rem) - halfTryte
+
+		// decrement index, if the highest considered word of the bigint turned zero
+		if nzIndex > 0 && b[nzIndex] == 0 {
+			nzIndex--
+		}
+	}
+
+	// special case for the last tryte, where no further division is necessary
+	vs[HashTrytesSize-1] = tryteZeroLastTrit(int8(b[0]) - halfTryte)
+
+	return vs
+}

--- a/kerl/converter.go
+++ b/kerl/converter.go
@@ -152,46 +152,6 @@ func tryteValuesToBytes(vs []int8) []byte {
 	return bigint.Reverse(bytes)
 }
 
-func bytesToTryteValues(bytes []byte) []int8 {
-	// copy and convert bytes to bigint
-	rb := make([]byte, len(bytes))
-	copy(rb, bytes)
-	bigint.Reverse(rb)
-	b := (*(*[]uint32)(unsafe.Pointer(&rb)))[0:IntLength]
-
-	// the two's complement representation is only correct, if the number fits
-	// into 48 bytes, i.e. has the 243th trit set to 0
-	bigintZeroLastTrit(b)
-
-	// convert to the unsigned bigint representing non-balanced ternary
-	bigint.MustAdd(b, halfThree)
-
-	vs := make([]int8, HashTrytesSize)
-
-	// initially, all words of the bigint are non-zero
-	nzIndex := IntLength - 1
-	for i := 0; i < HashTrytesSize-1; i++ {
-		// divide the bigint by the radix
-		var rem uint32
-		for i := nzIndex; i >= 0; i-- {
-			v := (uint64(rem) << 32) | uint64(b[i])
-			b[i], rem = uint32(v/tryteRadix), uint32(v%tryteRadix)
-		}
-		// the tryte value is the remainder converted back to balanced ternary
-		vs[i] = int8(rem) - halfTryte
-
-		// decrement index, if the highest considered word of the bigint turned zero
-		if nzIndex > 0 && b[nzIndex] == 0 {
-			nzIndex--
-		}
-	}
-
-	// special case for the last tryte, where no further division is necessary
-	vs[HashTrytesSize-1] = tryteZeroLastTrit(int8(b[0]) - halfTryte)
-
-	return vs
-}
-
 // KerlBytesZeroLastTrit changes a chunk of 48 bytes so that the corresponding ternary number has 242th trit set to 0.
 func KerlBytesZeroLastTrit(bytes []byte) {
 	// convert to bigint


### PR DESCRIPTION
# Description

bytesToTryteValues does a platform specific division now.
This is much faster on 32bit hardware.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

Compiled on amd64 and arm

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have written example code according to the contribution guidelines
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes