### PR TITLE
Improve BCT Curl comments

### DIFF
--- a/curl/bct/transform.go
+++ b/curl/bct/transform.go
@@ -8,23 +8,22 @@ func transformGeneric(lto, hto, lfrom, hfrom *[curl.StateSize]uint, rounds uint)
 	for r := rounds; r > 0; r-- {
 		// three Curl-P rounds unrolled
 		for i := 0; i < curl.StateSize-2; i += 3 {
-			t0 := curl.Indices[i+0] // r8
-			t1 := curl.Indices[i+1] // r9
-			t2 := curl.Indices[i+2] // r10
-			t3 := curl.Indices[i+3] // r11
+			t0 := curl.Indices[i+0]
+			t1 := curl.Indices[i+1]
+			t2 := curl.Indices[i+2]
+			t3 := curl.Indices[i+3]
 
-			l0, h0 := lfrom[t0], hfrom[t0] // r12, r13
-			l1, h1 := lfrom[t1], hfrom[t1] // r14, r15
-			l2, h2 := lfrom[t2], hfrom[t2] // r8, r9
-			l3, h3 := lfrom[t3], hfrom[t3] // r10, r11
+			l0, h0 := lfrom[t0], hfrom[t0]
+			l1, h1 := lfrom[t1], hfrom[t1]
+			l2, h2 := lfrom[t2], hfrom[t2]
+			l3, h3 := lfrom[t3], hfrom[t3]
 
-			v0 := (h0 ^ l1) & l0                 // r13
-			lto[i+0], hto[i+0] = ^v0, (l0^h1)|v0 // r13, r12
-			v1 := (h1 ^ l2) & l1                 // r15
-			lto[i+1], hto[i+1] = ^v1, (l1^h2)|v1 // r15, r14
-			v2 := (h2 ^ l3) & l2                 // r9
-			lto[i+2], hto[i+2] = ^v2, (l2^h3)|v2 // r9, r8
-			// tmp: r15
+			v0 := (h0 ^ l1) & l0
+			lto[i+0], hto[i+0] = ^v0, (l0^h1)|v0
+			v1 := (h1 ^ l2) & l1
+			lto[i+1], hto[i+1] = ^v1, (l1^h2)|v1
+			v2 := (h2 ^ l3) & l2
+			lto[i+2], hto[i+2] = ^v2, (l2^h3)|v2
 		}
 		// swap buffers
 		lfrom, lto = lto, lfrom

--- a/curl/bct/transform_amd64.s
+++ b/curl/bct/transform_amd64.s
@@ -13,34 +13,34 @@ TEXT ·transform(SB),NOSPLIT,$0
     JZ DONE
 
 LOOP:
-    MOVQ $·Indices(SB), R8      // var Indices [730]int
+    MOVQ $·Indices(SB), R8
     MOVQ (R8), R8
-    MOVQ (CX)(R8*8), R14
-    MOVQ (DX)(R8*8), R15
+    MOVQ (CX)(R8*8), R14        // ltmp := lfrom[Indices[0]]
+    MOVQ (DX)(R8*8), R15        // htmp := hfrom[Indices[0]]
 
     XORQ DI, DI                 // i := 0
 
 ROUND:
-    MOVQ $·Indices(SB), R12      // var Indices [730]int
-    MOVQ 8(R12)(DI*8), R9
-    MOVQ 16(R12)(DI*8), R10
-    MOVQ 24(R12)(DI*8), R11
+    MOVQ $·Indices(SB), R12
+    MOVQ 8(R12)(DI*8), R9       // t1 := Indices[i+1]
+    MOVQ 16(R12)(DI*8), R10     // t2 := Indices[i+2]
+    MOVQ 24(R12)(DI*8), R11     // t3 := Indices[i+3]
 
-    MOVQ R14, R12
-    MOVQ R15, R13
-    MOVQ (CX)(R9*8), R14
-    MOVQ (DX)(R9*8), R15
+    MOVQ R14, R12               // l0 := ltmp
+    MOVQ R15, R13               // h0 := htmp
+    MOVQ (CX)(R9*8), R14        // l1 := lfrom[t1]
+    MOVQ (DX)(R9*8), R15        // h1 := hfrom[t1]
     MOVQ (CX)(R10*8), R8
     MOVQ (DX)(R10*8), R9
     MOVQ (CX)(R11*8), R10
     MOVQ (DX)(R11*8), R11
 
-    XORQ R14, R13
+    XORQ R14, R13               // a0 := (l1 ^ h0) & l0
     ANDQ R12, R13
-    XORQ R15, R12
+    XORQ R15, R12               // b0 := (h1 ^ l0) | a0
     ORQ R13, R12
-    MOVQ R12, (BX)(DI*8)
-    NOTQ R13
+    MOVQ R12, (BX)(DI*8)        // hto[i] = b0
+    NOTQ R13                    // lto[i] = ^a0
     MOVQ R13, (AX)(DI*8)
 
     XORQ R8, R15
@@ -59,15 +59,15 @@ ROUND:
     NOTQ R9
     MOVQ R9, 16(AX)(DI*8)
 
-    MOVQ R10, R14
-    MOVQ R11, R15
+    MOVQ R10, R14               // ltmp = lfrom[t3]
+    MOVQ R11, R15               // htmp = hfrom[t3]
 
     ADDQ $3, DI                 // i += 3
     CMPQ DI, $727               // if i < 727 goto ROUND
     JL ROUND
 
-    XCHGQ AX, CX
-    XCHGQ BX, DX
+    XCHGQ AX, CX                // lfrom, lto = lto, lfrom
+    XCHGQ BX, DX                // hfrom, hto = hto, hfrom
 
     DECQ SI                     // r--
     JNZ LOOP                    // if r != 0 goto LOOP


### PR DESCRIPTION
# Description of change

This commit improves the comments for the `curl/bct` assembler code. It was actually intended as part of #180 but apparently forgotten.
It could either be merged now separately or closed as it does not change any code.
