### PR TITLE
Change address routes to ed25519 to adapt recent changes

### DIFF
--- a/node_api_client.go
+++ b/node_api_client.go
@@ -79,13 +79,15 @@ const (
 	// GET returns the output.
 	NodeAPIRouteOutput = "/api/v1/outputs/%s"
 
-	// NodeAPIRouteAddressBalance is the route for getting the total balance of all unspent outputs of an address.
+	// NodeAPIRouteAddressEd25519Balance is the route for getting the total balance of all unspent outputs of an ed25519 address.
+	// The ed25519 address must be encoded in hex.
 	// GET returns the balance of all unspent outputs of this address.
-	NodeAPIRouteAddressBalance = "/api/v1/addresses/%s"
+	NodeAPIRouteAddressEd25519Balance = "/api/v1/addresses/ed25519/%s"
 
-	// NodeAPIRouteAddressOutputs is the route for getting all output IDs for an address.
+	// NodeAPIRouteAddressEd25519Outputs is the route for getting all output IDs for an ed25519 address.
+	// The ed25519 address must be encoded in hex.
 	// GET returns the outputIDs for all outputs of this address (optional query parameters: "include-spent").
-	NodeAPIRouteAddressOutputs = "/api/v1/addresses/%s/outputs"
+	NodeAPIRouteAddressEd25519Outputs = "/api/v1/addresses/ed25519/%s/outputs"
 
 	// NodeAPIRoutePeer is the route for getting peers by their peerID.
 	// GET returns the peer
@@ -486,6 +488,8 @@ func (api *NodeAPI) OutputByID(utxoID UTXOInputID) (*NodeOutputResponse, error) 
 
 // AddressBalanceResponse defines the response of a GET addresses REST API call.
 type AddressBalanceResponse struct {
+	// The type of the address (0=WOTS, 1=Ed25519).
+	AddressType byte `json:"addressType"`
 	// The hex encoded address.
 	Address string `json:"address"`
 	// The maximum count of results that are returned by the node.
@@ -496,9 +500,9 @@ type AddressBalanceResponse struct {
 	Balance uint64 `json:"balance"`
 }
 
-// BalanceByAddress returns the balance of an address.
-func (api *NodeAPI) BalanceByAddress(address string) (*AddressBalanceResponse, error) {
-	query := fmt.Sprintf(NodeAPIRouteAddressBalance, address)
+// BalanceByEd25519Address returns the balance of an Ed25519 address.
+func (api *NodeAPI) BalanceByEd25519Address(address string) (*AddressBalanceResponse, error) {
+	query := fmt.Sprintf(NodeAPIRouteAddressEd25519Balance, address)
 
 	res := &AddressBalanceResponse{}
 	_, err := api.do(http.MethodGet, query, nil, res)
@@ -511,6 +515,8 @@ func (api *NodeAPI) BalanceByAddress(address string) (*AddressBalanceResponse, e
 
 // AddressOutputsResponse defines the response of a GET outputs by address REST API call.
 type AddressOutputsResponse struct {
+	// The type of the address (0=WOTS, 1=Ed25519).
+	AddressType byte `json:"addressType"`
 	// The hex encoded address.
 	Address string `json:"address"`
 	// The maximum count of results that are returned by the node.
@@ -521,10 +527,10 @@ type AddressOutputsResponse struct {
 	OutputIDs []string `json:"outputIDs"`
 }
 
-// OutputIDsByAddress gets outputs IDs by addresses from the node.
+// OutputIDsByEd25519Address gets outputs IDs by ed25519 addresses from the node.
 // Per default only unspent outputs are returned. Set includeSpentOutputs to true to also returned spent outputs.
-func (api *NodeAPI) OutputIDsByAddress(address string, includeSpentOutputs bool) (*AddressOutputsResponse, error) {
-	query := fmt.Sprintf(NodeAPIRouteAddressOutputs, address)
+func (api *NodeAPI) OutputIDsByEd25519Address(address string, includeSpentOutputs bool) (*AddressOutputsResponse, error) {
+	query := fmt.Sprintf(NodeAPIRouteAddressEd25519Outputs, address)
 	if includeSpentOutputs {
 		query += "?include-spent=true"
 	}

--- a/node_api_client_test.go
+++ b/node_api_client_test.go
@@ -282,26 +282,27 @@ func TestNodeAPI_OutputByID(t *testing.T) {
 	require.EqualValues(t, txID, *resTxID)
 }
 
-func TestNodeAPI_BalanceByAddress(t *testing.T) {
+func TestNodeAPI_BalanceByEd25519Address(t *testing.T) {
 	defer gock.Off()
 
 	ed25519Addr, _ := randEd25519Addr()
 	ed25519AddrHex := ed25519Addr.String()
 
 	originRes := &iota.AddressBalanceResponse{
-		Address:    ed25519AddrHex,
-		MaxResults: 1000,
-		Count:      1337,
-		Balance:    13371337,
+		AddressType: 1,
+		Address:     ed25519AddrHex,
+		MaxResults:  1000,
+		Count:       1337,
+		Balance:     13371337,
 	}
 
 	gock.New(nodeAPIUrl).
-		Get(fmt.Sprintf(iota.NodeAPIRouteAddressBalance, ed25519AddrHex)).
+		Get(fmt.Sprintf(iota.NodeAPIRouteAddressEd25519Balance, ed25519AddrHex)).
 		Reply(200).
 		JSON(&iota.HTTPOkResponseEnvelope{Data: originRes})
 
 	nodeAPI := iota.NewNodeAPI(nodeAPIUrl)
-	resp, err := nodeAPI.BalanceByAddress(ed25519AddrHex)
+	resp, err := nodeAPI.BalanceByEd25519Address(ed25519AddrHex)
 	require.NoError(t, err)
 	require.EqualValues(t, originRes, resp)
 }
@@ -316,9 +317,10 @@ func TestNodeAPI_OutputIDsByAddress(t *testing.T) {
 	output2 := rand32ByteHash()
 	output3 := rand32ByteHash()
 	originRes := &iota.AddressOutputsResponse{
-		Address:    ed25519AddrHex,
-		MaxResults: 1000,
-		Count:      2,
+		AddressType: 1,
+		Address:     ed25519AddrHex,
+		MaxResults:  1000,
+		Count:       2,
 		OutputIDs: []string{
 			hex.EncodeToString(output1[:]),
 			hex.EncodeToString(output2[:]),
@@ -326,9 +328,10 @@ func TestNodeAPI_OutputIDsByAddress(t *testing.T) {
 	}
 
 	originResWithUnspent := &iota.AddressOutputsResponse{
-		Address:    ed25519AddrHex,
-		MaxResults: 1000,
-		Count:      3,
+		AddressType: 1,
+		Address:     ed25519AddrHex,
+		MaxResults:  1000,
+		Count:       3,
 		OutputIDs: []string{
 			hex.EncodeToString(output1[:]),
 			hex.EncodeToString(output2[:]),
@@ -336,14 +339,14 @@ func TestNodeAPI_OutputIDsByAddress(t *testing.T) {
 		},
 	}
 
-	route := fmt.Sprintf(iota.NodeAPIRouteAddressOutputs, ed25519AddrHex)
+	route := fmt.Sprintf(iota.NodeAPIRouteAddressEd25519Outputs, ed25519AddrHex)
 	gock.New(nodeAPIUrl).
 		Get(route).
 		Reply(200).
 		JSON(&iota.HTTPOkResponseEnvelope{Data: originRes})
 
 	nodeAPI := iota.NewNodeAPI(nodeAPIUrl)
-	resp, err := nodeAPI.OutputIDsByAddress(ed25519AddrHex, false)
+	resp, err := nodeAPI.OutputIDsByEd25519Address(ed25519AddrHex, false)
 	require.NoError(t, err)
 	require.EqualValues(t, originRes, resp)
 
@@ -353,7 +356,7 @@ func TestNodeAPI_OutputIDsByAddress(t *testing.T) {
 		Reply(200).
 		JSON(&iota.HTTPOkResponseEnvelope{Data: originResWithUnspent})
 
-	resp, err = nodeAPI.OutputIDsByAddress(ed25519AddrHex, true)
+	resp, err = nodeAPI.OutputIDsByEd25519Address(ed25519AddrHex, true)
 	require.NoError(t, err)
 	require.EqualValues(t, originResWithUnspent, resp)
 }


### PR DESCRIPTION
# Description of change

To accept bech32 addresses in the fullnode, the former endpoint for ed25519 addresses was moved to another location.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Test cases were adapted.

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
