### PR TITLE
Use value-tryte conversion from trinary

### DIFF
--- a/kerl/converter.go
+++ b/kerl/converter.go
@@ -47,8 +47,7 @@ func tryteValuesToTrytes(vs []int8) Trytes {
 	}
 	trytes := make([]byte, HashTrytesSize)
 	for i := range vs {
-		idx := vs[i] - MinTryteValue
-		trytes[i] = TryteValueToTyteLUT[idx]
+		trytes[i] = MustTryteValueToTryte(vs[i])
 	}
 	return string(trytes)
 }
@@ -163,8 +162,7 @@ func KerlTrytesToBytes(trytes Trytes) ([]byte, error) {
 	// convert to tryte values
 	vs := make([]int8, HashTrytesSize)
 	for i := 0; i < HashTrytesSize; i++ {
-		idx := trytes[i] - '9'
-		vs[i] = TryteToTryteValueLUT[idx]
+		MustTryteToTryteValue(trytes[i])
 	}
 
 	return tryteValuesToBytes(vs), nil


### PR DESCRIPTION
# Description of change

This PR provides a minor code cleanup to use the newly exposed `MustTryteValueToTryte` and `MustTryteToTryteValue` in converter.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
