### PR TITLE
Fix: KerlTrytesToBytes computation

### DIFF
--- a/kerl/converter.go
+++ b/kerl/converter.go
@@ -162,7 +162,7 @@ func KerlTrytesToBytes(trytes Trytes) ([]byte, error) {
 	// convert to tryte values
 	vs := make([]int8, HashTrytesSize)
 	for i := 0; i < HashTrytesSize; i++ {
-		MustTryteToTryteValue(trytes[i])
+		vs[i] = MustTryteToTryteValue(trytes[i])
 	}
 
 	return tryteValuesToBytes(vs), nil


### PR DESCRIPTION
# Description of change

This PR fixes a bug introduced by #158 causing `KerlTrytesToBytes` to always return 0.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Since CI checks are not reported for this PR, the corresponding test results can be found here:
https://travis-ci.org/github/iotaledger/iota.go/builds/678896237

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
