### PR TITLE
chore: Use Go 1.15.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.14.4
+  - 1.15.5
 
 env:
 - ARCH='amd64'


### PR DESCRIPTION
# Description of change

Previous versions of Go have an issue where a specially crafted input to a math operation can cause a panic ([CVE-2020-28362](https://security.archlinux.org/CVE-2020-28362)). This bug is fixed in Go 1.15.5.

## Type of change

- Chore

## How the change has been tested

CI passes successfully

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code