### PR TITLE
Make variable shared among several go routines in the PoW atomic

### DIFF
--- a/curl/hamming/hamming.go
+++ b/curl/hamming/hamming.go
@@ -50,7 +50,7 @@ func Hamming(c *curl.Curl, offset, end, security int) Trits {
 	lmid[offset+3] = pow.PearlDiverMidStateLow3
 	hmid[offset+3] = pow.PearlDiverMidStateHigh3
 
-	cancelled := false
+	var cancelled int32
 	nonce, _, foundIndex := pow.Loop(lmid, hmid, security, &cancelled, check, int(c.Rounds))
 	if foundIndex >= 0 {
 		copy(c.State[offset:], ptritsToTrits(lmid, hmid, uint64(foundIndex), len(c.State)-offset))


### PR DESCRIPTION
## Description

- The variable `cancelled` is now atomic
- In the case of `optRate == nil` nothing assured that all the go routines have properly exited when the function is left. This has been fixed by introducing `sync.WaitGroup`.

No significant performance changes have been noticed for artificial benchmarks on amd64.

Fixes #143

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes