### PR TITLE
Adds more validation code to non Must().. funcs in trinary package

### DIFF
--- a/account/deposit/deposit.go
+++ b/account/deposit/deposit.go
@@ -92,12 +92,12 @@ func (dc *CDA) Checksum() (Trytes, error) {
 	if err != nil {
 		return "", err
 	}
-	timeoutAtTrits := PadTrits(IntToTrits(dc.TimeoutAt.Unix()), 27)
+	timeoutAtTrits := MustPadTrits(IntToTrits(dc.TimeoutAt.Unix()), 27)
 	var expectedAmountTrits Trits
 	if dc.ExpectedAmount != nil {
-		expectedAmountTrits = PadTrits(IntToTrits(int64(*dc.ExpectedAmount)), 81)
+		expectedAmountTrits = MustPadTrits(IntToTrits(int64(*dc.ExpectedAmount)), 81)
 	} else {
-		expectedAmountTrits = PadTrits(expectedAmountTrits, 81)
+		expectedAmountTrits = MustPadTrits(expectedAmountTrits, 81)
 	}
 	var multiUse int8
 	if dc.MultiUse {

--- a/account/store/store.go
+++ b/account/store/store.go
@@ -119,10 +119,10 @@ func PendingTransferToBundle(pt *PendingTransfer) (bundle.Bundle, error) {
 	for i := 0; i < len(bndl); i++ {
 		essenceTrytes := pt.Bundle[i]
 		// add empty trits for fields after the last index
-		txTrytes := essenceTrytes + Pad("", (consts.TransactionTrinarySize-consts.BundleTrinaryOffset)/3)
+		txTrytes := essenceTrytes + MustPad("", (consts.TransactionTrinarySize-consts.BundleTrinaryOffset)/3)
 		// add an empty signature message fragment if non was stored
 		if len(txTrytes) != consts.TransactionTrinarySize/3 {
-			txTrytes = Pad("", consts.SignatureMessageFragmentTrinarySize/3) + txTrytes
+			txTrytes = MustPad("", consts.SignatureMessageFragmentTrinarySize/3) + txTrytes
 		}
 		tx, err := transaction.ParseTransaction(MustTrytesToTrits(txTrytes), true)
 		if err != nil {

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -32,7 +32,7 @@ func (a BundlesByTimestamp) Less(i int, j int) bool {
 
 // PadTag pads the given trytes up to the length of a tag.
 func PadTag(tag Trytes) Trytes {
-	return Pad(tag, 27)
+	return MustPad(tag, 27)
 }
 
 // Bundle represents grouped together transactions for creating a transfer.
@@ -92,7 +92,7 @@ func TransfersToBundleEntries(timestamp uint64, transfers ...Transfer) (BundleEn
 			return nil, err
 		}
 
-		transfer.Message = Pad(transfer.Message, length*SignatureMessageFragmentSizeInTrytes)
+		transfer.Message = MustPad(transfer.Message, length*SignatureMessageFragmentSizeInTrytes)
 
 		bndlEntry := BundleEntry{
 			Address: addr, Value: int64(transfer.Value),
@@ -168,7 +168,7 @@ func getBundleEntryWithDefaults(entry BundleEntry) BundleEntry {
 		}
 	} else {
 		for i := range entry.SignatureMessageFragments {
-			entry.SignatureMessageFragments[i] = Pad(entry.SignatureMessageFragments[i], 2187)
+			entry.SignatureMessageFragments[i] = MustPad(entry.SignatureMessageFragments[i], 2187)
 		}
 	}
 
@@ -182,13 +182,13 @@ func Finalize(bundle Bundle) (Bundle, error) {
 	var timestampTrits = make([]Trits, len(bundle))
 	var currentIndexTrits = make([]Trits, len(bundle))
 	var obsoleteTagTrits = make([]Trits, len(bundle))
-	var lastIndexTrits = PadTrits(IntToTrits(int64(bundle[0].LastIndex)), 27)
+	var lastIndexTrits = MustPadTrits(IntToTrits(int64(bundle[0].LastIndex)), 27)
 
 	for i := range bundle {
-		valueTrits[i] = PadTrits(IntToTrits(bundle[i].Value), 81)
-		timestampTrits[i] = PadTrits(IntToTrits(int64(bundle[i].Timestamp)), 27)
-		currentIndexTrits[i] = PadTrits(IntToTrits(int64(bundle[i].CurrentIndex)), 27)
-		obsoleteTagTrits[i] = PadTrits(MustTrytesToTrits(bundle[i].ObsoleteTag), 81)
+		valueTrits[i] = MustPadTrits(IntToTrits(bundle[i].Value), 81)
+		timestampTrits[i] = MustPadTrits(IntToTrits(int64(bundle[i].Timestamp)), 27)
+		currentIndexTrits[i] = MustPadTrits(IntToTrits(int64(bundle[i].CurrentIndex)), 27)
+		obsoleteTagTrits[i] = MustPadTrits(MustTrytesToTrits(bundle[i].ObsoleteTag), 81)
 	}
 
 	var bundleHash Hash
@@ -239,7 +239,7 @@ func Finalize(bundle Bundle) (Bundle, error) {
 func AddTrytes(bndl Bundle, fragments []Trytes, offset int) Bundle {
 	for i := range bndl {
 		if i >= offset && i < offset+len(fragments) {
-			bndl[i].SignatureMessageFragment = Pad(fragments[i-offset], 27*81)
+			bndl[i].SignatureMessageFragment = MustPad(fragments[i-offset], 27*81)
 		}
 	}
 	return bndl

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Bundle", func() {
 			entry := entries[0]
 			Expect(entry.Address).To(Equal(transfers[0].Address[:81]))
 			Expect(len(entry.SignatureMessageFragments)).To(Equal(1))
-			Expect(entry.SignatureMessageFragments[0]).To(Equal(Pad(msg, SignatureMessageFragmentSizeInTrytes)))
+			Expect(entry.SignatureMessageFragments[0]).To(Equal(MustPad(msg, SignatureMessageFragmentSizeInTrytes)))
 			Expect(entry.Value).To(Equal(int64(transfers[0].Value)))
 		})
 

--- a/consts/errors.go
+++ b/consts/errors.go
@@ -69,6 +69,8 @@ var (
 	ErrInvalidReferenceHash = errors.New("invalid reference hash")
 	// ErrInvalidTrytes gets returned for invalid trytes.
 	ErrInvalidTrytes = errors.New("invalid trytes")
+	// ErrInvalidByte gets returned for an invalid byte for a to trits conversion (5 packed trits in 1 byte).
+	ErrInvalidByte = errors.New("invalid byte")
 	// ErrInvalidTrit gets returned for invalid trit.
 	ErrInvalidTrit = errors.New("invalid trit")
 	// ErrInvalidURI gets returned for invalid URIs.

--- a/mam/v1/mam.go
+++ b/mam/v1/mam.go
@@ -84,7 +84,7 @@ func MAMCreate(payloadLength uint64,
 	}
 	messageLength := len(messageTrits)
 
-	sideKey = Pad(sideKey, 81)
+	sideKey = MustPad(sideKey, 81)
 	sideKeyTrits, err := TrytesToTrits(sideKey)
 	if err != nil {
 		return nil, 0, err
@@ -197,7 +197,7 @@ func MAMCreate(payloadLength uint64,
 func MAMParse(payload Trits, payloadLength uint64, sideKey Trytes, root Trits) (uint64, Trytes, Trytes, SecurityLevel, error) {
 	var offset uint64 = 0
 
-	sideKey = Pad(sideKey, 81)
+	sideKey = MustPad(sideKey, 81)
 	sideKeyTrits, err := TrytesToTrits(sideKey)
 	if err != nil {
 		return 0, "", "", SecurityLevel(0), err

--- a/mam/v1/transmitter.go
+++ b/mam/v1/transmitter.go
@@ -126,7 +126,7 @@ func (t *Transmitter) createMessage(message string) (trinary.Trytes, trinary.Try
 	if err != nil {
 		return "", "", "", err
 	}
-	payload = trinary.PadTrits(payload, len(payload)+(3-len(payload)%3))
+	payload = trinary.MustPadTrits(payload, len(payload)+(3-len(payload)%3))
 	payloadTrytes, err := trinary.TritsToTrytes(payload)
 	if err != nil {
 		return "", "", "", err

--- a/multisig/multisig.go
+++ b/multisig/multisig.go
@@ -248,7 +248,7 @@ func createBundle(input MultisigInput, transfers bundle.Transfers, remainderAddr
 			sigFrags = append(sigFrags, frag)
 		}
 
-		tag = Pad(transfer.Tag, TagTrinarySize/3)
+		tag = MustPad(transfer.Tag, TagTrinarySize/3)
 
 		bndl = bundle.AddEntry(bndl, bundle.BundleEntry{
 			Length:  uint64(sigFragLength),

--- a/trinary/trinary.go
+++ b/trinary/trinary.go
@@ -111,8 +111,11 @@ func ValidTrit(t int8) bool {
 	return t >= -1 && t <= 1
 }
 
-// ValidTrits returns true if t is valid trits.
+// ValidTrits returns true if t is valid trits (non-empty and -1, 0 or 1).
 func ValidTrits(trits Trits) error {
+	if len(trits) == 0 {
+		return errors.Wrap(ErrInvalidTrit, "trits slice is empty")
+	}
 	for i, trit := range trits {
 		if !ValidTrit(trit) {
 			return errors.Wrapf(ErrInvalidTrit, "at index %d", i)
@@ -277,10 +280,19 @@ func tryteToTryteValue(t byte) int8 {
 
 // TritsToTrytes converts a slice of trits into trytes. Returns an error if len(t)%3!=0
 func TritsToTrytes(trits Trits) (Trytes, error) {
+	if err := ValidTrits(trits); err != nil {
+		return "", err
+	}
 	if !CanTritsToTrytes(trits) {
 		return "", errors.Wrap(ErrInvalidTritsLength, "trits slice size must be a multiple of 3")
 	}
+	return MustTritsToTrytes(trits), nil
+}
 
+// MustTritsToTrytes converts a slice of trits into trytes.
+// Performs no validation on the input trits and might therefore return an invalid trytes representation
+// (without a panic).
+func MustTritsToTrytes(trits Trits) Trytes {
 	var trytes strings.Builder
 	trytes.Grow(len(trits) / TritsPerTryte)
 
@@ -288,16 +300,7 @@ func TritsToTrytes(trits Trits) (Trytes, error) {
 		v := trits[i*TritsPerTryte] + trits[i*TritsPerTryte+1]*3 + trits[i*TritsPerTryte+2]*9
 		trytes.WriteByte(tryteValueToTryte(v))
 	}
-	return trytes.String(), nil
-}
-
-// MustTritsToTrytes converts a slice of trits into trytes. Panics if len(t)%3!=0
-func MustTritsToTrytes(trits Trits) Trytes {
-	trytes, err := TritsToTrytes(trits)
-	if err != nil {
-		panic(err)
-	}
-	return trytes
+	return trytes.String()
 }
 
 func validTryte(t rune) bool {
@@ -336,7 +339,12 @@ func TrytesToTrits(trytes Trytes) (Trits, error) {
 	if err := ValidTrytes(trytes); err != nil {
 		return nil, err
 	}
+	return MustTrytesToTrits(trytes), nil
+}
 
+// MustTrytesToTrits converts a slice of trytes into trits.
+// Performs no validation on the provided inputs (therefore might return an invalid representation) and might panic.
+func MustTrytesToTrits(trytes Trytes) Trits {
 	trits := make(Trits, len(trytes)*TritsPerTryte)
 	for i := 0; i < len(trytes); i++ {
 		v := tryteToTryteValue(trytes[i])
@@ -345,15 +353,6 @@ func TrytesToTrits(trytes Trytes) (Trits, error) {
 		trits[i*TritsPerTryte+0] = TryteValueToTritsLUT[idx][0]
 		trits[i*TritsPerTryte+1] = TryteValueToTritsLUT[idx][1]
 		trits[i*TritsPerTryte+2] = TryteValueToTritsLUT[idx][2]
-	}
-	return trits, nil
-}
-
-// MustTrytesToTrits converts a slice of trytes into trits.
-func MustTrytesToTrits(trytes Trytes) Trits {
-	trits, err := TrytesToTrits(trytes)
-	if err != nil {
-		panic(err)
 	}
 	return trits
 }
@@ -369,19 +368,16 @@ func TrytesToBytes(trytes Trytes) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return TritsToBytes(trits), nil
+	return MustTritsToBytes(trits), nil
 }
 
 // MustTrytesToBytes packs trytes into a slice of bytes (5 packed trits in 1 byte).
+// Performs no validation on the provided inputs (therefore might return an invalid representation) and might panic.
 func MustTrytesToBytes(trytes Trytes) []byte {
-	bytes, err := TrytesToBytes(trytes)
-	if err != nil {
-		panic(err)
-	}
-	return bytes
+	return MustTritsToBytes(MustTrytesToTrits(trytes))
 }
 
-// BytesToTrytes unpacks a slice of bytes into trytes.
+// BytesToTrytes unpacks a slice of bytes (5 packed trits in 1 byte) into trytes.
 func BytesToTrytes(bytes []byte, numTrytes ...int) (Trytes, error) {
 	var numTrits int
 	if len(numTrytes) > 0 {
@@ -390,22 +386,36 @@ func BytesToTrytes(bytes []byte, numTrytes ...int) (Trytes, error) {
 		numTrits = int(roundUpToTryteMultiple(uint(len(bytes)) * NumberOfTritsInAByte))
 	}
 
-	// we can ignore the error, as the correct number of trits is passed
-	trits, _ := BytesToTrits(bytes, numTrits)
-	return TritsToTrytes(trits)
+	trits, err := BytesToTrits(bytes, numTrits)
+	if err != nil {
+		return "", err
+	}
+	return MustTritsToTrytes(trits), nil
 }
 
-// MustBytesToTrytes unpacks a slice of bytes into trytes.
+// MustBytesToTrytes unpacks a slice of bytes (5 packed trits in 1 byte) into trytes.
+// Performs no validation on the provided inputs (therefore might return an invalid representation) and might panic.
 func MustBytesToTrytes(bytes []byte, numTrytes ...int) Trytes {
-	trytes, err := BytesToTrytes(bytes, numTrytes...)
-	if err != nil {
-		panic(err)
+	var numTrits int
+	if len(numTrytes) > 0 {
+		numTrits = numTrytes[0] * TritsPerTryte
+	} else {
+		numTrits = int(roundUpToTryteMultiple(uint(len(bytes)) * NumberOfTritsInAByte))
 	}
-	return trytes
+	return MustTritsToTrytes(MustBytesToTrits(bytes, numTrits))
 }
 
 // TritsToBytes packs an array of trits into an array of bytes (5 packed trits in 1 byte).
-func TritsToBytes(trits Trits) (bytes []byte) {
+func TritsToBytes(trits Trits) ([]byte, error) {
+	if err := ValidTrits(trits); err != nil {
+		return nil, err
+	}
+	return MustTritsToBytes(trits), nil
+}
+
+// MustTritsToBytes packs an array of trits into an array of bytes (5 packed trits in 1 byte).
+// Performs no validation on the provided inputs (therefore might return an invalid representation) and might panic.
+func MustTritsToBytes(trits Trits) (bytes []byte) {
 	tritsLength := len(trits)
 	bytesLength := (tritsLength + NumberOfTritsInAByte - 1) / NumberOfTritsInAByte
 
@@ -427,29 +437,64 @@ func TritsToBytes(trits Trits) (bytes []byte) {
 	return bytes
 }
 
-// BytesToTrits unpacks an array of bytes into an array of trits.
+// ValidBytesForTrits checks whether the given bytes are valid for bytes to trits conversion (5 packed trits in 1 byte).
+func ValidBytesForTrits(bytes []byte) error {
+	for i, b := range bytes {
+		c := int8(b)
+		if c > 121 || c < -121 {
+			return errors.Wrapf(ErrInvalidByte, "at index %d (byte value: %d)", i, c)
+		}
+	}
+	return nil
+}
+
+// BytesToTrits unpacks an array of bytes (5 packed trits in 1 byte) into an array of trits.
 func BytesToTrits(bytes []byte, numTrits ...int) (Trits, error) {
+	if err := ValidBytesForTrits(bytes); err != nil {
+		return nil, err
+	}
+	if len(numTrits) > 0 {
+		tritsLength := numTrits[0]
+
+		minTritLength := (len(bytes)-1)*NumberOfTritsInAByte + 1
+		if tritsLength < minTritLength {
+			return nil, errors.Wrapf(ErrInvalidTritsLength, "must be at least %d in size", minTritLength)
+		}
+	}
+	return MustBytesToTrits(bytes, numTrits...), nil
+}
+
+// MustBytesToTrits unpacks an array of bytes (5 packed trits in 1 byte) into an array of trits.
+// Performs no validation on the provided inputs (therefore might return an invalid representation) and might panic.
+func MustBytesToTrits(bytes []byte, numTrits ...int) Trits {
 	bytesLength := len(bytes)
 	tritsLength := bytesLength * NumberOfTritsInAByte
 
 	if len(numTrits) > 0 {
 		tritsLength = numTrits[0]
-
-		minTritLength := (bytesLength-1)*NumberOfTritsInAByte + 1
-		if tritsLength < minTritLength {
-			return nil, errors.Wrapf(ErrInvalidTritsLength, "must be at least %d in size", minTritLength)
-		}
 	}
 
 	trits := make(Trits, tritsLength)
 	for i := 0; i < bytesLength; i++ {
 		copy(trits[i*NumberOfTritsInAByte:], bytesToTritsLUT[bytes[i]])
 	}
-	return trits, nil
+	return trits
 }
 
 // Pad pads the given trytes with 9s up to the given size.
-func Pad(trytes Trytes, n int) Trytes {
+func Pad(trytes Trytes, n int) (Trytes, error) {
+	if len(trytes) > 0 {
+		if err := ValidTrytes(trytes); err != nil {
+			return "", err
+
+		}
+	}
+	return MustPad(trytes, n), nil
+}
+
+// MustPad pads the given trytes with 9s up to the given size.
+// Performs no validation on the provided inputs (therefore might return an invalid representation) and might panic.
+func MustPad(trytes Trytes, n int) Trytes {
 	if len(trytes) >= n {
 		return trytes
 	}
@@ -465,7 +510,25 @@ func Pad(trytes Trytes, n int) Trytes {
 }
 
 // PadTrits pads the given trits with 0 up to the given size.
-func PadTrits(trits Trits, n int) Trits {
+func PadTrits(trits Trits, n int) (Trits, error) {
+	if len(trits) > 0 {
+		if err := ValidTrits(trits); err != nil {
+			return nil, err
+
+		}
+	}
+	if len(trits) >= n {
+		return trits, nil
+	}
+
+	result := make(Trits, n)
+	copy(result, trits)
+	return result, nil
+}
+
+// MustPadTrits pads the given trits with 0 up to the given size.
+// Performs no validation on the provided inputs (therefore might return an invalid representation) and might panic.
+func MustPadTrits(trits Trits, n int) Trits {
 	if len(trits) >= n {
 		return trits
 	}

--- a/trinary/trinary.go
+++ b/trinary/trinary.go
@@ -486,7 +486,6 @@ func Pad(trytes Trytes, n int) (Trytes, error) {
 	if len(trytes) > 0 {
 		if err := ValidTrytes(trytes); err != nil {
 			return "", err
-
 		}
 	}
 	return MustPad(trytes, n), nil
@@ -514,16 +513,9 @@ func PadTrits(trits Trits, n int) (Trits, error) {
 	if len(trits) > 0 {
 		if err := ValidTrits(trits); err != nil {
 			return nil, err
-
 		}
 	}
-	if len(trits) >= n {
-		return trits, nil
-	}
-
-	result := make(Trits, n)
-	copy(result, trits)
-	return result, nil
+	return MustPadTrits(trits, n), nil
 }
 
 // MustPadTrits pads the given trits with 0 up to the given size.

--- a/trinary/trinary_test.go
+++ b/trinary/trinary_test.go
@@ -147,9 +147,6 @@ var _ = Describe("Trinary", func() {
 			trytes := MustTritsToTrytes(Trits{1, 1, 1})
 			Expect(trytes).To(Equal("M"))
 		})
-		It("should panic with invalid trits", func() {
-			Expect(func() { MustTritsToTrytes(Trits{12, -45}) }).To(Panic())
-		})
 	})
 
 	Context("CanBeHash()", func() {
@@ -165,7 +162,8 @@ var _ = Describe("Trinary", func() {
 	Context("TritsToBytes()", func() {
 		It("should return bytes for valid trits", func() {
 			trits := Trits{-1, 0, 1, 1, 0, 1, 1, 0, -1, -1, 1, 0, 1}
-			bytes := TritsToBytes(trits)
+			bytes, err := TritsToBytes(trits)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(bytes).To(Equal([]byte{0x23, 0x98, 0x0A}))
 		})
 	})
@@ -371,27 +369,23 @@ var _ = Describe("Trinary", func() {
 			Expect(trits).To(Equal(Trits{0, -1, -1}))
 		})
 
-		It("should panic for emptry trytes", func() {
-			Expect(func() { MustTrytesToTrits("") }).To(Panic())
-		})
-
 		It("should panic for invalid trytes", func() {
 			Expect(func() { MustTrytesToTrits("abcd") }).To(Panic())
 		})
 	})
 
-	Context("Pad()", func() {
+	Context("MustPad()", func() {
 		It("should pad up to the given size", func() {
-			Expect(Pad("A", 5)).To(Equal("A9999"))
-			Expect(Pad("", 81)).To(Equal(strings.Repeat("9", 81)))
+			Expect(MustPad("A", 5)).To(Equal("A9999"))
+			Expect(MustPad("", 81)).To(Equal(strings.Repeat("9", 81)))
 		})
 	})
 
-	Context("PadTrits()", func() {
+	Context("MustPadTrits()", func() {
 		It("should pad up to the given size", func() {
-			Expect(PadTrits(Trits{}, 5)).To(Equal(Trits{0, 0, 0, 0, 0}))
-			Expect(PadTrits(Trits{1, 1}, 5)).To(Equal(Trits{1, 1, 0, 0, 0}))
-			Expect(PadTrits(Trits{1, -1, 0, 1}, 5)).To(Equal(Trits{1, -1, 0, 1, 0}))
+			Expect(MustPadTrits(Trits{}, 5)).To(Equal(Trits{0, 0, 0, 0, 0}))
+			Expect(MustPadTrits(Trits{1, 1}, 5)).To(Equal(Trits{1, 1, 0, 0, 0}))
+			Expect(MustPadTrits(Trits{1, -1, 0, 1}, 5)).To(Equal(Trits{1, -1, 0, 1, 0}))
 		})
 	})
 


### PR DESCRIPTION
# Description
* `ValidTrits()` returns an error if the trits input is zero in length.
* `TritsToTrytes()` checks whether the given trits input is valid (checking for empty or non -1,0,1 trits)
* `TritsToBytes()` checks whether the given trits input is valid (checking for empty or non -1,0,1 trits) (previously didn't return any error)
* `BytesToTrits()` checks whether the given byte slice input is valid (checking for any byte out of the range between -121 to 121)
* `Pad()` now returns an error if the start trytes input is invalid.
* `PadTrits()` now returns an error if the start trits input is invalid.
* Added `MustPad/MustPadTrits` which to not perform any validation.
* All functions prefixed with `Must` do no longer perform any validation and can therefore be used in situations in which the input was validated before or is assumed to be valid. , `MustTritsToTrytes()`, `MustTrytesToTrits()`, `MustTrytesToBytes()`, `MustBytesToTrytes()`, `MustTritsToBytes()`, `MustBytesToTrits()`

Fixes https://github.com/iotaledger/iota.go/issues/136

## Type of change

Please delete options that are not relevant.

- [x] Enhancement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran the test suite.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have written example code according to the contribution guidelines
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes