### PR TITLE
Check if unused trits in tx value field are zero

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -89,6 +89,7 @@ const (
 	AddressTrinaryOffset                  = SignatureMessageFragmentTrinaryOffset + SignatureMessageFragmentTrinarySize
 	AddressTrinarySize                    = 243
 	ValueOffsetTrinary                    = AddressTrinaryOffset + AddressTrinarySize
+	ValueUsedSizeTrinary                  = 33
 	ValueSizeTrinary                      = 81
 	ObsoleteTagTrinaryOffset              = ValueOffsetTrinary + ValueSizeTrinary
 	ObsoleteTagTrinarySize                = 81

--- a/consts/errors.go
+++ b/consts/errors.go
@@ -35,6 +35,8 @@ var (
 	ErrInvalidChecksum = errors.New("invalid checksum")
 	// ErrInvalidHash gets returned for invalid hash parameters.
 	ErrInvalidHash = errors.New("invalid hash")
+	// ErrInvalidValue gets returned for invalid values (e.g. upper 48 trits of the value field used).
+	ErrInvalidValue = errors.New("invalid value")
 	// ErrInvalidIndex gets returned for invalid index parameters.
 	ErrInvalidIndex = errors.New("invalid index option")
 	// ErrInvalidTotalOption gets returned for invalid total option parameters.

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -3,15 +3,17 @@
 package transaction
 
 import (
+	"regexp"
+	"strconv"
+	"strings"
+
 	. "github.com/iotaledger/iota.go/consts"
 	"github.com/iotaledger/iota.go/converter"
 	"github.com/iotaledger/iota.go/curl"
 	"github.com/iotaledger/iota.go/guards"
+	"github.com/iotaledger/iota.go/trinary"
 	. "github.com/iotaledger/iota.go/trinary"
 	"github.com/pkg/errors"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 // Transactions is a slice of Transaction.
@@ -59,7 +61,10 @@ func ParseTransaction(trits Trits, noHash ...bool) (*Transaction, error) {
 	if err != nil {
 		return nil, err
 	}
-	t.Value = TritsToInt(trits[ValueOffsetTrinary : ValueOffsetTrinary+ValueSizeTrinary])
+	t.Value = TritsToInt(trits[ValueOffsetTrinary : ValueOffsetTrinary+ValueUsedSizeTrinary])
+	if trinary.TrailingZeros(trits[ValueOffsetTrinary+ValueUsedSizeTrinary:ValueOffsetTrinary+ValueSizeTrinary]) != 48 {
+		return nil, errors.Wrap(ErrInvalidValue, "unused value trits not zero")
+	}
 	t.ObsoleteTag = MustTritsToTrytes(trits[ObsoleteTagTrinaryOffset : ObsoleteTagTrinaryOffset+ObsoleteTagTrinarySize])
 	t.Timestamp = uint64(TritsToInt(trits[TimestampTrinaryOffset : TimestampTrinaryOffset+TimestampTrinarySize]))
 	t.CurrentIndex = uint64(TritsToInt(trits[CurrentIndexTrinaryOffset : CurrentIndexTrinaryOffset+CurrentIndexTrinarySize]))


### PR DESCRIPTION
# Description of change

Only the first 33 trits of the value field of a transaction are used in current IOTA implementation.
This PR adds a check, if the unused trits are set to zero.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Synced mainnet with HORNET

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
