### PR TITLE
Code improvements of the Kerl binary-ternary conversion

### DIFF
--- a/kerl/bigint/bigint.go
+++ b/kerl/bigint/bigint.go
@@ -1,89 +1,184 @@
-// Package bigint implements a set of functions for big integer arithmetic.
+// Package bigint contains a very lightweight and high-performance implementation of unsigned multi-precision integers.
 package bigint
 
 import (
-	"github.com/pkg/errors"
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"math/bits"
 )
+
+type Word = uint32
+
+const (
+	wordSize     = 32
+	wordByteSize = wordSize / 8
+)
+
+// A Bigint is an unsigned integer x of the form
+//   x = x[n-1]*B^(n-1) + x[n-2]*B^(n-2) + ... + x[1]*B + x[0]
+// with 0 <= x[i] < B and 0 <= i < n is stored in a slice of length n, with the digits x[i] as the slice elements.
+// The length of the slice never changes and operations are only well-defined for operands of the same length.
+type Bigint []Word
 
 // Errors for bigint package.
 var (
-	ErrUnequallySizedSlices = errors.New("operation not defined for differently sized slices")
+	ErrUnsupportedOperandSize = errors.New("unsupported operand size")
+	ErrInvalidBufferSize      = errors.New("invalid buffer sizer")
+	ErrInvalidLength          = errors.New("byte length not a multiple of the word size")
+	ErrMissingPrefix          = errors.New("hex string without 0x prefix")
 )
 
-// MustAdd adds the given big ints together.
-func MustAdd(b []uint32, rh []uint32) {
-	if len(b) != len(rh) {
-		panic(ErrUnequallySizedSlices)
-	}
+var hexPrefix = []byte("0x")
 
-	carry := false
-	for i := range b {
-		b[i], carry = FullAdd(b[i], rh[i], carry)
+// U384 creates a 384-bit big unsigned integer.
+func U384() Bigint {
+	return make([]Word, 384/wordSize)
+}
+
+// ParseU384 parses s as a Bigint, returning the result.
+// The encoding of s must be the same as in UnmarshalText.
+func ParseU384(s string) (Bigint, error) {
+	x := U384()
+	if err := x.UnmarshalText([]byte(s)); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// MustParseU384 parses s as a Bigint, returning the result.
+// The encoding of s must be the same as in UnmarshalText, it panics when the encoding is not valid.
+func MustParseU384(s string) Bigint {
+	x, err := ParseU384(s)
+	if err != nil {
+		panic(err)
+	}
+	return x
+}
+
+// SetBytes interprets buf as the bytes of a big-endian unsigned integer and sets x to that value.
+func (x Bigint) SetBytes(buf []byte) {
+	n := x.BytesLen()
+	if n != len(buf) {
+		panic(ErrInvalidBufferSize)
+	}
+	for i := len(x) - 1; i >= 0; i-- {
+		x[i] = binary.BigEndian.Uint32(buf[n-i*wordByteSize-wordByteSize:])
 	}
 }
 
-// MustSub subtracts rh from b.
-func MustSub(b []uint32, rh []uint32) {
-	if len(b) != len(rh) {
-		panic(ErrUnequallySizedSlices)
+// Read reads the big-endian byte representation of x into out and returns the number of bytes read.
+// It returns an error when len(out) <= x.BytesLen() and the bytes cannot be written in one call.
+func (x Bigint) Read(out []byte) (n int, err error) {
+	if len(out) < x.BytesLen() {
+		return 0, ErrInvalidBufferSize
 	}
-
-	noborrow := true
-	for i := range b {
-		b[i], noborrow = FullAdd(b[i], ^rh[i], noborrow)
+	n = x.BytesLen()
+	for i := len(x) - 1; i >= 0; i-- {
+		binary.BigEndian.PutUint32(out[n-i*wordByteSize-wordByteSize:], x[i])
 	}
+	return
 }
 
-// IsNegative checks whether the given big int represents a negative number in two's complement.
-func IsNegative(b []uint32) bool {
-	ms := b[len(b)-1]
-	return (ms >> 31) != 0
+// Words provides raw access to x by returning its underlying little-endian Word slice.
+func (x Bigint) Words() []Word {
+	return x
 }
 
-// MustCmp compares the given big ints with each other.
-func MustCmp(lh, rh []uint32) int {
-	if len(lh) != len(rh) {
-		panic(ErrUnequallySizedSlices)
+// BytesLen returns the length of x in bytes.
+func (x Bigint) BytesLen() int {
+	return len(x) * wordByteSize
+}
+
+// MSB returns the value of the most significant bit of x.
+func (x Bigint) MSB() uint {
+	return uint(x[len(x)-1] >> (wordSize - 1))
+}
+
+// Add sets x to the sum x+y and returns the carry.
+// The carry output is guaranteed to be 0 or 1.
+func (x Bigint) Add(y Bigint) Word {
+	if len(x) != len(y) {
+		panic(ErrUnsupportedOperandSize)
 	}
 
-	for i := len(lh) - 1; i >= 0; i-- {
+	var carry Word
+	for i := range x {
+		x[i], carry = bits.Add32(x[i], y[i], carry)
+	}
+	return carry
+}
+
+// Sub sets x to the difference x-y and returns the borrow.
+// The borrow output is guaranteed to be 0 or 1.
+func (x Bigint) Sub(y Bigint) Word {
+	if len(x) != len(y) {
+		panic(ErrUnsupportedOperandSize)
+	}
+
+	var borrow Word
+	for i := range x {
+		x[i], borrow = bits.Sub32(x[i], y[i], borrow)
+	}
+	return borrow
+}
+
+// Cmp compares x and y and returns:
+//   -1 if x <  y
+//    0 if x == y
+//   +1 if x >  y
+func (x Bigint) Cmp(y Bigint) int {
+	if len(x) != len(y) {
+		panic(ErrUnsupportedOperandSize)
+	}
+
+	for i := len(x) - 1; i >= 0; i-- {
 		switch {
-		case lh[i] < rh[i]:
+		case x[i] < y[i]:
 			return -1
-		case lh[i] > rh[i]:
+		case x[i] > y[i]:
 			return 1
 		}
 	}
 	return 0
 }
 
-// AddSmall adds a uint32 to a big int and returns the highest index that was changed.
-func AddSmall(b []uint32, a uint32) int {
-	v, carry := FullAdd(b[0], a, false)
-	b[0] = v
-	if !carry {
-		return 0
-	}
-	for i := 1; i < len(b); i++ {
-		b[i], carry = FullAdd(b[i], 0, carry)
-		if !carry {
-			return i
-		}
-	}
-	return len(b)
+// String returns the hexadecimal representation of x including leading zeroes and with the "0x" prefix.
+func (x Bigint) String() string {
+	text, _ := x.MarshalText()
+	return string(text)
 }
 
-// FullAdd returns the sum and whether the operation overflowed.
-func FullAdd(lh, rh uint32, carry bool) (uint32, bool) {
-	v, c1 := addCarry(lh, rh)
-	var c2 bool
-	if carry {
-		v, c2 = addCarry(v, 1)
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String.
+func (x Bigint) MarshalText() ([]byte, error) {
+	buf := make([]byte, x.BytesLen())
+	n, err := x.Read(buf)
+	if err != nil {
+		return nil, err
 	}
-	return v, c1 || c2
+	text := make([]byte, hex.EncodedLen(n))
+	hex.Encode(text, buf[:n])
+	return append(hexPrefix, text...), nil
 }
 
-func addCarry(lh, rh uint32) (uint32, bool) {
-	sum := lh + rh
-	return sum, sum < lh
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// The Bigint is expected in hexadecimal representation starting with the prefix "0x".
+// It must include leading zeroes such that the encoded byte length matches x.BytesLen().
+func (x *Bigint) UnmarshalText(text []byte) error {
+	if !bytes.HasPrefix(text, hexPrefix) {
+		return ErrMissingPrefix
+	}
+	// ignore prefix
+	text = text[len(hexPrefix):]
+	buf := make([]byte, hex.DecodedLen(len(text)))
+	if _, err := hex.Decode(buf, text); err != nil {
+		return err
+	}
+	if len(buf) != x.BytesLen() {
+		return ErrInvalidLength
+	}
+	x.SetBytes(buf)
+	return nil
 }

--- a/kerl/converter_test.go
+++ b/kerl/converter_test.go
@@ -2,7 +2,7 @@ package kerl_test
 
 import (
 	"bytes"
-	"strings"
+	"encoding/hex"
 
 	. "github.com/iotaledger/iota.go/consts"
 	. "github.com/iotaledger/iota.go/kerl"
@@ -13,41 +13,204 @@ import (
 
 var _ = Describe("Converter", func() {
 
-	Context("KerlTritsToBytes()", func() {
-		It("should return zero bytes", func() {
-			trits := MustTrytesToTrits(strings.Repeat("9", HashTrytesSize))
-			bs, err := KerlTritsToBytes(trits)
-			Expect(err).ToNot(HaveOccurred())
+	Context("KerlBytesZeroLastTrit()", func() {
+		It("0 → 0", func() {
+			bs := bytes.Repeat([]byte{0}, HashBytesSize)
+			KerlBytesZeroLastTrit(bs)
 			Expect(bs).To(Equal(bytes.Repeat([]byte{0}, HashBytesSize)))
 		})
 
-		It("should return bytes for largest", func() {
-			trits := MustTrytesToTrits(strings.Repeat("M", HashTrytesSize))
-			bs, err := KerlTritsToBytes(trits)
+		It("⌊3²⁴² / 2⌋ → ⌊3²⁴² / 2⌋", func() {
+			// in: ⌊3²⁴² / 2⌋
+			in := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8964"
+			// expected:  ⌊3²⁴² / 2⌋
+			expected := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8964"
+
+			bs, err := hex.DecodeString(in)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal([]byte{94, 105, 235, 239, 168, 127, 171, 223, 170, 6, 168, 5, 169, 246, 128, 139, 72, 187, 174, 54, 121, 164, 199, 2, 80, 151, 157, 87, 12, 36, 72, 110, 58, 222, 0, 217, 20, 132, 80, 79, 159, 0, 118, 105, 165, 206, 137, 100}))
+			KerlBytesZeroLastTrit(bs)
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
-		It("should return bytes for smallest", func() {
-			trits := MustTrytesToTrits(strings.Repeat("N", HashTrytesSize))
+		It("-⌊3²⁴² / 2⌋ → -⌊3²⁴² / 2⌋", func() {
+			// in: -⌊3²⁴² / 2⌋
+			in := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+			// expected:  -⌊3²⁴² / 2⌋
+			expected := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
+			bs, err := hex.DecodeString(in)
+			Expect(err).ToNot(HaveOccurred())
+			KerlBytesZeroLastTrit(bs)
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("-⌊3²⁴² / 2⌋ - 1 → ⌊3²⁴² / 2⌋", func() {
+			// in: -⌊3²⁴² / 2⌋ - 1
+			in := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769b"
+			// expected:  -⌊3²⁴² / 2⌋ - 1 + 3²⁴²
+			expected := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8964"
+
+			bs, err := hex.DecodeString(in)
+			Expect(err).ToNot(HaveOccurred())
+			KerlBytesZeroLastTrit(bs)
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("⌊3²⁴² / 2⌋ + 1 → -⌊3²⁴² / 2⌋", func() {
+			// in: ⌊3²⁴² / 2⌋ + 1
+			in := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8965"
+			// expected:  ⌊3²⁴² / 2⌋ + 1 - 3²⁴²
+			expected := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
+			bs, err := hex.DecodeString(in)
+			Expect(err).ToNot(HaveOccurred())
+			KerlBytesZeroLastTrit(bs)
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("⌊3²⁴² / 2⌋ + 1 → -⌊3²⁴² / 2⌋", func() {
+			// in: ⌊3²⁴² / 2⌋ + 1
+			in := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8965"
+			// expected:  ⌊3²⁴² / 2⌋ + 1 - 3²⁴²
+			expected := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
+			bs, err := hex.DecodeString(in)
+			Expect(err).ToNot(HaveOccurred())
+			KerlBytesZeroLastTrit(bs)
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("2³⁸³ - 1 → 2³⁸³ - 1 - 3²⁴²", func() {
+			// in: 2³⁸³ - 1
+			in := "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+			// expected:  2³⁸³ - 1 - 3²⁴²
+			expected := "c32c2820af00a840abf2aff4ac12fee96e88a3930cb671fb5ed0c551e7b76f238a43fe4dd6f75f60c1ff132cb462ed36"
+
+			bs, err := hex.DecodeString(in)
+			Expect(err).ToNot(HaveOccurred())
+			KerlBytesZeroLastTrit(bs)
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("-2³⁸³ → -2³⁸³ + 3²⁴²", func() {
+			// in: -2³⁸³
+			in := "800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+			// expected:  -2³⁸³ + 3²⁴²
+			expected := "3cd3d7df50ff57bf540d500b53ed011691775c6cf3498e04a12f3aae184890dc75bc01b22908a09f3e00ecd34b9d12c9"
+
+			bs, err := hex.DecodeString(in)
+			Expect(err).ToNot(HaveOccurred())
+			KerlBytesZeroLastTrit(bs)
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+	})
+
+	Context("KerlTritsToBytes()", func() {
+		It("should return bytes for 0", func() {
+			// in: balanced 243-trit representation of 0
+			trits := make(Trits, HashTrinarySize)
+			// expected: unsigned 384-bit representation of 0
+			expected := "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
 			bs, err := KerlTritsToBytes(trits)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal([]byte{161, 150, 20, 16, 87, 128, 84, 32, 85, 249, 87, 250, 86, 9, 127, 116, 183, 68, 81, 201, 134, 91, 56, 253, 175, 104, 98, 168, 243, 219, 183, 145, 197, 33, 255, 38, 235, 123, 175, 176, 96, 255, 137, 150, 90, 49, 118, 156}))
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for 1", func() {
+			// in: balanced 243-trit representation of 1
+			trits, _ := PadTrits(Trits{1}, HashTrinarySize)
+			// expected: unsigned 384-bit representation of 1
+			expected := "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
+
+			bs, err := KerlTritsToBytes(trits)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for -1", func() {
+			// in: balanced 243-trit representation of -1
+			trits, _ := PadTrits(Trits{-1}, HashTrinarySize)
+			// expected: unsigned 384-bit representation of -1
+			expected := "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+			bs, err := KerlTritsToBytes(trits)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for all '1's", func() {
+			// in: balanced 243-trit representation of ⌊3²⁴³ / 2⌋
+			trits := MustTrytesToTrits("MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM")
+			// expected: unsigned 384-bit representation of ⌊3²⁴² / 2⌋
+			expected := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8964"
+
+			bs, err := KerlTritsToBytes(trits)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for all '-1's", func() {
+			// in: balanced 243-trit representation of -⌊3²⁴³ / 2⌋
+			trits := MustTrytesToTrits("NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN")
+			// expected: unsigned 384-bit representation of -⌊3²⁴² / 2⌋
+			expected := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
+			bs, err := KerlTritsToBytes(trits)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for the uint32 chunk size", func() {
+			// in: balanced 243-trit representation of 27⁶
+			trits, _ := PadTrits(IntToTrits(0x17179149), HashTrinarySize)
+			// expected: unsigned 384-bit representation of -⌊3²⁴² / 2⌋
+			expected := "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000017179149"
+
+			bs, err := KerlTritsToBytes(trits)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for min number with positive last trit", func() {
+			// in: balanced 243-trit representation of ⌊3²⁴² / 2⌋ + 1
+			trits := MustTrytesToTrits("NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNE")
+			// expected: unsigned 384-bit representation of -⌊3²⁴² / 2⌋
+			expected := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
+			bs, err := KerlTritsToBytes(trits)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for max number with negative last trit", func() {
+			// in: balanced 243-trit representation of -⌊3²⁴² / 2⌋ - 1
+			trits := MustTrytesToTrits("MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMV")
+			// expected: unsigned 384-bit representation of ⌊3²⁴² / 2⌋
+			expected := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8964"
+
+			bs, err := KerlTritsToBytes(trits)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
 		It("should handle internal carries", func() {
 			// the following trytes correspond to 2^320 leading to additions with many carries
 			trits := MustTrytesToTrits("NNNNNNNNNNNNIPWAK9KOEYFFRZLJXRFLFLBRBFQATTA9TLIDNFNIEMCSPPUHKUGISALJSLL9PSXBQXEPW")
+			expected := "a3ab5256e3121af155f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
 			bs, err := KerlTritsToBytes(trits)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal([]byte{163, 171, 82, 86, 227, 18, 26, 241, 85, 249, 87, 250, 86, 9, 127, 116, 183, 68, 81, 201, 134, 91, 56, 253, 175, 104, 98, 168, 243, 219, 183, 145, 197, 33, 255, 38, 235, 123, 175, 176, 96, 255, 137, 150, 90, 49, 118, 156}))
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
 		It("should return bytes for valid trits", func() {
 			trits := MustTrytesToTrits("9RFAOVEWQDNGBPEGFZTVJKKITBASFWCQBSTZYWTYIJETVZJYNFFIEQ9JMQWEHQ9ZKARYTE9GGDYZHIPJX")
+			expected := "c88581022f0df1dd6289b737d911363a2390e2d379a2940a77ca15203024629b02fd392859dc58d3774ef615792ce00f"
+
 			bs, err := KerlTritsToBytes(trits)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal([]byte{200, 133, 129, 2, 47, 13, 241, 221, 98, 137, 183, 55, 217, 17, 54, 58, 35, 144, 226, 211, 121, 162, 148, 10, 119, 202, 21, 32, 48, 36, 98, 155, 2, 253, 57, 40, 89, 220, 88, 211, 119, 78, 246, 21, 121, 44, 224, 15}))
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
 		It("should return an error for invalid trits slice length", func() {
@@ -57,35 +220,111 @@ var _ = Describe("Converter", func() {
 	})
 
 	Context("KerlTrytesToBytes()", func() {
-		It("should return zero bytes", func() {
-			bs, err := KerlTrytesToBytes(strings.Repeat("9", HashTrytesSize))
+		It("should return bytes for 0", func() {
+			// in: balanced 81-tryte representation of 0
+			trytes := IntToTrytes(0, HashTrytesSize)
+			// expected: unsigned 384-bit representation of 0
+			expected := "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+			bs, err := KerlTrytesToBytes(trytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal(bytes.Repeat([]byte{0}, HashBytesSize)))
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
-		It("should return bytes for largest", func() {
-			bs, err := KerlTrytesToBytes(strings.Repeat("M", HashTrytesSize))
+		It("should return bytes for 1", func() {
+			// in: balanced 81-tryte representation of 1
+			trytes := IntToTrytes(1, HashTrytesSize)
+			// expected: unsigned 384-bit representation of 1
+			expected := "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
+
+			bs, err := KerlTrytesToBytes(trytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal([]byte{94, 105, 235, 239, 168, 127, 171, 223, 170, 6, 168, 5, 169, 246, 128, 139, 72, 187, 174, 54, 121, 164, 199, 2, 80, 151, 157, 87, 12, 36, 72, 110, 58, 222, 0, 217, 20, 132, 80, 79, 159, 0, 118, 105, 165, 206, 137, 100}))
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
-		It("should return bytes for smallest", func() {
-			bs, err := KerlTrytesToBytes(strings.Repeat("N", HashTrytesSize))
+		It("should return bytes for -1", func() {
+			// in: balanced 81-tryte representation of -1
+			trytes := IntToTrytes(-1, HashTrytesSize)
+			// expected: unsigned 384-bit representation of -1
+			expected := "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+			bs, err := KerlTrytesToBytes(trytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal([]byte{161, 150, 20, 16, 87, 128, 84, 32, 85, 249, 87, 250, 86, 9, 127, 116, 183, 68, 81, 201, 134, 91, 56, 253, 175, 104, 98, 168, 243, 219, 183, 145, 197, 33, 255, 38, 235, 123, 175, 176, 96, 255, 137, 150, 90, 49, 118, 156}))
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for all 'M's", func() {
+			// in: balanced 81-tryte representation of ⌊3²⁴³ / 2⌋
+			trytes := "MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM"
+			// expected: unsigned 384-bit representation of ⌊3²⁴² / 2⌋
+			expected := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8964"
+
+			bs, err := KerlTrytesToBytes(trytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for all 'N's", func() {
+			// in: balanced 81-tryte representation of -⌊3²⁴³ / 2⌋
+			trytes := "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN"
+			// expected: unsigned 384-bit representation of -⌊3²⁴² / 2⌋
+			expected := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
+			bs, err := KerlTrytesToBytes(trytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for the uint32 chunk size", func() {
+			// in: balanced 81-tryte representation of 27⁶
+			trytes := IntToTrytes(0x17179149, HashTrytesSize)
+			// expected: unsigned 384-bit representation of -⌊3²⁴² / 2⌋
+			expected := "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000017179149"
+
+			bs, err := KerlTrytesToBytes(trytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for min number with positive last trit", func() {
+			// in: balanced 81-tryte representation of ⌊3²⁴² / 2⌋ + 1
+			trytes := "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNE"
+			// expected: unsigned 384-bit representation of -⌊3²⁴² / 2⌋
+			expected := "a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
+			bs, err := KerlTrytesToBytes(trytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
+		})
+
+		It("should return bytes for max number with negative last trit", func() {
+			// in: balanced 81-tryte representation of -⌊3²⁴² / 2⌋ - 1
+			trytes := "MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMV"
+			// expected: unsigned 384-bit representation of ⌊3²⁴² / 2⌋
+			expected := "5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8964"
+
+			bs, err := KerlTrytesToBytes(trytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
 		It("should handle internal carries", func() {
 			// the following trytes correspond to 2^320 leading to additions with many carries
-			bs, err := KerlTrytesToBytes("NNNNNNNNNNNNIPWAK9KOEYFFRZLJXRFLFLBRBFQATTA9TLIDNFNIEMCSPPUHKUGISALJSLL9PSXBQXEPW")
+			trytes := "NNNNNNNNNNNNIPWAK9KOEYFFRZLJXRFLFLBRBFQATTA9TLIDNFNIEMCSPPUHKUGISALJSLL9PSXBQXEPW"
+			expected := "a3ab5256e3121af155f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769c"
+
+			bs, err := KerlTrytesToBytes(trytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal([]byte{163, 171, 82, 86, 227, 18, 26, 241, 85, 249, 87, 250, 86, 9, 127, 116, 183, 68, 81, 201, 134, 91, 56, 253, 175, 104, 98, 168, 243, 219, 183, 145, 197, 33, 255, 38, 235, 123, 175, 176, 96, 255, 137, 150, 90, 49, 118, 156}))
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
 		It("should return bytes for valid trytes", func() {
-			bs, err := KerlTrytesToBytes("9RFAOVEWQDNGBPEGFZTVJKKITBASFWCQBSTZYWTYIJETVZJYNFFIEQ9JMQWEHQ9ZKARYTE9GGDYZHIPJX")
+			trytes := "9RFAOVEWQDNGBPEGFZTVJKKITBASFWCQBSTZYWTYIJETVZJYNFFIEQ9JMQWEHQ9ZKARYTE9GGDYZHIPJX"
+			expected := "c88581022f0df1dd6289b737d911363a2390e2d379a2940a77ca15203024629b02fd392859dc58d3774ef615792ce00f"
+
+			bs, err := KerlTrytesToBytes(trytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(bs).To(Equal([]byte{200, 133, 129, 2, 47, 13, 241, 221, 98, 137, 183, 55, 217, 17, 54, 58, 35, 144, 226, 211, 121, 162, 148, 10, 119, 202, 21, 32, 48, 36, 98, 155, 2, 253, 57, 40, 89, 220, 88, 211, 119, 78, 246, 21, 121, 44, 224, 15}))
+			Expect(hex.EncodeToString(bs)).To(Equal(expected))
 		})
 
 		It("should return an error for invalid trytes slice length", func() {
@@ -95,28 +334,58 @@ var _ = Describe("Converter", func() {
 	})
 
 	Context("KerlBytesToTrits()", func() {
-		It("should return all 0 trits", func() {
-			trits, err := KerlBytesToTrits(bytes.Repeat([]byte{0}, HashBytesSize))
+		It("should return trits for all '0x00's", func() {
+			bytes, _ := hex.DecodeString("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+			expected, _ := PadTrits(IntToTrits(0), HashTrinarySize)
+
+			trits, err := KerlBytesToTrits(bytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(trits).To(Equal(MustTrytesToTrits(strings.Repeat("9", HashTrytesSize))))
+			Expect(trits).To(Equal(expected))
 		})
 
-		It("should return trytes for largest", func() {
-			trits, err := KerlBytesToTrits([]byte{127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255})
+		It("should return trits for max", func() {
+			bytes, _ := hex.DecodeString("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+			expected := MustTrytesToTrits("VTPNBFOMDQVXGNPDQGHWKHKXLWMYDWXHLVJIQZVJGGAIPXJ9MAAAGXXEQBCBCXBWEWRNODU9NGUQWNHXC")
+
+			trits, err := KerlBytesToTrits(bytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(trits).To(Equal(MustTrytesToTrits("DGKMYULNWJECTMKWJTSDPSPCODNBWDCSOEQRJAEQTTZRKCQ9NZZZTCCVJYXYXCYDVDIMLWF9MTFJDMSCX")))
+			Expect(trits).To(Equal(expected))
 		})
 
-		It("should return trytes for smallest", func() {
-			trits, err := KerlBytesToTrits([]byte{128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+		It("should return trits for min", func() {
+			bytes, _ := hex.DecodeString("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+			expected := MustTrytesToTrits("DGKMYULNWJECTMKWJTSDPSPCODNBWDCSOEQRJAEQTTZRKCQ9NZZZTCCVJYXYXCYDVDIMLWF9MTFJDMSCX")
+
+			trits, err := KerlBytesToTrits(bytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(trits).To(Equal(MustTrytesToTrits("VTPNBFOMDQVXGNPDQGHWKHKXLWMYDWXHLVJIQZVJGGAIPXJ9MAAAGXXEQBCBCXBWEWRNODU9NGUQWNHXC")))
+			Expect(trits).To(Equal(expected))
+		})
+
+		It("should return trytes for ⌊3²⁴² / 2⌋ + 1", func() {
+			bytes, _ := hex.DecodeString("5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8965")
+			expected := MustTrytesToTrits("NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNW")
+
+			trits, err := KerlBytesToTrits(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trits).To(Equal(expected))
+		})
+
+		It("should return trytes for -⌊3²⁴² / 2⌋ - 1", func() {
+			bytes, _ := hex.DecodeString("a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769b")
+			expected := MustTrytesToTrits("MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMD")
+
+			trits, err := KerlBytesToTrits(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trits).To(Equal(expected))
 		})
 
 		It("should return trits for valid bytes", func() {
-			trits, err := KerlBytesToTrits([]byte{200, 133, 129, 2, 47, 13, 241, 221, 98, 137, 183, 55, 217, 17, 54, 58, 35, 144, 226, 211, 121, 162, 148, 10, 119, 202, 21, 32, 48, 36, 98, 155, 2, 253, 57, 40, 89, 220, 88, 211, 119, 78, 246, 21, 121, 44, 224, 15})
+			bytes, _ := hex.DecodeString("c88581022f0df1dd6289b737d911363a2390e2d379a2940a77ca15203024629b02fd392859dc58d3774ef615792ce00f")
+			expected := MustTrytesToTrits("9RFAOVEWQDNGBPEGFZTVJKKITBASFWCQBSTZYWTYIJETVZJYNFFIEQ9JMQWEHQ9ZKARYTE9GGDYZHIPJX")
+
+			trits, err := KerlBytesToTrits(bytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(trits).To(Equal(MustTrytesToTrits("9RFAOVEWQDNGBPEGFZTVJKKITBASFWCQBSTZYWTYIJETVZJYNFFIEQ9JMQWEHQ9ZKARYTE9GGDYZHIPJX")))
+			Expect(trits).To(Equal(expected))
 		})
 
 		It("should return an error for invalid bytes slice length", func() {
@@ -126,28 +395,58 @@ var _ = Describe("Converter", func() {
 	})
 
 	Context("KerlBytesToTrytes()", func() {
-		It("should return all 9 trytes", func() {
-			ts, err := KerlBytesToTrytes(bytes.Repeat([]byte{0}, HashBytesSize))
+		It("should return trytes for all '0x00's", func() {
+			bytes, _ := hex.DecodeString("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+			expected := IntToTrytes(0, HashTrytesSize)
+
+			trytes, err := KerlBytesToTrytes(bytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ts).To(Equal(strings.Repeat("9", HashTrytesSize)))
+			Expect(trytes).To(Equal(expected))
 		})
 
-		It("should return trytes for largest", func() {
-			ts, err := KerlBytesToTrytes([]byte{127, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255})
+		It("should return trytes for max", func() {
+			bytes, _ := hex.DecodeString("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+			expected := "VTPNBFOMDQVXGNPDQGHWKHKXLWMYDWXHLVJIQZVJGGAIPXJ9MAAAGXXEQBCBCXBWEWRNODU9NGUQWNHXC"
+
+			trytes, err := KerlBytesToTrytes(bytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ts).To(Equal("DGKMYULNWJECTMKWJTSDPSPCODNBWDCSOEQRJAEQTTZRKCQ9NZZZTCCVJYXYXCYDVDIMLWF9MTFJDMSCX"))
+			Expect(trytes).To(Equal(expected))
 		})
 
-		It("should return trytes for smallest", func() {
-			ts, err := KerlBytesToTrytes([]byte{128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+		It("should return trytes for min", func() {
+			bytes, _ := hex.DecodeString("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+			expected := "DGKMYULNWJECTMKWJTSDPSPCODNBWDCSOEQRJAEQTTZRKCQ9NZZZTCCVJYXYXCYDVDIMLWF9MTFJDMSCX"
+
+			trytes, err := KerlBytesToTrytes(bytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ts).To(Equal("VTPNBFOMDQVXGNPDQGHWKHKXLWMYDWXHLVJIQZVJGGAIPXJ9MAAAGXXEQBCBCXBWEWRNODU9NGUQWNHXC"))
+			Expect(trytes).To(Equal(expected))
+		})
+
+		It("should return trytes for ⌊3²⁴² / 2⌋ + 1", func() {
+			bytes, _ := hex.DecodeString("5e69ebefa87fabdfaa06a805a9f6808b48bbae3679a4c70250979d570c24486e3ade00d91484504f9f007669a5ce8965")
+			expected := "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNW"
+
+			trytes, err := KerlBytesToTrytes(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trytes).To(Equal(expected))
+		})
+
+		It("should return trytes for -⌊3²⁴² / 2⌋ - 1", func() {
+			bytes, _ := hex.DecodeString("a19614105780542055f957fa56097f74b74451c9865b38fdaf6862a8f3dbb791c521ff26eb7bafb060ff89965a31769b")
+			expected := "MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMD"
+
+			trytes, err := KerlBytesToTrytes(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trytes).To(Equal(expected))
 		})
 
 		It("should return trytes for valid bytes", func() {
-			ts, err := KerlBytesToTrytes([]byte{200, 133, 129, 2, 47, 13, 241, 221, 98, 137, 183, 55, 217, 17, 54, 58, 35, 144, 226, 211, 121, 162, 148, 10, 119, 202, 21, 32, 48, 36, 98, 155, 2, 253, 57, 40, 89, 220, 88, 211, 119, 78, 246, 21, 121, 44, 224, 15})
+			bytes, _ := hex.DecodeString("c88581022f0df1dd6289b737d911363a2390e2d379a2940a77ca15203024629b02fd392859dc58d3774ef615792ce00f")
+			expected := "9RFAOVEWQDNGBPEGFZTVJKKITBASFWCQBSTZYWTYIJETVZJYNFFIEQ9JMQWEHQ9ZKARYTE9GGDYZHIPJX"
+
+			trytes, err := KerlBytesToTrytes(bytes)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ts).To(Equal("9RFAOVEWQDNGBPEGFZTVJKKITBASFWCQBSTZYWTYIJETVZJYNFFIEQ9JMQWEHQ9ZKARYTE9GGDYZHIPJX"))
+			Expect(trytes).To(Equal(expected))
 		})
 
 		It("should return an error for invalid bytes slice length", func() {

--- a/kerl/kerl.go
+++ b/kerl/kerl.go
@@ -3,14 +3,13 @@ package kerl
 
 import (
 	"hash"
-	"unsafe"
-
-	"github.com/pkg/errors"
+	"strings"
 
 	. "github.com/iotaledger/iota.go/consts"
 	keccak "github.com/iotaledger/iota.go/kerl/sha3"
 	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
+	"github.com/pkg/errors"
 )
 
 // Kerl is a to trinary aligned version of keccak
@@ -26,28 +25,74 @@ func NewKerl() SpongeFunction {
 	return k
 }
 
-func (k *Kerl) squeezeBytes(numChunks int) ([]byte, error) {
-	result := make([]byte, numChunks*HashBytesSize)
-	buffer := make([]byte, HashBytesSize)
+func (k *Kerl) absorbBytes(in []byte) (err error) {
+	_, err = k.s.Write(in)
+	return
+}
 
-	for i := 1; i <= numChunks; i++ {
-		h := k.s.Sum(buffer[:0])
+func (k *Kerl) squeezeBytes() ([]byte, error) {
+	out := make([]byte, HashBytesSize)
+	h := k.s.Sum(nil)
 
-		// copy into result and fix the last trit
-		chunk := result[HashBytesSize*(i-1) : HashBytesSize*i]
-		copy(chunk, h)
-		KerlBytesZeroLastTrit(chunk)
+	// copy into out and fix the last trit
+	copy(out, h)
+	KerlBytesZeroLastTrit(out)
 
-		// re-initialize keccak for the next squeeze
-		k.s.Reset()
-		for i, e := range h {
-			h[i] = ^e
+	// re-initialize keccak for the next squeeze
+	k.Reset()
+	for i := range h {
+		h[i] = ^h[i]
+	}
+	if err := k.absorbBytes(h); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Absorb fills the internal state of the sponge with the given trits.
+// This is only defined for Trit slices that are a multiple of HashTrinarySize long.
+func (k *Kerl) Absorb(in Trits) error {
+	if len(in) == 0 || len(in)%HashTrinarySize != 0 {
+		return errors.Wrap(ErrInvalidTritsLength, "trits slice length must be a multiple of 243")
+	}
+
+	for i := 0; i < len(in); i += HashTrinarySize {
+		bs, err := KerlTritsToBytes(in[i : i+HashTrinarySize])
+		if err != nil {
+			return err
 		}
-		if _, err := k.s.Write(h); err != nil {
-			return nil, err
+		if err = k.absorbBytes(bs); err != nil {
+			return err
 		}
 	}
-	return result, nil
+	return nil
+}
+
+// AbsorbTrytes fills the internal State of the sponge with the given trytes.
+func (k *Kerl) AbsorbTrytes(in Trytes) error {
+	if len(in) == 0 || len(in)%HashTrytesSize != 0 {
+		return errors.Wrap(ErrInvalidTrytesLength, "trytes length must be a multiple of 81")
+	}
+
+	for i := 0; i < len(in); i += HashTrytesSize {
+		bs, err := KerlTrytesToBytes(in[i : i+HashTrytesSize])
+		if err != nil {
+			return err
+		}
+		if err = k.absorbBytes(bs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MustAbsorbTrytes fills the internal State of the sponge with the given trytes.
+// It panics if the given trytes are not valid.
+func (k *Kerl) MustAbsorbTrytes(inn Trytes) {
+	err := k.AbsorbTrytes(inn)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Squeeze out length trits. Length has to be a multiple of HashTrinarySize.
@@ -56,18 +101,17 @@ func (k *Kerl) Squeeze(length int) (Trits, error) {
 		return nil, ErrInvalidSqueezeLength
 	}
 
-	bs, err := k.squeezeBytes(length / HashTrinarySize)
-	if err != nil {
-		return nil, err
-	}
-
 	out := make(Trits, length)
-	for i := 1; i <= length/HashTrinarySize; i++ {
-		ts, err := KerlBytesToTrits(bs[HashBytesSize*(i-1) : HashBytesSize*i])
+	for i := 0; i < length; i += HashTrinarySize {
+		bs, err := k.squeezeBytes()
 		if err != nil {
 			return nil, err
 		}
-		copy(out[HashTrinarySize*(i-1):HashTrinarySize*i], ts)
+		ts, err := KerlBytesToTrits(bs)
+		if err != nil {
+			return nil, err
+		}
+		copy(out[i:], ts)
 	}
 
 	return out, nil
@@ -89,74 +133,31 @@ func (k *Kerl) SqueezeTrytes(length int) (Trytes, error) {
 		return "", ErrInvalidSqueezeLength
 	}
 
-	bs, err := k.squeezeBytes(length / HashTrinarySize)
-	if err != nil {
-		return "", err
-	}
+	var out strings.Builder
+	out.Grow(length / TritsPerTryte)
 
-	out := make([]byte, length/HashTrinarySize*HashTrytesSize)
-	for i := 1; i <= length/HashTrinarySize; i++ {
-		ts, err := KerlBytesToTrytes(bs[HashBytesSize*(i-1) : HashBytesSize*i])
+	for i := 0; i < length/HashTrinarySize; i++ {
+		bs, err := k.squeezeBytes()
 		if err != nil {
 			return "", err
 		}
-		copy(out[HashTrytesSize*(i-1):HashTrytesSize*i], ts)
+		ts, err := KerlBytesToTrytes(bs)
+		if err != nil {
+			return "", err
+		}
+		out.WriteString(ts)
 	}
-
-	// convert into trytes without copying
-	return *(*string)(unsafe.Pointer(&out)), nil
+	return out.String(), nil
 }
 
 // MustSqueezeTrytes squeezes out trytes of the given trit length. Length has to be a multiple of HashTrinarySize.
 // It panics if the trytes or the length are not valid.
 func (k *Kerl) MustSqueezeTrytes(length int) Trytes {
-	return MustTritsToTrytes(k.MustSqueeze(length))
-}
-
-// Absorb fills the internal state of the sponge with the given trits.
-// This is only defined for Trit slices that are a multiple of HashTrinarySize long.
-func (k *Kerl) Absorb(in Trits) error {
-	if len(in) == 0 || len(in)%HashTrinarySize != 0 {
-		return errors.Wrap(ErrInvalidTritsLength, "trits slice length must be a multiple of 243")
-	}
-
-	for i := 1; i <= len(in)/HashTrinarySize; i++ {
-		b, err := KerlTritsToBytes(in[HashTrinarySize*(i-1) : HashTrinarySize*i])
-		if err != nil {
-			return err
-		}
-		if _, err := k.s.Write(b); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// AbsorbTrytes fills the internal State of the sponge with the given trytes.
-func (k *Kerl) AbsorbTrytes(in Trytes) error {
-	if len(in) == 0 || len(in)%HashTrytesSize != 0 {
-		return errors.Wrap(ErrInvalidTrytesLength, "trytes length must be a multiple of 81")
-	}
-
-	for i := 1; i <= len(in)/HashTrytesSize; i++ {
-		b, err := KerlTrytesToBytes(in[HashTrytesSize*(i-1) : HashTrytesSize*i])
-		if err != nil {
-			return err
-		}
-		if _, err := k.s.Write(b); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// MustAbsorbTrytes fills the internal State of the sponge with the given trytes.
-// It panics if the given trytes are not valid.
-func (k *Kerl) MustAbsorbTrytes(inn Trytes) {
-	err := k.AbsorbTrytes(inn)
+	out, err := k.SqueezeTrytes(length)
 	if err != nil {
 		panic(err)
 	}
+	return out
 }
 
 // Reset the internal state of the Kerl sponge.

--- a/kerl/kerl.go
+++ b/kerl/kerl.go
@@ -150,7 +150,7 @@ func (k *Kerl) AbsorbTrytes(in Trytes) error {
 	return nil
 }
 
-// AbsorbTrytes fills the internal State of the sponge with the given trytes.
+// MustAbsorbTrytes fills the internal State of the sponge with the given trytes.
 // It panics if the given trytes are not valid.
 func (k *Kerl) MustAbsorbTrytes(inn Trytes) {
 	err := k.AbsorbTrytes(inn)


### PR DESCRIPTION
# Description of change

This PR adds code improvements and optimizations to the binary-ternary conversion used for Kerl:
- Add idiomatic go bigint package based on `[]uint32`
- Add more and better testcases for the exposed functions
- Add more comments to explain the math behind the conversion
- Use the `bits` package for better pattern matching support of CPU functionality
- Avoid slice allocations on the heap
- Reduce go bounds checks added by the compiler
- Unroll and inline hot functions

On the tested machine this leads to a significant speedup for all Kerl related functions. This has been tested and verified with a few artificial benchmarks:
### `amd64`
```
name                  old time/op  new time/op  delta
KerlTrytesToBytes-48   693ns ± 5%   492ns ± 7%  -29.06%
KerlBytesToTrytes-48   881ns ± 3%   533ns ± 2%  -39.50%
Kerl-48               2.88µs ± 5%  2.44µs ± 6%  -15.24%
KerlTrytes-48         2.85µs ± 6%  2.27µs ± 5%  -20.46%
```

### `386`
```
name                  old time/op  new time/op  delta
KerlTrytesToBytes-48   911ns ± 2%   604ns ± 2%  -33.75%
KerlBytesToTrytes-48  4.62µs ± 2%  1.45µs ± 3%  -68.60%
Kerl-48               8.66µs ± 4%  5.28µs ± 3%  -38.98%
KerlTrytes-48         8.82µs ± 4%  5.14µs ± 4%  -41.72%
```

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- Added ginko tests for `KerlBytesZeroLastTrit`
- Added converter tests for the edge case around the criticial ±⌊3²⁴² / 2⌋ values
- Artificial tests against the reference implementation

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
