### PR TITLE
Eliminate bounds checks in trinary

### DIFF
--- a/signing/signing.go
+++ b/signing/signing.go
@@ -161,9 +161,8 @@ func normalizeHashFragment(fragmentTryteValues []int8) {
 
 func trytesToTryteValues(trytes Trytes) []int8 {
 	vs := make([]int8, len(trytes))
-	for i, tryte := range trytes {
-		idx := tryte - '9'
-		vs[i] = TryteToTryteValueLUT[idx]
+	for i := 0; i < len(trytes); i++ {
+		vs[i] = MustTryteToTryteValue(trytes[i])
 	}
 	return vs
 }


### PR DESCRIPTION
# Description of change

This PR aims to reduce the number of bounds checks added by the go compiler for array/slice accesses that are known to be good.
By giving certain "hints" to the compiler the build-in bounds check elimination can be made more efficient which leads to very significant speedups. This has been verified with a few artificial benchmarks: 

###  `amd64`
```
name                  old time/op  new time/op  delta
IntToTrits-48          266ns ± 3%   205ns ± 2%  -22.81%
TrytesToInt-48        50.6ns ±12%  39.9ns ± 2%  -21.02%
MustTritsToTrytes-48  5.27µs ± 8%  4.37µs ±14%  -17.16%
MustTrytesToTrits-48  5.67µs ± 5%  4.77µs ± 4%  -15.86%
MustTritsToBytes-48   11.0µs ±14%   6.4µs ±19%  -41.93%
MustBytesToTrits-48   14.9µs ±13%   8.2µs ± 5%  -44.97%
MustPad-48            2.17µs ± 3%  0.77µs ±10%  -64.60%
```

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

- The implemented algorithms are not changed only the instructions have been reordered to eliminate bound checks.
- The changes have been verified with existing test suites. 

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
