### PR TITLE
Add peer routes to NodeAPI

### DIFF
--- a/node_api_client.go
+++ b/node_api_client.go
@@ -612,9 +612,8 @@ func (api *NodeAPI) RemovePeerByID(id string) error {
 
 // Peers returns a list of all peers.
 func (api *NodeAPI) Peers() ([]*PeerResponse, error) {
-
 	res := []*PeerResponse{}
-	_, err := api.do(http.MethodGet, NodeAPIRoutePeers, nil, res)
+	_, err := api.do(http.MethodGet, NodeAPIRoutePeers, nil, &res)
 	if err != nil {
 		return nil, err
 	}

--- a/node_api_client_test.go
+++ b/node_api_client_test.go
@@ -485,9 +485,10 @@ func TestNodeAPI_AddPeer(t *testing.T) {
 	defer gock.Off()
 
 	peerID := "12D3KooWFJ8Nq6gHLLvigTpPSbyMmLk35k1TcpJof8Y4y8yFAB32"
+	multiAddr := fmt.Sprintf("/ip4/127.0.0.1/tcp/15600/p2p/%s", peerID)
 
 	originRes := &iota.PeerResponse{
-		MultiAddress: fmt.Sprintf("/ip4/127.0.0.1/tcp/15600/p2p/%s", peerID),
+		MultiAddress: multiAddr,
 		ID:           peerID,
 		Connected:    true,
 		Relation:     "autopeered",
@@ -503,18 +504,17 @@ func TestNodeAPI_AddPeer(t *testing.T) {
 	}
 
 	req := &iota.AddPeerRequest{
-		MultiAddress: fmt.Sprintf("/ip4/127.0.0.1/tcp/15600/p2p/%s", peerID),
+		MultiAddress: multiAddr,
 	}
 
 	gock.New(nodeAPIUrl).
 		Post(iota.NodeAPIRoutePeers).
-		MatchType("json").
 		JSON(req).
 		Reply(201).
 		JSON(&iota.HTTPOkResponseEnvelope{Data: originRes})
 
 	nodeAPI := iota.NewNodeAPI(nodeAPIUrl)
-	resp, err := nodeAPI.AddPeer(peerID)
+	resp, err := nodeAPI.AddPeer(multiAddr)
 	require.NoError(t, err)
 	require.EqualValues(t, originRes, resp)
 }


### PR DESCRIPTION
# Description of change

This PR adds the NodeAPI routes for managing the peers of a fullnode.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

I added several test cases and fixed the old ones.

**Unfortunately the last two test cases do not seem to work correctly, but I don't understand why gock is not mocking correctly...**

:(

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
