### PR TITLE
Check value overflows in ValidBundle

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -298,6 +298,10 @@ func ValidBundle(bundle Bundle) error {
 	for i := range bundle {
 		tx := &bundle[i]
 
+		if iotaGoMath.AbsInt64(tx.Value) > consts.TotalSupply {
+			return errors.Wrapf(ErrInvalidValue, "tx value (%d) overflows/underflows total supply", tx.Value)
+		}
+
 		totalSum += tx.Value
 		if iotaGoMath.AbsInt64(totalSum) > consts.TotalSupply {
 			return errors.Wrapf(ErrInvalidBundleTotalValue, "total sum of balance mutations (%d) overflows/underflows total supply", totalSum)

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -2,15 +2,19 @@
 package bundle
 
 import (
-	"github.com/iotaledger/iota.go/checksum"
-	. "github.com/iotaledger/iota.go/consts"
-	"github.com/iotaledger/iota.go/kerl"
-	"github.com/iotaledger/iota.go/signing"
-	"github.com/iotaledger/iota.go/transaction"
-	. "github.com/iotaledger/iota.go/trinary"
-	"github.com/pkg/errors"
 	"math"
 	"time"
+
+	"github.com/iotaledger/iota.go/checksum"
+	"github.com/iotaledger/iota.go/consts"
+	. "github.com/iotaledger/iota.go/consts"
+	"github.com/iotaledger/iota.go/kerl"
+	iotaGoMath "github.com/iotaledger/iota.go/math"
+	"github.com/iotaledger/iota.go/signing"
+	"github.com/iotaledger/iota.go/transaction"
+	"github.com/iotaledger/iota.go/trinary"
+	. "github.com/iotaledger/iota.go/trinary"
+	"github.com/pkg/errors"
 )
 
 // Bundles are a slice of Bundle.
@@ -287,12 +291,22 @@ func ValidBundle(bundle Bundle) error {
 	var totalSum int64
 
 	sigs := make(map[Hash][]Trytes)
+	changes := map[trinary.Trytes]int64{}
 	k := kerl.NewKerl()
 
 	lastIndex := uint64(len(bundle) - 1)
 	for i := range bundle {
 		tx := &bundle[i]
+
 		totalSum += tx.Value
+		if iotaGoMath.Abs(totalSum) > int64(consts.TotalSupply) {
+			return errors.Wrapf(ErrInvalidBundleTotalValue, "total sum of balance mutations (%d) overflows/underflows total supply", totalSum)
+		}
+
+		changes[tx.Address] += tx.Value
+		if iotaGoMath.Abs(changes[tx.Address]) > int64(consts.TotalSupply) {
+			return errors.Wrapf(ErrInvalidBundleAddressValue, "balance mutation (%d) on address %v overflows/underflows total supply", changes[tx.Address], tx.Address)
+		}
 
 		if tx.CurrentIndex != uint64(i) {
 			return errors.Wrapf(ErrInvalidBundle, "expected tx at index %d to have current index %d but got %d", i, i, tx.CurrentIndex)

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -299,12 +299,12 @@ func ValidBundle(bundle Bundle) error {
 		tx := &bundle[i]
 
 		totalSum += tx.Value
-		if iotaGoMath.Abs(totalSum) > int64(consts.TotalSupply) {
+		if iotaGoMath.AbsInt64(totalSum) > consts.TotalSupply {
 			return errors.Wrapf(ErrInvalidBundleTotalValue, "total sum of balance mutations (%d) overflows/underflows total supply", totalSum)
 		}
 
 		changes[tx.Address] += tx.Value
-		if iotaGoMath.Abs(changes[tx.Address]) > int64(consts.TotalSupply) {
+		if iotaGoMath.AbsInt64(changes[tx.Address]) > consts.TotalSupply {
 			return errors.Wrapf(ErrInvalidBundleAddressValue, "balance mutation (%d) on address %v overflows/underflows total supply", changes[tx.Address], tx.Address)
 		}
 

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -60,11 +60,15 @@ const (
 	KeySegmentHashRounds = 26
 )
 
-// Address and checksum constants.
+// Address, balance and checksum constants.
 const (
 	AddressChecksumTrytesSize     = 9
 	AddressWithChecksumTrytesSize = HashTrytesSize + AddressChecksumTrytesSize
 	MinChecksumTrytesSize         = 3
+
+	// Total supply of IOTA available in the network. Used for ensuring a balanced ledger state and bundle balances
+	// = (3^33 - 1) / 2
+	TotalSupply uint64 = 2779530283277761
 )
 
 // Null value constants.

--- a/consts/errors.go
+++ b/consts/errors.go
@@ -27,6 +27,10 @@ var (
 	ErrInvalidBranchTransaction = errors.New("invalid branch transaction")
 	// ErrInvalidBundle gets returned for Bundles which are schematically wrong or/and don't pass validation.
 	ErrInvalidBundle = errors.New("invalid bundle")
+	// ErrInvalidBundleTotalValue gets returned for Bundles whose total value would overflow/underflow from the total supply.
+	ErrInvalidBundleTotalValue = errors.New("invalid bundle total value")
+	// ErrInvalidBundleAddressValue gets returned for Bundles with balance mutations in an address that would overflow/underflow from the total supply.
+	ErrInvalidBundleAddressValue = errors.New("invalid bundle address value")
 	// ErrInvalidBundleHash gets returned for invalid bundle hash parameters.
 	ErrInvalidBundleHash = errors.New("invalid bundle hash")
 	// ErrInvalidSignature gets returned for bundles with invalid signatures.

--- a/math/math.go
+++ b/math/math.go
@@ -1,0 +1,7 @@
+package math
+
+// Abs returns the absolute value of an int64 value.
+func Abs(n int64) int64 {
+	y := n >> 63
+	return (n ^ y) - y
+}

--- a/math/math.go
+++ b/math/math.go
@@ -1,7 +1,16 @@
 package math
 
-// Abs returns the absolute value of an int64 value.
-func Abs(n int64) int64 {
-	y := n >> 63
-	return (n ^ y) - y
+import (
+	"math"
+)
+
+// AbsInt64 returns the absolute value of an int64 value.
+func AbsInt64(v int64) uint64 {
+	if v == math.MinInt64 {
+		return math.MaxInt64 + 1
+	}
+	if v < 0 {
+		return uint64(-v)
+	}
+	return uint64(v)
 }

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -1,0 +1,17 @@
+package math_test
+
+import (
+	. "github.com/iotaledger/iota.go/math"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Math", func() {
+
+	Context("AbsInt64()", func() {
+		It("should only return positive values", func() {
+			v := AbsInt64(-9223372036854775807)
+			Expect(v).To(Equal(int64(9223372036854775807)))
+		})
+	})
+})

--- a/trinary/trinary.go
+++ b/trinary/trinary.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	. "github.com/iotaledger/iota.go/consts"
+	iotaGoMath "github.com/iotaledger/iota.go/math"
 	"github.com/pkg/errors"
 )
 
@@ -171,25 +172,6 @@ func TrailingZeros(trits Trits) int {
 	return z
 }
 
-// MustAbsInt64 returns the absolute value of an int64.
-func MustAbsInt64(n int64) int64 {
-	if n == -1<<63 {
-		panic("value out of range")
-	}
-	y := n >> 63       // y ← x ⟫ 63
-	return (n ^ y) - y // (x ⨁ y) - y
-}
-
-func absInt64(v int64) uint64 {
-	if v == math.MinInt64 {
-		return math.MaxInt64 + 1
-	}
-	if v < 0 {
-		return uint64(-v)
-	}
-	return uint64(v)
-}
-
 // roundUpToTryteMultiple rounds the given number up the the nearest multiple of 3 to make a valid tryte count.
 func roundUpToTryteMultiple(n uint) uint {
 	rem := n % TritsPerTryte
@@ -201,7 +183,7 @@ func roundUpToTryteMultiple(n uint) uint {
 
 // MinTrits returns the length of trits needed to encode the value.
 func MinTrits(value int64) int {
-	valueAbs := absInt64(value)
+	valueAbs := iotaGoMath.AbsInt64(value)
 
 	var vp uint64
 	var num int
@@ -247,7 +229,7 @@ func TritsToInt(t Trits) int64 {
 // IntToTrytes converts int64 to a slice of trytes.
 func IntToTrytes(value int64, trytesCnt int) Trytes {
 	negative := value < 0
-	v := absInt64(value)
+	v := iotaGoMath.AbsInt64(value)
 
 	var trytes strings.Builder
 	trytes.Grow(trytesCnt)

--- a/trinary/trinary_test.go
+++ b/trinary/trinary_test.go
@@ -262,18 +262,6 @@ var _ = Describe("Trinary", func() {
 		})
 	})
 
-	Context("AbsInt64()", func() {
-		It("should return only positive values", func() {
-			v := MustAbsInt64(-9223372036854775807)
-			Expect(v).To(Equal(int64(9223372036854775807)))
-		})
-
-		It("should panic for Int64_Min", func() {
-			Expect(func() { MustAbsInt64(-9223372036854775808) }).To(Panic())
-		})
-
-	})
-
 	Context("MinTrits()", func() {
 		It("should return correct length", func() {
 			v := MinTrits(1)


### PR DESCRIPTION
# Description of change

This PR adds a check to ValidBundle to ensure that the balance mutations of a bundle would not overflow the total supply of IOTA.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
