### PR TITLE
Add draft RFC-20 Bech32 address format

### DIFF
--- a/address.go
+++ b/address.go
@@ -282,7 +282,7 @@ func (j *jsoned25519) ToSerializable() (Serializable, error) {
 		return nil, fmt.Errorf("unable to decode address from JSON for Ed25519 address: %w", err)
 	}
 	if err := checkExactByteLength(len(addrBytes), Ed25519AddressBytesLength); err != nil {
-		return nil, fmt.Errorf("unable to decode address from JSON for WOTS address: %w", err)
+		return nil, fmt.Errorf("unable to decode address from JSON for Ed25519 address: %w", err)
 	}
 	addr := &Ed25519Address{}
 	copy(addr[:], addrBytes)

--- a/address.go
+++ b/address.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/iotaledger/iota.go/bech32"
+	"github.com/iotaledger/iota.go/encoding/t5b1"
+	"github.com/iotaledger/iota.go/legacy/trinary"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -17,9 +20,20 @@ const (
 	AddressWOTS AddressType = iota
 	// Denotes a Ed25510 address.
 	AddressEd25519
+)
 
+// NetworkPrefix denotes the different network prefixes.
+type NetworkPrefix int
+
+// Network prefix options
+const (
+	PrefixMainnet NetworkPrefix = iota
+	PrefixTestnet
+)
+
+const (
 	// The length of a WOTS address.
-	WOTSAddressBytesLength = 49
+	WOTSAddressBytesLength = 49 // t5b1.EncodedLen(legacy.HashTrytesSize)
 	// The size of a serialized WOTS address with its type denoting byte.
 	WOTSAddressSerializedBytesSize = SmallTypeDenotationByteSize + WOTSAddressBytesLength
 
@@ -29,22 +43,108 @@ const (
 	Ed25519AddressSerializedBytesSize = SmallTypeDenotationByteSize + Ed25519AddressBytesLength
 )
 
-// AddressSelector implements SerializableSelectorFunc for address types.
-func AddressSelector(typeByte uint32) (Serializable, error) {
-	var seri Serializable
-	switch byte(typeByte) {
-	case AddressWOTS:
-		seri = &WOTSAddress{}
-	case AddressEd25519:
-		seri = &Ed25519Address{}
-	default:
-		return nil, fmt.Errorf("%w: type %d", ErrUnknownAddrType, typeByte)
+func (p NetworkPrefix) String() string {
+	return hrpStrings[p]
+}
+
+// ParsePrefix parses the string and returns the corresponding NetworkPrefix.
+func ParsePrefix(s string) (NetworkPrefix, error) {
+	for i := range hrpStrings {
+		if s == hrpStrings[i] {
+			return NetworkPrefix(i), nil
+		}
 	}
-	return seri, nil
+	return 0, fmt.Errorf("%w: prefix %s", ErrUnknownNetworkPrefix, s)
+}
+
+var (
+	hrpStrings = [...]string{"iot", "tio"}
+)
+
+// Address describes a general address.
+type Address interface {
+	Serializable
+
+	// Type returns the type of the address.
+	Type() AddressType
+	// Bech32 encodes the address as a bech32 string.
+	Bech32(hrp NetworkPrefix) string
+
+	String() string
+}
+
+// AddressSelector implements SerializableSelectorFunc for address types.
+func AddressSelector(addressType uint32) (Serializable, error) {
+	return newAddress(byte(addressType))
+}
+
+func newAddress(addressType byte) (address Address, err error) {
+	switch addressType {
+	case AddressWOTS:
+		return &WOTSAddress{}, nil
+	case AddressEd25519:
+		return &Ed25519Address{}, nil
+	default:
+		return nil, fmt.Errorf("%w: type %d", ErrUnknownAddrType, addressType)
+	}
+}
+
+func bech32String(hrp NetworkPrefix, addr Address) string {
+	bytes, _ := addr.Serialize(DeSeriModeNoValidation)
+	s, err := bech32.Encode(hrp.String(), bytes)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// ParseBech32 decodes a bech32 encoded string.
+func ParseBech32(s string) (NetworkPrefix, Address, error) {
+	hrp, addrData, err := bech32.Decode(s)
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid bech32 encoding: %w", err)
+	}
+	prefix, err := ParsePrefix(hrp)
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid human-readable prefix: %w", err)
+	}
+	if len(addrData) == 0 {
+		return 0, nil, ErrDeserializationNotEnoughData
+	}
+
+	addr, err := newAddress(addrData[0])
+	if err != nil {
+		return 0, nil, err
+	}
+	n, err := addr.Deserialize(addrData, DeSeriModePerformValidation)
+	if err != nil {
+		return 0, nil, err
+	}
+	if n != len(addrData) {
+		return 0, nil, ErrDeserializationNotAllConsumed
+	}
+	return prefix, addr, nil
 }
 
 // Defines a WOTS address.
+// TODO: it could make more sense to store WOTS addresses as tryte arrays.
 type WOTSAddress [WOTSAddressBytesLength]byte
+
+// WOTSAddressFromTrytes creates a new WOTSAddress from trytes.
+func WOTSAddressFromTrytes(trytes trinary.Trytes) *WOTSAddress {
+	addrBytes := t5b1.EncodeTrytes(trytes)
+	addr := &WOTSAddress{}
+	copy(addr[:], addrBytes)
+	return addr
+}
+
+func (wotsAddr *WOTSAddress) Type() AddressType {
+	return AddressWOTS
+}
+
+func (wotsAddr *WOTSAddress) Bech32(hrp NetworkPrefix) string {
+	return bech32String(hrp, wotsAddr)
+}
 
 func (wotsAddr *WOTSAddress) String() string {
 	return hex.EncodeToString(wotsAddr[:])
@@ -58,20 +158,22 @@ func (wotsAddr *WOTSAddress) Deserialize(data []byte, deSeriMode DeSerialization
 		if err := checkTypeByte(data, AddressWOTS); err != nil {
 			return 0, fmt.Errorf("unable to deserialize WOTS address: %w", err)
 		}
-		// TODO: check T5B1 encoding
+		if _, err := t5b1.DecodeToTrytes(data[SmallTypeDenotationByteSize:]); err != nil {
+			return 0, fmt.Errorf("invalid WOTS address bytes: %w", err)
+		}
 	}
 	copy(wotsAddr[:], data[SmallTypeDenotationByteSize:])
 	return WOTSAddressSerializedBytesSize, nil
 }
 
-func (wotsAddr *WOTSAddress) Serialize(deSeriMode DeSerializationMode) (data []byte, err error) {
+func (wotsAddr *WOTSAddress) Serialize(deSeriMode DeSerializationMode) ([]byte, error) {
 	if deSeriMode.HasMode(DeSeriModePerformValidation) {
-		// TODO: check T5B1 encoding
+		_, err := t5b1.DecodeToTrytes(wotsAddr[:])
+		if err != nil {
+			return nil, fmt.Errorf("invalid WOTS address bytes: %w", err)
+		}
 	}
-	var b [WOTSAddressSerializedBytesSize]byte
-	b[0] = AddressWOTS
-	copy(b[SmallTypeDenotationByteSize:], wotsAddr[:])
-	return b[:], nil
+	return append([]byte{wotsAddr.Type()}, wotsAddr[:]...), nil
 }
 
 func (wotsAddr *WOTSAddress) MarshalJSON() ([]byte, error) {
@@ -96,6 +198,14 @@ func (wotsAddr *WOTSAddress) UnmarshalJSON(bytes []byte) error {
 
 // Defines an Ed25519 address.
 type Ed25519Address [Ed25519AddressBytesLength]byte
+
+func (edAddr *Ed25519Address) Type() AddressType {
+	return AddressEd25519
+}
+
+func (edAddr *Ed25519Address) Bech32(hrp NetworkPrefix) string {
+	return bech32String(hrp, edAddr)
+}
 
 func (edAddr *Ed25519Address) String() string {
 	return hex.EncodeToString(edAddr[:])
@@ -167,11 +277,14 @@ type jsoned25519 struct {
 }
 
 func (j *jsoned25519) ToSerializable() (Serializable, error) {
-	addr := &Ed25519Address{}
 	addrBytes, err := hex.DecodeString(j.Address)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode address from JSON for Ed25519 address: %w", err)
 	}
+	if err := checkExactByteLength(len(addrBytes), Ed25519AddressBytesLength); err != nil {
+		return nil, fmt.Errorf("unable to decode address from JSON for WOTS address: %w", err)
+	}
+	addr := &Ed25519Address{}
 	copy(addr[:], addrBytes)
 	return addr, nil
 }
@@ -183,11 +296,14 @@ type jsonwotsaddress struct {
 }
 
 func (j *jsonwotsaddress) ToSerializable() (Serializable, error) {
-	addr := &WOTSAddress{}
 	addrBytes, err := hex.DecodeString(j.Address)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode address from JSON for WOTS address: %w", err)
 	}
+	if err := checkExactByteLength(len(addrBytes), WOTSAddressBytesLength); err != nil {
+		return nil, fmt.Errorf("unable to decode address from JSON for WOTS address: %w", err)
+	}
+	addr := &WOTSAddress{}
 	copy(addr[:], addrBytes)
 	return addr, nil
 }

--- a/address_test.go
+++ b/address_test.go
@@ -125,3 +125,54 @@ func TestEd25519Address_Serialize(t *testing.T) {
 		})
 	}
 }
+
+var bech32Tests = []struct {
+	name    string
+	network iota.NetworkPrefix
+	addr    iota.Address
+	bech32  string
+}{
+	{
+		"RFC example: W-OTS mainnet",
+		iota.PrefixMainnet,
+		iota.WOTSAddressFromTrytes("EQSAUZXULTTYZCLNJNTXQTQHOMOFZERHTCGTXOLTVAHKSA9OGAZDEKECURBRIXIJWNPFCQIOVFVVXJVD9"),
+		"iot1qr4r3j4wamzu8ltdp6y7xtysj77vqtwua3q23hx9zmrmcqfdpd4muv25jwctsmxlh5g60w8s6k4x7gsq28c8da",
+	},
+	{
+		"RFC example: Ed25519 mainnet",
+		iota.PrefixMainnet,
+		&iota.Ed25519Address{0x52, 0xfd, 0xfc, 0x07, 0x21, 0x82, 0x65, 0x4f, 0x16, 0x3f, 0x5f, 0x0f, 0x9a, 0x62, 0x1d, 0x72, 0x95, 0x66, 0xc7, 0x4d, 0x10, 0x03, 0x7c, 0x4d, 0x7b, 0xbb, 0x04, 0x07, 0xd1, 0xe2, 0xc6, 0x49},
+		"iot1q9f0mlq8yxpx2nck8a0slxnzr4ef2ek8f5gqxlzd0wasgp73utryjtzcp98",
+	},
+	{
+		"RFC example: W-OTS testnet",
+		iota.PrefixTestnet,
+		iota.WOTSAddressFromTrytes("EQSAUZXULTTYZCLNJNTXQTQHOMOFZERHTCGTXOLTVAHKSA9OGAZDEKECURBRIXIJWNPFCQIOVFVVXJVD9"),
+		"tio1qr4r3j4wamzu8ltdp6y7xtysj77vqtwua3q23hx9zmrmcqfdpd4muv25jwctsmxlh5g60w8s6k4x7gsqcmnkzh",
+	},
+	{
+		"RFC example: Ed25519 testnet",
+		iota.PrefixTestnet,
+		&iota.Ed25519Address{0x52, 0xfd, 0xfc, 0x07, 0x21, 0x82, 0x65, 0x4f, 0x16, 0x3f, 0x5f, 0x0f, 0x9a, 0x62, 0x1d, 0x72, 0x95, 0x66, 0xc7, 0x4d, 0x10, 0x03, 0x7c, 0x4d, 0x7b, 0xbb, 0x04, 0x07, 0xd1, 0xe2, 0xc6, 0x49},
+		"tio1q9f0mlq8yxpx2nck8a0slxnzr4ef2ek8f5gqxlzd0wasgp73utryj3qemv4",
+	},
+}
+
+func TestBech32(t *testing.T) {
+	for _, tt := range bech32Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.bech32, tt.addr.Bech32(tt.network))
+		})
+	}
+}
+
+func TestParseBech32(t *testing.T) {
+	for _, tt := range bech32Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, addr, err := iota.ParseBech32(tt.bech32)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.network, network)
+			assert.Equal(t, tt.addr, addr)
+		})
+	}
+}

--- a/bech32/bech32.go
+++ b/bech32/bech32.go
@@ -1,0 +1,153 @@
+// Package bech32 implements bech32 encoding and decoding.
+package bech32
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/iotaledger/iota.go/bech32/internal/base32"
+)
+
+const (
+	maxStringLength = 90
+	checksumLength  = 6
+	separator       = '1'
+)
+
+var charset = newEncoding("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+
+// Encode encodes the String string and the src data as a Bech32 string.
+// It returns an error when the input is invalid.
+func Encode(hrp string, src []byte) (string, error) {
+	dataLen := base32.EncodedLen(len(src))
+	if len(hrp)+dataLen+checksumLength+1 > maxStringLength {
+		return "", fmt.Errorf("%w: String length=%d, data length=%d", ErrInvalidLength, len(hrp), dataLen)
+	}
+	// validate the human-readable part
+	if len(hrp) < 1 {
+		return "", fmt.Errorf("%w: String must not be empty", ErrInvalidLength)
+	}
+	for _, c := range hrp {
+		if !isValidHRPChar(c) {
+			return "", fmt.Errorf("%w: not US-ASCII character in human-readable part", ErrInvalidCharacter)
+		}
+	}
+	if err := validateCase(hrp); err != nil {
+		return "", err
+	}
+
+	// convert the human-readable part to lower for the checksum
+	hrpLower := strings.ToLower(hrp)
+
+	// convert to base32 and add the checksum
+	data := make([]uint8, base32.EncodedLen(len(src))+checksumLength)
+	base32.Encode(data, src)
+	copy(data[dataLen:], bech32CreateChecksum(hrpLower, data[:dataLen]))
+
+	// enc the data part using the charset
+	chars := charset.encode(data)
+
+	// convert to a string using the corresponding charset
+	var res strings.Builder
+	res.WriteString(hrp)
+	res.WriteByte(separator)
+	res.WriteString(chars)
+
+	// return with the correct case
+	if hrp == hrpLower {
+		return res.String(), nil
+	}
+	return strings.ToUpper(res.String()), nil
+}
+
+// Decode decodes the Bech32 string s into its human-readable and data part.
+// It returns an error when s does not represent a valid Bech32 encoding.
+// An SyntaxError is returned when the error can be matched to a certain position in s.
+func Decode(s string) (string, []byte, error) {
+	if len(s) > maxStringLength {
+		return "", nil, &SyntaxError{fmt.Errorf("%w: maximum length exceeded", ErrInvalidLength), maxStringLength}
+	}
+	// validate the separator
+	hrpLen := strings.LastIndex(s, string(separator))
+	if hrpLen == -1 {
+		return "", nil, ErrMissingSeparator
+	}
+	if hrpLen < 1 || hrpLen+checksumLength > len(s) {
+		return "", nil, &SyntaxError{fmt.Errorf("%w: invalid position", ErrInvalidSeparator), hrpLen}
+	}
+	// validate characters in human-readable part
+	for i, c := range s[:hrpLen] {
+		if !isValidHRPChar(c) {
+			return "", nil, &SyntaxError{fmt.Errorf("%w: not US-ASCII character in human-readable part", ErrInvalidCharacter), i}
+		}
+	}
+	// validate that the case of the entire string is consistent
+	if err := validateCase(s); err != nil {
+		return "", nil, err
+	}
+
+	// convert everything to lower
+	s = strings.ToLower(s)
+	hrp := s[:hrpLen]
+	chars := s[hrpLen+1:]
+
+	// decode the data part
+	data, err := charset.decode(chars)
+	if err != nil {
+		return "", nil, &SyntaxError{fmt.Errorf("%w: non-charset character in data part", ErrInvalidCharacter), hrpLen + 1 + len(data)}
+	}
+
+	// validate the checksum
+	if len(data) < checksumLength || !bech32VerifyChecksum(hrp, data) {
+		return "", nil, &SyntaxError{ErrInvalidChecksum, len(s) - checksumLength}
+	}
+	data = data[:len(data)-checksumLength]
+
+	// decode the data part
+	dst := make([]byte, base32.DecodedLen(len(data)))
+	if _, err := base32.Decode(dst, data); err != nil {
+		var e *base32.CorruptInputError
+		if errors.As(err, &e) {
+			return "", nil, &SyntaxError{e.Unwrap(), hrpLen + 1 + e.Offset}
+		}
+		return "", nil, err
+	}
+	return hrp, dst, nil
+}
+
+func isValidHRPChar(r rune) bool {
+	// it must only contain US-ASCII characters, with each character having a value in the range [33-126]
+	return r >= 33 && r <= 126
+}
+
+func validateCase(s string) error {
+	upper, lower := firstUpper(s), firstLower(s)
+	if upper < lower && upper >= 0 {
+		return &SyntaxError{ErrMixedCase, lower}
+	}
+	if lower < upper && lower >= 0 {
+		return &SyntaxError{ErrMixedCase, upper}
+	}
+	return nil
+}
+
+func firstUpper(s string) int {
+	lower := strings.ToLower(s)
+	for i := range s {
+		if lower[i] != s[i] {
+			return i
+		}
+	}
+	return -1
+}
+
+func firstLower(s string) int {
+	lower := strings.ToUpper(s)
+	for i := range s {
+		if lower[i] != s[i] {
+			return i
+		}
+	}
+	return -1
+}

--- a/bech32/bech32_test.go
+++ b/bech32/bech32_test.go
@@ -1,0 +1,204 @@
+package bech32
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/iotaledger/iota.go/bech32/internal/base32"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncode(t *testing.T) {
+	var tests = []*struct {
+		hrp    string
+		src    []byte
+		expS   string
+		expErr error
+	}{
+		{
+			hrp:  "A",
+			src:  []byte{},
+			expS: "A12UEL5L",
+		},
+		{
+			hrp:  "a",
+			src:  []byte{},
+			expS: "a12uel5l",
+		},
+		{
+			hrp:  "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio",
+			src:  []byte{},
+			expS: "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+		},
+		{
+			hrp:  "abcdef",
+			src:  decodeHex("00443214c74254b635cf84653a56d7c675be77df"),
+			expS: "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
+		},
+		{
+			hrp:  "1",
+			src:  make([]byte, 51),
+			expS: "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+		},
+		{
+			hrp:  "split",
+			src:  decodeHex("c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d"),
+			expS: "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+		},
+		{
+			hrp:  "?",
+			src:  []byte{},
+			expS: "?1ezyfcl",
+		},
+		{
+			hrp:  "test",
+			src:  decodeHex("daf4d8dd12769fcc87f7ad04a6495b"),
+			expS: "test1mt6d3hgjw60ueplh45z2vj2mnsrk9a",
+		},
+		{
+			hrp:  "test",
+			src:  decodeHex("ff"),
+			expS: "test1lu0zy72x",
+		},
+		{
+			hrp:  "bc",
+			src:  []byte{},
+			expS: "bc1gmk9yu",
+		},
+		{
+			hrp:  "tb",
+			src:  decodeHex("00c318a1e0a628b34025e8c9019ab6d09b64c2b3c66a693d0dc63194b024819310"),
+			expS: "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+		},
+		{
+			hrp:  "ca",
+			src:  decodeHex("030102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
+			expS: "ca1qvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqxuzx4s",
+		},
+		{hrp: "\x20", src: []byte{}, expErr: ErrInvalidCharacter},
+		{hrp: "\x7F", src: []byte{}, expErr: ErrInvalidCharacter},
+		{hrp: "\x80", src: []byte{}, expErr: ErrInvalidCharacter},
+		{hrp: "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio", src: []byte{}, expErr: ErrInvalidLength},
+		{hrp: "", src: decodeHex("ff"), expErr: ErrInvalidLength},
+		{hrp: "bC", src: []byte{}, expErr: ErrMixedCase},
+		{hrp: "Cb", src: []byte{}, expErr: ErrMixedCase},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprint(tt.hrp, tt.src), func(t *testing.T) {
+			s, err := Encode(tt.hrp, tt.src)
+			if assert.Truef(t, errors.Is(err, tt.expErr), "unexpected error: %v", err) {
+				assert.Equal(t, tt.expS, s)
+			}
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	var tests = []*struct {
+		s       string
+		expHRP  string
+		expData []byte
+		expErr  error
+	}{
+		{
+			s:       "A12UEL5L",
+			expHRP:  "a",
+			expData: []byte{},
+		},
+		{
+			s:       "a12uel5l",
+			expHRP:  "a",
+			expData: []byte{},
+		},
+		{
+			s:       "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+			expHRP:  "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio",
+			expData: []byte{},
+		},
+		{
+			s:       "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
+			expHRP:  "abcdef",
+			expData: decodeHex("00443214c74254b635cf84653a56d7c675be77df"),
+		},
+		{
+			s:       "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+			expHRP:  "1",
+			expData: make([]byte, 51),
+		},
+		{
+			s:       "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+			expHRP:  "split",
+			expData: decodeHex("c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d"),
+		},
+		{
+			s:       "?1ezyfcl",
+			expHRP:  "?",
+			expData: []byte{},
+		},
+		{
+			s:       "test1mt6d3hgjw60ueplh45z2vj2mnsrk9a",
+			expHRP:  "test",
+			expData: decodeHex("daf4d8dd12769fcc87f7ad04a6495b"),
+		},
+		{
+			s:       "test1lu0zy72x",
+			expHRP:  "test",
+			expData: decodeHex("ff"),
+		},
+		{
+			s:       "bc1gmk9yu",
+			expHRP:  "bc",
+			expData: []byte{},
+		},
+		{
+			s:       "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+			expHRP:  "tb",
+			expData: decodeHex("00c318a1e0a628b34025e8c9019ab6d09b64c2b3c66a693d0dc63194b024819310"),
+		},
+		{
+			s:       "ca1qvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqxuzx4s",
+			expHRP:  "ca",
+			expData: decodeHex("030102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"),
+		},
+		{s: "\x201nwldj5", expErr: ErrInvalidCharacter},
+		{s: "\x7F1axkwrx", expErr: ErrInvalidCharacter},
+		{s: "\x801eym55h", expErr: ErrInvalidCharacter},
+		{s: "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx", expErr: ErrInvalidLength},
+		{s: "pzry9x0s0muk", expErr: ErrMissingSeparator},
+		{s: "1pzry9x0s0muk", expErr: ErrInvalidSeparator},
+		{s: "x1b4n0q5v", expErr: ErrInvalidCharacter},
+		{s: "li1dgmt3", expErr: ErrInvalidChecksum},
+		{s: "A1G7SGD8", expErr: ErrInvalidChecksum},
+		{s: "10a06t8", expErr: ErrInvalidSeparator},
+		{s: "1qzzfhee", expErr: ErrInvalidSeparator},
+		{s: "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7", expErr: ErrMixedCase},
+		{s: "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv", expErr: base32.ErrNonZeroPadding},
+		{s: "bC1gmk9yu", expErr: ErrMixedCase},
+		{s: "Cb1gmk9yu", expErr: ErrMixedCase},
+		{s: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", expErr: base32.ErrInvalidLength},
+		{s: "test1ls7uz56", expErr: base32.ErrInvalidLength},
+		{s: "test1lllxt840c", expErr: base32.ErrInvalidLength},
+		{s: "test1llllllkmgrnu", expErr: base32.ErrInvalidLength},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			hrp, data, err := Decode(tt.s)
+			if assert.Truef(t, errors.Is(err, tt.expErr), "unexpected error: %v", err) {
+				assert.Equal(t, tt.expHRP, hrp)
+				assert.Equal(t, tt.expData, data)
+			}
+		})
+	}
+}
+
+func decodeHex(s string) []byte {
+	dst, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return dst
+}

--- a/bech32/chars.go
+++ b/bech32/chars.go
@@ -1,0 +1,52 @@
+package bech32
+
+import (
+	"strings"
+)
+
+type encoding struct {
+	enc    [32]byte
+	decMap [256]uint8
+}
+
+// newEncoding returns a new encoding defined by the given alphabet,
+// which must be a 32-byte string.
+func newEncoding(charset string) *encoding {
+	if len(charset) != 32 {
+		panic("encoding alphabet is not 32-bytes long")
+	}
+
+	e := new(encoding)
+	copy(e.enc[:], charset)
+
+	for i := 0; i < len(e.decMap); i++ {
+		e.decMap[i] = 0xFF
+	}
+	for i := 0; i < len(charset); i++ {
+		e.decMap[charset[i]] = uint8(i)
+	}
+	return e
+}
+
+// encode converts the base32 digits of src into a string.
+func (e *encoding) encode(src []uint8) string {
+	var dst strings.Builder
+	dst.Grow(len(src))
+	for i := range src {
+		dst.WriteByte(e.enc[src[i]])
+	}
+	return dst.String()
+}
+
+// decode converts the string into base32 digits.
+func (e *encoding) decode(src string) ([]uint8, error) {
+	dst := make([]uint8, len(src))
+	for i := range src {
+		d := e.decMap[src[i]]
+		if d == 0xFF {
+			return dst[:i], ErrInvalidCharacter
+		}
+		dst[i] = e.decMap[src[i]]
+	}
+	return dst, nil
+}

--- a/bech32/checksum.go
+++ b/bech32/checksum.go
@@ -1,0 +1,47 @@
+package bech32
+
+var gen = []int{0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3}
+
+// For more details on the checksum calculation, please refer to BIP 173.
+func bech32CreateChecksum(hrp string, blocks []byte) []byte {
+	values := append(bech32HrpExpand(hrp), blocks...)
+	polymod := bech32Polymod(append(values, []byte{0, 0, 0, 0, 0, 0}...)) ^ 1
+	res := make([]byte, 6)
+	for i := range res {
+		res[i] = byte((polymod >> (5 * (5 - i))) & 31)
+	}
+	return res
+}
+
+// For more details on the polymod calculation, please refer to BIP 173.
+func bech32Polymod(values []byte) int {
+	chk := 1
+	for _, v := range values {
+		b := chk >> 25
+		chk = (chk&0x1ffffff)<<5 ^ int(v)
+		for i := range gen {
+			if (b>>i)&1 != 0 {
+				chk ^= gen[i]
+			}
+		}
+	}
+	return chk
+}
+
+// For more details on String expansion, please refer to BIP 173.
+func bech32HrpExpand(s string) []byte {
+	res := make([]byte, 0, 2*len(s)+1)
+	for _, x := range []byte(s) {
+		res = append(res, x>>5)
+	}
+	res = append(res, 0)
+	for _, x := range []byte(s) {
+		res = append(res, x&31)
+	}
+	return res
+}
+
+// For more details on the checksum verification, please refer to BIP 173.
+func bech32VerifyChecksum(hrp string, data []byte) bool {
+	return bech32Polymod(append(bech32HrpExpand(hrp), data...)) == 1
+}

--- a/bech32/errors.go
+++ b/bech32/errors.go
@@ -1,0 +1,23 @@
+package bech32
+
+import "errors"
+
+// Errors reported during bech32 decoding.
+var (
+	ErrInvalidLength    = errors.New("invalid length")
+	ErrMissingSeparator = errors.New("missing separator '" + string(separator) + "'")
+	ErrInvalidSeparator = errors.New("separator '" + string(separator) + "' at invalid position")
+	ErrMixedCase        = errors.New("mixed case")
+	ErrInvalidCharacter = errors.New("invalid character")
+	ErrInvalidChecksum  = errors.New("invalid checksum")
+)
+
+// A SyntaxError is a description of a Bech32 syntax error.
+type SyntaxError struct {
+	err    error // wrapped error
+	Offset int   // error occurred after reading Offset bytes
+}
+
+func (e *SyntaxError) Error() string { return e.err.Error() }
+
+func (e *SyntaxError) Unwrap() error { return e.err }

--- a/bech32/internal/base32/base32.go
+++ b/bech32/internal/base32/base32.go
@@ -1,0 +1,136 @@
+// Package base32 implements the conversion for bytes (base256) to base32.
+package base32
+
+import (
+	"errors"
+	"fmt"
+)
+
+// EncodedLen returns the length of the base32 encoding of an input buffer of length n.
+func EncodedLen(n int) int {
+	return (n*8 + 4) / 5
+}
+
+// Encode encodes src into EncodedLen(len(src)) digits of dst.
+// As a convenience, it returns the number of digits written to dst,
+// but this value is always EncodedLen(len(src)).
+// Encode implements base32 encoding.
+func Encode(dst []uint8, src []byte) int {
+	n := EncodedLen(len(src))
+	for len(src) > 0 {
+		var carry byte
+
+		// unpack 8x 5-bit source blocks into a 5 byte destination quantum
+		switch len(src) {
+		default:
+			dst[7] = src[4] & 0x1F
+			carry = src[4] >> 5
+			fallthrough
+		case 4:
+			dst[6] = carry | (src[3]<<3)&0x1F
+			dst[5] = (src[3] >> 2) & 0x1F
+			carry = src[3] >> 7
+			fallthrough
+		case 3:
+			dst[4] = carry | (src[2]<<1)&0x1F
+			carry = (src[2] >> 4) & 0x1F
+			fallthrough
+		case 2:
+			dst[3] = carry | (src[1]<<4)&0x1F
+			dst[2] = (src[1] >> 1) & 0x1F
+			carry = (src[1] >> 6) & 0x1F
+			fallthrough
+		case 1:
+			dst[1] = carry | (src[0]<<2)&0x1F
+			dst[0] = src[0] >> 3
+		}
+
+		if len(src) < 5 {
+			break
+		}
+		src = src[5:]
+		dst = dst[8:]
+	}
+	return n
+}
+
+var (
+	// ErrInvalidLength reports an attempt to decode an input of invalid length.
+	ErrInvalidLength = errors.New("invalid length")
+	// ErrNonZeroPadding reports an attempt to decode an input without zero padding.
+	ErrNonZeroPadding = errors.New("non-zero padding")
+)
+
+// A CorruptInputError is a description of a base32 syntax error.
+type CorruptInputError struct {
+	err    error // wrapped error
+	Offset int   // error occurred after reading Offset bytes
+}
+
+func (e CorruptInputError) Error() string {
+	return fmt.Sprintf("%s at input byte %d", e.err, e.Offset)
+}
+
+func (e CorruptInputError) Unwrap() error {
+	return e.err
+}
+
+// DecodedLen returns the maximum length in bytes of the decoded data corresponding to n base32-encoded values.
+func DecodedLen(n int) int {
+	return n * 5 / 8
+}
+
+// Decode decodes src into DecodedLen(len(src)) bytes, returning the actual number of bytes written to dst.
+// If the input is malformed, Decode returns an error and the number of bytes decoded before the error.
+func Decode(dst []byte, src []uint8) (int, error) {
+	written := 0
+	read := 0
+	for len(src) > 0 {
+		n := len(src)
+		if n == 1 || n == 3 || n == 6 {
+			return written, &CorruptInputError{ErrInvalidLength, read}
+		}
+
+		// pack 8x 5-bit source blocks into 5 byte destination quantum
+		switch n {
+		default:
+			dst[4] = src[6]<<5 | src[7]
+			written++
+			fallthrough
+		case 7:
+			dst[3] = src[4]<<7 | src[5]<<2 | src[6]>>3
+			written++
+			fallthrough
+		case 5:
+			dst[2] = src[3]<<4 | src[4]>>1
+			written++
+			fallthrough
+		case 4:
+			dst[1] = src[1]<<6 | src[2]<<1 | src[3]>>4
+			written++
+			fallthrough
+		case 2:
+			dst[0] = src[0]<<3 | src[1]>>2
+			written++
+		}
+
+		if n < 8 {
+			// check for non-zero padding
+			switch {
+			case n == 2 && src[1]&(1<<2-1) != 0:
+				return written, &CorruptInputError{ErrNonZeroPadding, read + 1}
+			case n == 4 && src[3]&(1<<4-1) != 0:
+				return written, &CorruptInputError{ErrNonZeroPadding, read + 3}
+			case n == 5 && src[4]&(1<<1-1) != 0:
+				return written, &CorruptInputError{ErrNonZeroPadding, read + 4}
+			case n == 7 && src[6]&(1<<3-1) != 0:
+				return written, &CorruptInputError{ErrNonZeroPadding, read + 6}
+			}
+			break
+		}
+		dst = dst[5:]
+		src = src[8:]
+		read += 8
+	}
+	return written, nil
+}

--- a/error.go
+++ b/error.go
@@ -30,6 +30,8 @@ var (
 	ErrDeserializationNotEnoughData = errors.New("not enough data for deserialization")
 	// Returned if not all bytes were consumed during deserialization of a given type.
 	ErrDeserializationNotAllConsumed = errors.New("not all data has been consumed but should have been")
+	// Returned for unknown bech32 network HRP.
+	ErrUnknownNetworkPrefix = errors.New("unknown network prefix")
 	// Returned when WOTS objects are tried to be de/serialized.
 	ErrWOTSNotImplemented = errors.New("unfortunately WOTS is not yet implemented")
 )

--- a/util_test.go
+++ b/util_test.go
@@ -7,9 +7,13 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/iotaledger/iota.go"
+	"github.com/iotaledger/iota.go/encoding/t5b1"
+	"github.com/iotaledger/iota.go/legacy"
+	"github.com/iotaledger/iota.go/legacy/trinary"
 )
 
 func must(err error) {
@@ -27,6 +31,14 @@ func randBytes(length int) []byte {
 	return b
 }
 
+func randTrytes(length int) trinary.Trytes {
+	var trytes strings.Builder
+	for i := 0; i < length; i++ {
+		trytes.WriteByte(legacy.TryteAlphabet[rand.Intn(len(legacy.TryteAlphabet))])
+	}
+	return trytes.String()
+}
+
 func rand32ByteHash() [32]byte {
 	var h [iota.TransactionIDLength]byte
 	b := randBytes(32)
@@ -37,13 +49,10 @@ func rand32ByteHash() [32]byte {
 func randWOTSAddr() (*iota.WOTSAddress, []byte) {
 	// type
 	wotsAddr := &iota.WOTSAddress{}
-	addr := randBytes(iota.WOTSAddressBytesLength)
+	addr := t5b1.EncodeTrytes(randTrytes(legacy.HashTrytesSize))
 	copy(wotsAddr[:], addr)
 	// serialized
-	var b [iota.WOTSAddressSerializedBytesSize]byte
-	b[0] = iota.AddressWOTS
-	copy(b[iota.SmallTypeDenotationByteSize:], addr)
-	return wotsAddr, b[:]
+	return wotsAddr, append([]byte{iota.AddressWOTS}, addr...)
 }
 
 func randEd25519Addr() (*iota.Ed25519Address, []byte) {


### PR DESCRIPTION
# Description of change

- Port Bech32 address format from https://github.com/Wollac/iota-crypto-demo
- Introduce `Address` interface containing a `Bech32` method.
- Add RFC examples as test cases.