### PR TITLE
Feat: Add non M-bug safe bundle finalization

### DIFF
--- a/bundle/.examples/bundle_examples_test.go
+++ b/bundle/.examples/bundle_examples_test.go
@@ -2,10 +2,11 @@ package bundle_examples_test
 
 import (
 	"fmt"
-	"github.com/iotaledger/iota.go/bundle"
-	"github.com/iotaledger/iota.go/trinary"
 	"strings"
 	"time"
+
+	"github.com/iotaledger/iota.go/bundle"
+	"github.com/iotaledger/iota.go/trinary"
 )
 
 // i req: tag, The tag Trytes to pad.
@@ -69,8 +70,6 @@ func ExampleAddEntry() {
 // o: Bundle, The finalized Bundle.
 // o: error, Returned for invalid finalization.
 func ExampleFinalize() {
-	// Unix epoch in seconds
-	ts := uint64(time.Now().UnixNano() / int64(time.Second))
 	transfers := bundle.Transfers{
 		{
 			Address: strings.Repeat("9", 81),
@@ -79,6 +78,10 @@ func ExampleFinalize() {
 			Message: "",
 		},
 	}
+	// timestamp should be Unix epoch in seconds
+	// ts := uint64(time.Now().UnixNano() / int64(time.Second))
+	// but we set it to 1 for deterministic results
+	ts := uint64(1)
 	bundleEntries, err := bundle.TransfersToBundleEntries(ts, transfers...)
 	if err != nil {
 		// handle error
@@ -87,10 +90,8 @@ func ExampleFinalize() {
 
 	bndl := bundle.Bundle{}
 	for _, entry := range bundleEntries {
-		bundle.AddEntry(bndl, entry)
+		bndl = bundle.AddEntry(bndl, entry)
 	}
-
-	fmt.Println(len(bndl)) // 1
 
 	finalizedBundle, err := bundle.Finalize(bndl)
 	if err != nil {
@@ -99,7 +100,46 @@ func ExampleFinalize() {
 	}
 
 	// finalized bundle, ready for PoW
-	_ = finalizedBundle
+	fmt.Println(finalizedBundle[0].Bundle)
+	// output: MGHYQJYZJ9TAGOUIUGL9B9LSDSBLMCPTDAHNHRDVQCFBVLJAIQDAHHUWWWKLAZCKKIJUNKNIVTWEWZDSY
+}
+
+// i req: bundle, The Bundle to finalize.
+// o: Bundle, The finalized Bundle.
+// o: error, Returned for invalid finalization.
+func ExampleFinalizeInsecure() {
+	transfers := bundle.Transfers{
+		{
+			Address: strings.Repeat("9", 81),
+			Tag:     strings.Repeat("9", 27),
+			Value:   0,
+			Message: "",
+		},
+	}
+	// timestamp should be Unix epoch in seconds
+	// ts := uint64(time.Now().UnixNano() / int64(time.Second))
+	// but we set it to 1 for deterministic results
+	ts := uint64(1)
+	bundleEntries, err := bundle.TransfersToBundleEntries(ts, transfers...)
+	if err != nil {
+		// handle error
+		return
+	}
+
+	bndl := bundle.Bundle{}
+	for _, entry := range bundleEntries {
+		bndl = bundle.AddEntry(bndl, entry)
+	}
+
+	finalizedBundle, err := bundle.FinalizeInsecure(bndl)
+	if err != nil {
+		// handle error
+		return
+	}
+
+	// finalized bundle, ready for PoW
+	fmt.Println(finalizedBundle[0].Bundle)
+	// output: UBF9RSGNCZXZBJ9RUQPSBEXDWSLLVVN9KSIHTMYVFGROQQZO9MRESTW9BWFIZPJHYY9DVMCAJKKTWKSI9
 }
 
 // i req: bndl, The Bundle to add the Trytes to.

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -189,7 +189,6 @@ var _ = Describe("Bundle", func() {
 	})
 
 	Context("Finalize()", func() {
-
 		It("computes the bundle hash and adds it to all transactions in the bundle", func() {
 			bndlCopy := make(Bundle, len(bndl))
 			copy(bndlCopy, bndl)
@@ -198,6 +197,19 @@ var _ = Describe("Bundle", func() {
 			Expect(bndlCopy[0].ObsoleteTag).To(Equal("ZUH999999999999999999999999"))
 			for i := range bndlCopy {
 				Expect(bndlCopy[i].Bundle).To(Equal("VRGXKZDODWIVGFYFCCXJRNDCQJVYUVBRIWJXKFGBIEWUPHHTJLTKH99JW9OLJ9JCIXCEIRRXJKLWOBDZZ"))
+			}
+		})
+	})
+
+	Context("FinalizeInsecure()", func() {
+		It("computes the bundle hash and adds it to all transactions in the bundle", func() {
+			bndlCopy := make(Bundle, len(bndl))
+			copy(bndlCopy, bndl)
+			_, err := FinalizeInsecure(bndlCopy)
+			Expect(err).ToNot(HaveOccurred())
+			for i := range bndlCopy {
+				Expect(bndlCopy[i].ObsoleteTag).To(Equal(bndlCopy[i].Tag))
+				Expect(bndlCopy[i].Bundle).To(Equal("YIRZIQZEVGPUFQAKTISUPRGNSBBUYBBWFIBFVWO9GEQMPHKKZBM9TF9CFEKIWVYTCYMKDWWQ999ZKW9IB"))
 			}
 		})
 	})


### PR DESCRIPTION
# Description of change

This PR adds `bundle.FinalizeInsecure` that finalizes a bundle without mining for a normalized bundle hash.
For 0-value bundles or for bundles signed with private keys derived in a secure way `bundle.Finalize` would be much slower.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
