### PR TITLE
Use MustTrytesToTrits inside IntToTrits

### DIFF
--- a/trinary/trinary.go
+++ b/trinary/trinary.go
@@ -212,9 +212,9 @@ func MinTrits(value int64) int {
 
 // IntToTrits converts int64 to a slice of trits.
 func IntToTrits(value int64) Trits {
-	numTrits := int(MinTrits(value))
+	numTrits := MinTrits(value)
 	numTrytes := (numTrits + TritsPerTryte - 1) / TritsPerTryte
-	trits, _ := TrytesToTrits(IntToTrytes(value, numTrytes))
+	trits := MustTrytesToTrits(IntToTrytes(value, numTrytes))
 	return trits[:numTrits]
 }
 


### PR DESCRIPTION
# Description

Internally `IntToTrits` first converts the input to trytes and then to trits. Here, `TrytesToTrits` was used and the returned error ignored. After the changes from #139 `MustTrytesToTrits` should be used to avoid unnecessary checks.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes