### PR TITLE
Add Kerl state and let it implement hash.Hash

### DIFF
--- a/kerl/.examples/kerl_examples_test.go
+++ b/kerl/.examples/kerl_examples_test.go
@@ -21,16 +21,26 @@ func ExampleSqueezeTrytes() {}
 // o: Trytes, The Trytes representation of the hash.
 func ExampleMustSqueezeTrytes() {}
 
+// i req: []byte, The target buffer for the squeezed bytes.
+// o: n, The number of bytes squeezed. If the buffer is not a multiple of 48, this will be smaller than the buffer size.
+// o: error, Returned for internal errors.
+func ExampleRead() {}
+
 // i req: in, The Trits slice to absorb. Must be a multiple of 243 in length.
 // o: error, Returned for invalid slice lengths and internal errors.
 func ExampleAbsorb() {}
 
-// i req: inn, The Trytes to absorb.
+// i req: in, The Trytes to absorb.
 // o: error, Returned for internal errors.
 func ExampleAbsorbTrytes() {}
 
-// i req: inn, The Trytes to absorb.
+// i req: in, The Trytes to absorb.
 func ExampleMustAbsorbTrytes() {}
+
+// i req: in, The bytes to absorb.
+// o: n, The number of bytes squeezed.
+// o: error, Returned for internal errors.
+func ExampleWrite() {}
 
 // i req: trits, The Trits to convert to []byte.
 // o: []byte, The converted bytes.

--- a/kerl/kerl.go
+++ b/kerl/kerl.go
@@ -1,57 +1,113 @@
-// Package kerl implements the Kerl hashing function.
+// Package kerl implements the Kerl hash function.
 package kerl
 
 import (
 	"hash"
 	"strings"
+	"unsafe"
 
 	. "github.com/iotaledger/iota.go/consts"
-	keccak "github.com/iotaledger/iota.go/kerl/sha3"
+	"github.com/iotaledger/iota.go/kerl/sha3"
 	. "github.com/iotaledger/iota.go/signing/utils"
-	. "github.com/iotaledger/iota.go/trinary"
+	"github.com/iotaledger/iota.go/trinary"
 	"github.com/pkg/errors"
+)
+
+// ErrAbsorbAfterSqueeze is returned when absorb is called on the same hash after a squeeze.
+var ErrAbsorbAfterSqueeze = errors.New("absorb after squeeze")
+
+// kerlDirection indicates the direction bytes are flowing through the sponge.
+type kerlDirection int
+
+const (
+	// kerlAbsorbing indicates that the sponge is absorbing input.
+	kerlAbsorbing kerlDirection = iota
+	// kerlSqueezing indicates that the sponge is being squeezed.
+	kerlSqueezing
 )
 
 // Kerl is a to trinary aligned version of keccak
 type Kerl struct {
-	s hash.Hash
+	hash.Hash                     // underlying binary hashing function
+	state     kerlDirection       // whether the sponge is absorbing or squeezing
+	buf       [HashBytesSize]byte // internal buffer
 }
 
 // NewKerl returns a new Kerl
-func NewKerl() SpongeFunction {
-	k := &Kerl{
-		s: keccak.NewLegacyKeccak384(),
-	}
-	return k
+func NewKerl() *Kerl {
+	return &Kerl{Hash: sha3.NewLegacyKeccak384(), state: kerlAbsorbing}
 }
 
-func (k *Kerl) absorbBytes(in []byte) (err error) {
-	_, err = k.s.Write(in)
-	return
+// xorUnaligned xors each byte of the internal buffer.
+func (k *Kerl) xorUnaligned() {
+	bw := (*[HashBytesSize / 8]uint64)(unsafe.Pointer(&k.buf))[: HashBytesSize/8 : HashBytesSize/8]
+	bw[0] = ^bw[0]
+	bw[1] = ^bw[1]
+	bw[2] = ^bw[2]
+	bw[3] = ^bw[3]
+	bw[4] = ^bw[4]
+	bw[5] = ^bw[5]
 }
 
-func (k *Kerl) squeezeBytes() ([]byte, error) {
-	out := make([]byte, HashBytesSize)
-	h := k.s.Sum(nil)
-
-	// copy into out and fix the last trit
-	copy(out, h)
-	KerlBytesZeroLastTrit(out)
-
-	// re-initialize keccak for the next squeeze
-	k.Reset()
-	for i := range h {
-		h[i] = ^h[i]
+// squeezeSum squeezes the current hash sum into the hash's state.
+func (k *Kerl) squeezeSum() {
+	// absorb the new state, when squeezing more than once
+	if k.state == kerlSqueezing {
+		k.xorUnaligned()
+		k.Hash.Reset()
+		k.Hash.Write(k.buf[:])
 	}
-	if err := k.absorbBytes(h); err != nil {
-		return nil, err
+	k.state = kerlSqueezing
+	k.Hash.Sum(k.buf[:0])
+}
+
+// Write absorbs more data into the hash's state.
+// In oder to have consistent behavior with Absorb and AbsorbTrytes, it must be assured that the bytes written are
+// multiples of HashByteSize and do not represent ternary numbers with a non-zero 243rd trit, e.g. by calling
+// KerlBytesZeroLastTrit or by only using output from the Kerl hash function.
+func (k *Kerl) Write(in []byte) (int, error) {
+	if k.state != kerlAbsorbing {
+		return 0, ErrAbsorbAfterSqueeze
 	}
-	return out, nil
+	return k.Hash.Write(in)
+}
+
+// Read squeezes an arbitrary number of bytes. The buffer will be filled in multiples of HashByteSize.
+func (k *Kerl) Read(b []byte) (n int, err error) {
+	for len(b) >= HashBytesSize {
+		k.squeezeSum()
+
+		copy(b, k.buf[:])
+		KerlBytesZeroLastTrit(b[:HashBytesSize])
+		b = b[HashBytesSize:]
+		n += HashBytesSize
+	}
+	return n, nil
+}
+
+// Sum appends the current hash to b and returns the resulting slice.
+// It does not change the underlying hash state.
+func (k *Kerl) Sum(b []byte) []byte {
+	// make a copy of k so that state and buffer are preserved
+	dup := *k
+	dup.squeezeSum()
+	return append(b, dup.buf[:]...)
+}
+
+// Reset resets the Hash to its initial state.
+func (k *Kerl) Reset() {
+	k.Hash.Reset()
+	k.state = kerlAbsorbing
+}
+
+// Size returns the number of bytes Sum will return.
+func (k *Kerl) Size() int {
+	return HashBytesSize
 }
 
 // Absorb fills the internal state of the sponge with the given trits.
 // This is only defined for Trit slices that are a multiple of HashTrinarySize long.
-func (k *Kerl) Absorb(in Trits) error {
+func (k *Kerl) Absorb(in trinary.Trits) error {
 	if len(in) == 0 || len(in)%HashTrinarySize != 0 {
 		return errors.Wrap(ErrInvalidTritsLength, "trits slice length must be a multiple of 243")
 	}
@@ -61,7 +117,7 @@ func (k *Kerl) Absorb(in Trits) error {
 		if err != nil {
 			return err
 		}
-		if err = k.absorbBytes(bs); err != nil {
+		if _, err = k.Write(bs); err != nil {
 			return err
 		}
 	}
@@ -69,7 +125,7 @@ func (k *Kerl) Absorb(in Trits) error {
 }
 
 // AbsorbTrytes fills the internal State of the sponge with the given trytes.
-func (k *Kerl) AbsorbTrytes(in Trytes) error {
+func (k *Kerl) AbsorbTrytes(in trinary.Trytes) error {
 	if len(in) == 0 || len(in)%HashTrytesSize != 0 {
 		return errors.Wrap(ErrInvalidTrytesLength, "trytes length must be a multiple of 81")
 	}
@@ -79,7 +135,7 @@ func (k *Kerl) AbsorbTrytes(in Trytes) error {
 		if err != nil {
 			return err
 		}
-		if err = k.absorbBytes(bs); err != nil {
+		if _, err = k.Write(bs); err != nil {
 			return err
 		}
 	}
@@ -88,26 +144,23 @@ func (k *Kerl) AbsorbTrytes(in Trytes) error {
 
 // MustAbsorbTrytes fills the internal State of the sponge with the given trytes.
 // It panics if the given trytes are not valid.
-func (k *Kerl) MustAbsorbTrytes(inn Trytes) {
-	err := k.AbsorbTrytes(inn)
+func (k *Kerl) MustAbsorbTrytes(in trinary.Trytes) {
+	err := k.AbsorbTrytes(in)
 	if err != nil {
 		panic(err)
 	}
 }
 
 // Squeeze out length trits. Length has to be a multiple of HashTrinarySize.
-func (k *Kerl) Squeeze(length int) (Trits, error) {
+func (k *Kerl) Squeeze(length int) (trinary.Trits, error) {
 	if length%HashTrinarySize != 0 {
 		return nil, ErrInvalidSqueezeLength
 	}
 
-	out := make(Trits, length)
+	out := make(trinary.Trits, length)
 	for i := 0; i < length; i += HashTrinarySize {
-		bs, err := k.squeezeBytes()
-		if err != nil {
-			return nil, err
-		}
-		ts, err := KerlBytesToTrits(bs)
+		k.squeezeSum()
+		ts, err := KerlBytesToTrits(k.buf[:])
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +172,7 @@ func (k *Kerl) Squeeze(length int) (Trits, error) {
 
 // MustSqueeze squeezes out trits of the given length. Length has to be a multiple of HashTrinarySize.
 // It panics if the length is not valid.
-func (k *Kerl) MustSqueeze(length int) Trits {
+func (k *Kerl) MustSqueeze(length int) trinary.Trits {
 	out, err := k.Squeeze(length)
 	if err != nil {
 		panic(err)
@@ -128,7 +181,7 @@ func (k *Kerl) MustSqueeze(length int) Trits {
 }
 
 // SqueezeTrytes squeezes out trytes of the given trit length. Length has to be a multiple of HashTrinarySize.
-func (k *Kerl) SqueezeTrytes(length int) (Trytes, error) {
+func (k *Kerl) SqueezeTrytes(length int) (trinary.Trytes, error) {
 	if length%HashTrinarySize != 0 {
 		return "", ErrInvalidSqueezeLength
 	}
@@ -137,11 +190,8 @@ func (k *Kerl) SqueezeTrytes(length int) (Trytes, error) {
 	out.Grow(length / TritsPerTryte)
 
 	for i := 0; i < length/HashTrinarySize; i++ {
-		bs, err := k.squeezeBytes()
-		if err != nil {
-			return "", err
-		}
-		ts, err := KerlBytesToTrytes(bs)
+		k.squeezeSum()
+		ts, err := KerlBytesToTrytes(k.buf[:])
 		if err != nil {
 			return "", err
 		}
@@ -152,7 +202,7 @@ func (k *Kerl) SqueezeTrytes(length int) (Trytes, error) {
 
 // MustSqueezeTrytes squeezes out trytes of the given trit length. Length has to be a multiple of HashTrinarySize.
 // It panics if the trytes or the length are not valid.
-func (k *Kerl) MustSqueezeTrytes(length int) Trytes {
+func (k *Kerl) MustSqueezeTrytes(length int) trinary.Trytes {
 	out, err := k.SqueezeTrytes(length)
 	if err != nil {
 		panic(err)
@@ -160,15 +210,9 @@ func (k *Kerl) MustSqueezeTrytes(length int) Trytes {
 	return out
 }
 
-// Reset the internal state of the Kerl sponge.
-func (k *Kerl) Reset() {
-	k.s.Reset()
-}
-
 // Clone returns a deep copy of the current Kerl
 func (k *Kerl) Clone() SpongeFunction {
-	clone := NewKerl().(*Kerl)
-
-	clone.s = keccak.CloneState(k.s)
-	return clone
+	clone := *k
+	clone.Hash = sha3.CloneState(k.Hash)
+	return &clone
 }

--- a/kerl/kerl.go
+++ b/kerl/kerl.go
@@ -38,8 +38,8 @@ func NewKerl() *Kerl {
 	return &Kerl{Hash: sha3.NewLegacyKeccak384(), state: kerlAbsorbing}
 }
 
-// xorUnaligned xors each byte of the internal buffer.
-func (k *Kerl) xorUnaligned() {
+// notUnaligned flips each bit of the internal buffer.
+func (k *Kerl) notUnaligned() {
 	bw := (*[HashBytesSize / 8]uint64)(unsafe.Pointer(&k.buf))[: HashBytesSize/8 : HashBytesSize/8]
 	bw[0] = ^bw[0]
 	bw[1] = ^bw[1]
@@ -53,7 +53,7 @@ func (k *Kerl) xorUnaligned() {
 func (k *Kerl) squeezeSum() {
 	// absorb the new state, when squeezing more than once
 	if k.state == kerlSqueezing {
-		k.xorUnaligned()
+		k.notUnaligned()
 		k.Hash.Reset()
 		k.Hash.Write(k.buf[:])
 	}

--- a/kerl/kerl_test.go
+++ b/kerl/kerl_test.go
@@ -262,24 +262,24 @@ var _ = Describe("Kerl", func() {
 			Expect(hash1Clone).To(Equal(hash2))
 			Expect(hash1Clone).ToNot(Equal(hash1))
 		})
-	})
 
-	It("clone during squeeze", func() {
-		k1, k2 := NewKerl(), NewKerl()
-		Expect(k1.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
-		Expect(k2.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+		It("clone during squeeze", func() {
+			k1, k2 := NewKerl(), NewKerl()
+			Expect(k1.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+			Expect(k2.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
 
-		k1.MustSqueeze(HashTrinarySize)
-		k2.MustSqueeze(HashTrinarySize)
+			k1.MustSqueeze(HashTrinarySize)
+			k2.MustSqueeze(HashTrinarySize)
 
-		k1Clone := k1.Clone()
-		k1.MustSqueeze(HashTrinarySize)
+			k1Clone := k1.Clone()
+			k1.MustSqueeze(HashTrinarySize)
 
-		hash1 := k1.MustSqueeze(HashTrinarySize)
-		hash2 := k2.MustSqueeze(HashTrinarySize)
-		hash1Clone := k1Clone.MustSqueeze(HashTrinarySize)
-		Expect(hash1Clone).To(Equal(hash2))
-		Expect(hash1Clone).ToNot(Equal(hash1))
+			hash1 := k1.MustSqueeze(HashTrinarySize)
+			hash2 := k2.MustSqueeze(HashTrinarySize)
+			hash1Clone := k1Clone.MustSqueeze(HashTrinarySize)
+			Expect(hash1Clone).To(Equal(hash2))
+			Expect(hash1Clone).ToNot(Equal(hash1))
+		})
 	})
 
 })

--- a/kerl/kerl_test.go
+++ b/kerl/kerl_test.go
@@ -1,10 +1,11 @@
 package kerl_test
 
 import (
+	"encoding/hex"
+
 	. "github.com/iotaledger/iota.go/consts"
 	. "github.com/iotaledger/iota.go/kerl"
-	. "github.com/iotaledger/iota.go/signing/utils"
-	. "github.com/iotaledger/iota.go/trinary"
+	"github.com/iotaledger/iota.go/trinary"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -14,12 +15,12 @@ var _ = Describe("Kerl", func() {
 
 	Context("hash valid trits", func() {
 		DescribeTable("hash computation",
-			func(in Trytes, expected Trytes) {
+			func(in trinary.Trytes, expected trinary.Trytes) {
 				k := NewKerl()
-				Expect(k.Absorb(MustTrytesToTrits(in))).ToNot(HaveOccurred())
+				Expect(k.Absorb(trinary.MustTrytesToTrits(in))).ToNot(HaveOccurred())
 				trits, err := k.Squeeze(len(expected) * HashTrinarySize / HashTrytesSize)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(MustTritsToTrytes(trits)).To(Equal(expected))
+				Expect(trinary.MustTritsToTrytes(trits)).To(Equal(expected))
 			},
 			Entry("normal trytes",
 				"HHPELNTNJIOKLYDUW9NDULWPHCWFRPTDIUWLYUHQWWJVPAKKGKOAZFJPQJBLNDPALCVXGJLRBFSHATF9C",
@@ -53,7 +54,7 @@ var _ = Describe("Kerl", func() {
 
 	Context("hash valid trytes", func() {
 		DescribeTable("hash computation",
-			func(in Trytes, expected Trytes) {
+			func(in trinary.Trytes, expected trinary.Trytes) {
 				k := NewKerl()
 				Expect(k.AbsorbTrytes(in)).ToNot(HaveOccurred())
 				trytes, err := k.SqueezeTrytes(len(expected) * HashTrinarySize / HashTrytesSize)
@@ -90,29 +91,86 @@ var _ = Describe("Kerl", func() {
 		)
 	})
 
-	Context("hash invalid trits", func() {
+	Context("hash valid bytes", func() {
+		DescribeTable("hash computation",
+			func(in string, expected string) {
+				k := NewKerl()
+				// absorb
+				inBuf, err := hex.DecodeString(in)
+				Expect(err).ToNot(HaveOccurred())
+				written, err := k.Write(inBuf)
+				Expect(written).To(Equal(len(inBuf)))
+				Expect(err).ToNot(HaveOccurred())
+				// squeeze
+				outBuf := make([]byte, hex.DecodedLen(len(expected)))
+				read, err := k.Read(outBuf)
+				Expect(read).To(Equal(len(outBuf)))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(hex.EncodeToString(outBuf)).To(Equal(expected))
+			},
+			Entry("input with 48 bytes",
+				"3f1b9727c967dda4f0ef98032f97483864e0dc9ed391dd5b8bc8133d9ce77fe182fef749de882dace92b655c6bba22df",
+				"bec15753fa767d98b59de095a962f472f7b4e15da47d6dd987c4608ccd32f8e2231c3201faca0ee2591f11179c816e30",
+			),
+			Entry("output with more than 48 bytes",
+				"ec3357c2b1f26b6567a80542a65159f3fdc5c4a7ff0d07ff52c14ed39df3cdee8e3b62250b04592ba0beef909e1c430e",
+				"be8fc99ed01018cd8e1904d5188ddc62d85edf1aecc61609a820df347cfe7b8bfa928e9c0460854c638fa330cfd0e3f517a7a822b3d0a0fb3d7b05bbe86ae815c8e063b638363351ac87dd62784db4441e1beae32596a224699fd5aeeab61eab",
+			),
+			Entry("input & output with more than 48 bytes",
+				"be8fc99ed01018cd8e1904d5188ddc62d85edf1aecc61609a820df347cfe7b8bfa928e9c0460854c638fa330cfd0e3f517a7a822b3d0a0fb3d7b05bbe86ae815c8e063b638363351ac87dd62784db4441e1beae32596a224699fd5aeeab61eab",
+				"4b6e005b96685f95c22b94e5248b2fa06b22062124bea182a2e7d8834f9bcf1a3e0debe180a377f19207404916263040b9acbbca8851297604dcdf1ae0cb11f8444d9f387fdd80993e7158e4efea04630bcf931d90190dc98a4243265eb73c3f"),
+		)
+	})
 
-		var k SpongeFunction
-
+	Context("hash invalid bytes", func() {
+		var k *Kerl
 		BeforeEach(func() {
 			k = NewKerl()
 		})
+
+		It("should return an error for Write after Read", func() {
+			written, err := k.Write(make([]byte, HashBytesSize))
+			Expect(written).To(Equal(HashBytesSize))
+			Expect(err).ToNot(HaveOccurred())
+			read, err := k.Read(make([]byte, HashBytesSize))
+			Expect(read).To(Equal(HashBytesSize))
+			Expect(err).ToNot(HaveOccurred())
+			// write again
+			written, err = k.Write(make([]byte, HashBytesSize))
+			Expect(written).To(Equal(0))
+			Expect(err).To(Equal(ErrAbsorbAfterSqueeze))
+		})
+	})
+
+	Context("hash invalid trits", func() {
+		var k *Kerl
+		BeforeEach(func() {
+			k = NewKerl()
+		})
+
 		It("should return an error with empty trits slice", func() {
-			Expect(k.Absorb(Trits{})).To(HaveOccurred())
+			Expect(k.Absorb(trinary.Trits{})).To(HaveOccurred())
 		})
 
 		It("should return an error with invalid trits slice length", func() {
-			Expect(k.Absorb(Trits{1, 0, 0, 0, 0, -1})).To(HaveOccurred())
+			Expect(k.Absorb(trinary.Trits{1, 0, 0, 0, 0, -1})).To(HaveOccurred())
+		})
+
+		It("should return an error for Absorb after Squeeze", func() {
+			Expect(k.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+			_, err := k.Squeeze(HashTrinarySize)
+			Expect(err).ToNot(HaveOccurred())
+			// absorb again
+			Expect(k.Absorb(make(trinary.Trits, HashTrinarySize))).To(Equal(ErrAbsorbAfterSqueeze))
 		})
 	})
 
 	Context("hash invalid trytes", func() {
-
-		var k SpongeFunction
-
+		var k *Kerl
 		BeforeEach(func() {
 			k = NewKerl()
 		})
+
 		It("should return an error with empty tryte slice", func() {
 			Expect(k.AbsorbTrytes("")).To(HaveOccurred())
 		})
@@ -120,6 +178,108 @@ var _ = Describe("Kerl", func() {
 		It("should return an error with invalid trits slice length", func() {
 			Expect(k.AbsorbTrytes("AR")).To(HaveOccurred())
 		})
+
+		It("should return an error for Absorb after Squeeze", func() {
+			Expect(k.AbsorbTrytes(NullHashTrytes)).ToNot(HaveOccurred())
+			_, err := k.SqueezeTrytes(HashTrinarySize)
+			Expect(err).ToNot(HaveOccurred())
+			// absorb again
+			Expect(k.AbsorbTrytes(NullHashTrytes)).To(Equal(ErrAbsorbAfterSqueeze))
+		})
+	})
+
+	Context("(*Kerl).Sum", func() {
+		in := "ff"
+		hash := "08869cad3dc2429eb295195200ad22eb36188452ba65f0e31b2b21bd49b503a7f1d1d61a6df8bff569d3decc9810721b"
+
+		var k *Kerl
+		BeforeEach(func() {
+			k = NewKerl()
+		})
+
+		It("valid bytes", func() {
+			// absorb
+			inBuf, err := hex.DecodeString(in)
+			Expect(err).ToNot(HaveOccurred())
+			written, err := k.Write(inBuf)
+			Expect(written).To(Equal(len(inBuf)))
+			Expect(err).ToNot(HaveOccurred())
+			// append sum to inBuf
+			outBuf := k.Sum(inBuf)
+			Expect(hex.EncodeToString(outBuf)).To(Equal(in + hash))
+		})
+
+		It("absorb after sum", func() {
+			// absorb
+			inBuf, err := hex.DecodeString(in)
+			Expect(err).ToNot(HaveOccurred())
+			written, err := k.Write(inBuf)
+			Expect(written).To(Equal(len(inBuf)))
+			Expect(err).ToNot(HaveOccurred())
+			// append sum to inBuf
+			outBuf := k.Sum(inBuf)
+			Expect(hex.EncodeToString(outBuf)).To(Equal(in + hash))
+			// absorb again
+			written, err = k.Write(inBuf)
+			Expect(written).To(Equal(len(inBuf)))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("(*Kerl).Reset", func() {
+		It("reset during absorb", func() {
+			k1 := NewKerl()
+			Expect(k1.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+
+			k1.Reset()
+			k2 := NewKerl()
+			Expect(k1.MustSqueeze(HashTrinarySize)).To(Equal(k2.MustSqueeze(HashTrinarySize)))
+		})
+
+		It("reset during squeeze", func() {
+			k1 := NewKerl()
+			Expect(k1.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+			k1.MustSqueeze(HashTrinarySize)
+
+			k1.Reset()
+			k2 := NewKerl()
+			Expect(k1.MustSqueeze(HashTrinarySize)).To(Equal(k2.MustSqueeze(HashTrinarySize)))
+		})
+	})
+
+	Context("(*Kerl).Clone", func() {
+		It("clone during absorb", func() {
+			k1, k2 := NewKerl(), NewKerl()
+			Expect(k1.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+			Expect(k2.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+
+			k1Clone := k1.Clone()
+			Expect(k1.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+
+			hash1 := k1.MustSqueeze(HashTrinarySize)
+			hash2 := k2.MustSqueeze(HashTrinarySize)
+			hash1Clone := k1Clone.MustSqueeze(HashTrinarySize)
+			Expect(hash1Clone).To(Equal(hash2))
+			Expect(hash1Clone).ToNot(Equal(hash1))
+		})
+	})
+
+	It("clone during squeeze", func() {
+		k1, k2 := NewKerl(), NewKerl()
+		Expect(k1.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+		Expect(k2.Absorb(make(trinary.Trits, HashTrinarySize))).ToNot(HaveOccurred())
+
+		k1.MustSqueeze(HashTrinarySize)
+		k2.MustSqueeze(HashTrinarySize)
+
+		k1Clone := k1.Clone()
+		k1.MustSqueeze(HashTrinarySize)
+
+		hash1 := k1.MustSqueeze(HashTrinarySize)
+		hash2 := k2.MustSqueeze(HashTrinarySize)
+		hash1Clone := k1Clone.MustSqueeze(HashTrinarySize)
+		Expect(hash1Clone).To(Equal(hash2))
+		Expect(hash1Clone).ToNot(Equal(hash1))
 	})
 
 })

--- a/multisig/address.go
+++ b/multisig/address.go
@@ -1,15 +1,16 @@
 package multisig
 
-import "github.com/iotaledger/iota.go/kerl"
 import (
 	. "github.com/iotaledger/iota.go/consts"
+
 	. "github.com/iotaledger/iota.go/signing/utils"
+
 	. "github.com/iotaledger/iota.go/trinary"
 )
 
 // NewMultisigAddress creates a new multisig address object.
 func NewMultisigAddress(digests Trytes, spongeFunc ...SpongeFunction) (*MultisigAddress, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 
 	m := &MultisigAddress{h: h}
 	if len(digests) != 0 {

--- a/multisig/address.go
+++ b/multisig/address.go
@@ -2,9 +2,7 @@ package multisig
 
 import (
 	. "github.com/iotaledger/iota.go/consts"
-
 	. "github.com/iotaledger/iota.go/signing/utils"
-
 	. "github.com/iotaledger/iota.go/trinary"
 )
 

--- a/multisig/multisig.go
+++ b/multisig/multisig.go
@@ -2,6 +2,10 @@
 package multisig
 
 import (
+	"math"
+	"strings"
+	"time"
+
 	. "github.com/iotaledger/iota.go/api"
 	"github.com/iotaledger/iota.go/bundle"
 	"github.com/iotaledger/iota.go/checksum"
@@ -12,10 +16,10 @@ import (
 	"github.com/iotaledger/iota.go/signing"
 	. "github.com/iotaledger/iota.go/signing/utils"
 	. "github.com/iotaledger/iota.go/trinary"
-	"math"
-	"strings"
-	"time"
 )
+
+// the default SpongeFunction creator
+var defaultCreator = func() SpongeFunction { return kerl.NewKerl() }
 
 // MultisigInput represents a multisig input.
 type MultisigInput struct {
@@ -38,7 +42,7 @@ type Multisig struct {
 
 // Key gets the key value of a seed.
 func (m *Multisig) Key(seed Trytes, index uint64, security SecurityLevel, spongeFunc ...SpongeFunction) (Trytes, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 
 	subseed, err := signing.Subseed(seed, index, h)
 	if err != nil {
@@ -55,7 +59,7 @@ func (m *Multisig) Key(seed Trytes, index uint64, security SecurityLevel, sponge
 
 // Digest gets the digest of a seed under the given index and security.
 func (m *Multisig) Digest(seed Trytes, index uint64, security SecurityLevel, spongeFunc ...SpongeFunction) (Trytes, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 
 	subseed, err := signing.Subseed(seed, index, h)
 	if err != nil {
@@ -77,7 +81,7 @@ func (m *Multisig) Digest(seed Trytes, index uint64, security SecurityLevel, spo
 
 // ValidateAddress validates the given multisig address.
 func (m *Multisig) ValidateAddress(addr Trytes, digests []Trytes, spongeFunc ...SpongeFunction) (bool, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 
 	for i := range digests {
 		digestTrits, err := TrytesToTrits(digests[i])

--- a/signing/legacy/signing.go
+++ b/signing/legacy/signing.go
@@ -12,6 +12,9 @@ import (
 	. "github.com/iotaledger/iota.go/trinary"
 )
 
+// the default SpongeFunction creator
+var defaultCreator = func() SpongeFunction { return kerl.NewKerl() }
+
 // Subseed takes a seed and an index and returns the given subseed.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, error) {
@@ -28,7 +31,7 @@ func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, er
 
 	incrementedSeed := AddTrits(trits, IntToTrits(int64(index)))
 
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	err = h.Absorb(incrementedSeed)
@@ -46,7 +49,7 @@ func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, er
 // Key computes a new private key from the given subseed using the given security level.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Key(subseed Trits, securityLevel SecurityLevel, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	keyLength := KeyFragmentLength * int(securityLevel)
@@ -89,7 +92,7 @@ func Digests(key Trits, spongeFunc ...SpongeFunction) (Trits, error) {
 	digests := make(Trits, HashTrinarySize)
 	buf := make(Trits, HashTrinarySize)
 
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	// iterate through each key fragment
@@ -136,7 +139,7 @@ func Digests(key Trits, spongeFunc ...SpongeFunction) (Trits, error) {
 // Address generates the address trits from the given digests.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Address(digests Trits, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	if err := h.Absorb(digests); err != nil {
@@ -173,7 +176,7 @@ func SignatureFragment(bundleHash Trits, keyFragment Trits, startOffset int, spo
 	keyLength := int(secLvl) * int(ISSKeyLength)
 	sigFrag := make(Trits, keyLength)
 
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	sig := make(Trits, HashTrinarySize)
@@ -220,7 +223,7 @@ func Digest(bundleHash []int8, signatureFragment Trits, startOffset int, spongeF
 	sigFrag := make(Trits, sigLength)
 	copy(sigFrag, signatureFragment[:sigLength])
 
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	dig := make(Trits, HashTrinarySize)

--- a/signing/signing.go
+++ b/signing/signing.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/iotaledger/iota.go/trinary"
 )
 
+// the default SpongeFunction creator
+var defaultCreator = func() SpongeFunction { return kerl.NewKerl() }
+
 // Subseed takes a seed and an index and returns the given subseed.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, error) {
@@ -27,7 +30,7 @@ func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, er
 
 	incrementedSeed := AddTrits(trits, IntToTrits(int64(index)))
 
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	err = h.Absorb(incrementedSeed)
@@ -45,7 +48,7 @@ func Subseed(seed Trytes, index uint64, spongeFunc ...SpongeFunction) (Trits, er
 // Key computes a new private key from the given subseed using the given security level.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Key(subseed Trits, securityLevel SecurityLevel, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	if err := h.Absorb(subseed); err != nil {
@@ -75,7 +78,7 @@ func Digests(key Trits, spongeFunc ...SpongeFunction) (Trits, error) {
 	digests := make(Trits, fragments*HashTrinarySize)
 	buf := make(Trits, HashTrinarySize)
 
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	// iterate through each key fragment
@@ -120,7 +123,7 @@ func Digests(key Trits, spongeFunc ...SpongeFunction) (Trits, error) {
 // Address generates the address trits from the given digests.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Address(digests Trits, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	if err := h.Absorb(digests); err != nil {
@@ -173,7 +176,7 @@ func SignatureFragment(normalizedBundleHashFragment Trits, keyFragment Trits, sp
 	sigFrag := make(Trits, len(keyFragment))
 	copy(sigFrag, keyFragment)
 
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	for i := 0; i < KeySegmentsPerFragment; i++ {
@@ -201,7 +204,7 @@ func SignatureFragment(normalizedBundleHashFragment Trits, keyFragment Trits, sp
 // Digest computes the digest derived from the signature fragment and normalized bundle hash.
 // Optionally takes the SpongeFunction to use. Default is Kerl.
 func Digest(normalizedBundleHashFragment []int8, signatureFragment Trits, spongeFunc ...SpongeFunction) (Trits, error) {
-	h := GetSpongeFunc(spongeFunc, kerl.NewKerl)
+	h := GetSpongeFunc(spongeFunc, defaultCreator)
 	defer h.Reset()
 
 	buf := make(Trits, HashTrinarySize)


### PR DESCRIPTION
# Description of change

- `Kerl` now implements `hash.Hash`. This allows much more efficient hashing of binary data if no ternary representation is required. (This is the case most of the time.)
- Introduce an internal state for `Kerl`:
  - A buffer to store the hash sum without additional memory allocation.
  - Multiple calls of squeeze require a re-initialization of Keccak. This is now only performed on the beginning of a second squeeze instead of the end of every squeeze.  
- Unroll bit flipping and compute it on `uint64` instead of `byte`.
- Added ginkgo tests for all new functions.

On the tested machine this leads to a speedup for all Kerl related functions. This has been tested and verified with a few artificial benchmarks:

### `amd64`
```
name                         old time/op  new time/op  delta
KerlTrytes-48                2.29µs ± 7%  2.08µs ± 6%   -9.21%
GenerateAddress-48           6.17ms ± 8%  5.64ms ± 6%   -8.59%
ValidateBundleSignatures-48  1.12ms ± 5%  1.00ms ± 4%  -10.86%
```

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Add new test-cases and verified result on existing tests.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
