### PR TITLE
Fix: Use the updated address in the bundle essence

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -226,7 +226,7 @@ func finalize(bundle Bundle, validator func(Hash) bool) (Bundle, error) {
 			var essence strings.Builder
 			essence.Grow(2 * HashTrytesSize)
 
-			essence.WriteString(bundle[i].Address)
+			essence.WriteString(addresses[i])
 			essence.WriteString(values[i])
 			essence.WriteString(MustTritsToTrytes(obsoleteTagsTrits[i]))
 			essence.WriteString(timestamps[i])

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Bundle", func() {
 	tag := "TAG" + strings.Repeat("9", 24)
 	bndl := Bundle{
 		{
-			Address:                       strings.Repeat("A", 80) + "J",
+			Address:                       strings.Repeat("A", 80) + "J", // as the last trit will be zeroed, this should be the same as all As
 			Value:                         -2,
 			Tag:                           tag,
 			ObsoleteTag:                   tag,

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Bundle", func() {
 	tag := "TAG" + strings.Repeat("9", 24)
 	bndl := Bundle{
 		{
-			Address:                       strings.Repeat("A", 81),
+			Address:                       strings.Repeat("A", 80) + "J",
 			Value:                         -2,
 			Tag:                           tag,
 			ObsoleteTag:                   tag,
@@ -39,7 +39,7 @@ var _ = Describe("Bundle", func() {
 		},
 
 		{
-			Address:                       strings.Repeat("A", 81),
+			Address:                       strings.Repeat("A", 80) + "J",
 			Value:                         0,
 			Tag:                           tag,
 			ObsoleteTag:                   tag,
@@ -58,7 +58,7 @@ var _ = Describe("Bundle", func() {
 		},
 
 		{
-			Address:                       strings.Repeat("B", 81),
+			Address:                       strings.Repeat("B", 80) + "K",
 			Value:                         2,
 			Tag:                           tag,
 			ObsoleteTag:                   tag,


### PR DESCRIPTION
# Description of change

The last trit in the address is manually set to zero to allow hashing with Kerl. The updated address was not used for the essence, though.

## Type of change


- Bug fix (a non-breaking change which fixes an issue)


## Change checklist


- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
