### PR TITLE
Return state instead of Hash in CloneState

### DIFF
--- a/kerl/sha3/sha3.go
+++ b/kerl/sha3/sha3.go
@@ -198,6 +198,6 @@ func (d *state) Sum(in []byte) []byte {
 
 // CloneState returns a copy of the given hash s by cloning its internal state.
 // This function will panic when it is called with a hash not from this sha3 package.
-func CloneState(s hash.Hash) hash.Hash {
+func CloneState(s hash.Hash) *state {
 	return s.(*state).clone()
 }


### PR DESCRIPTION
# Description of change

Before PR #147 the custom function `CloneState` returned a `*state` instead of `hash.Hash`. This PR reverts to this behavior:
- `*state` offers a `Read` method to squeeze data more efficiently and longer than the hash size. Some applications might rely on this behavior.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Since `*state` implements `hash.Hash` it does not require any additional tests.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
