### PR TITLE
Change number of parents in iota message

### DIFF
--- a/benches_test.go
+++ b/benches_test.go
@@ -97,8 +97,7 @@ func BenchmarkVerifyEd25519OneIOTxEssence(b *testing.B) {
 func BenchmarkSerializeAndHashMessageWithTransactionPayload(b *testing.B) {
 	txPayload := oneInputOutputTransaction()
 	m := &iota.Message{
-		Parent1: rand32ByteHash(),
-		Parent2: rand32ByteHash(),
+		Parents: iota.MessageIDs{rand32ByteHash(), rand32ByteHash()},
 		Payload: txPayload,
 		Nonce:   0,
 	}

--- a/benches_test.go
+++ b/benches_test.go
@@ -96,8 +96,9 @@ func BenchmarkVerifyEd25519OneIOTxEssence(b *testing.B) {
 
 func BenchmarkSerializeAndHashMessageWithTransactionPayload(b *testing.B) {
 	txPayload := oneInputOutputTransaction()
+
 	m := &iota.Message{
-		Parents: iota.MessageIDs{rand32ByteHash(), rand32ByteHash()},
+		Parents: sortedRand32ByteHashes(2),
 		Payload: txPayload,
 		Nonce:   0,
 	}

--- a/error.go
+++ b/error.go
@@ -33,9 +33,9 @@ var (
 	// Returned if the count of elements is too big.
 	ErrArrayValidationMaxElementsExceeded = errors.New("max count of elements within the array exceeded")
 	// Returned if the array elements are not unique.
-	ErrArrayValidationViolatesUniqueness = errors.New("array elements must be unique when serialized")
-	// Returned if the array elements are not in lexical order when serialized.
-	ErrArrayValidationOrderViolatesLexicalOrder = errors.New("array elements must be in their lexical order (byte wise) when serialized")
+	ErrArrayValidationViolatesUniqueness = errors.New("array elements must be unique")
+	// Returned if the array elements are not in lexical order.
+	ErrArrayValidationOrderViolatesLexicalOrder = errors.New("array elements must be in their lexical order (byte wise)")
 	// Returned if there is not enough data available to deserialize a given object.
 	ErrDeserializationNotEnoughData = errors.New("not enough data for deserialization")
 	// Returned if a length denotation exceeds a specified limit.

--- a/error.go
+++ b/error.go
@@ -26,6 +26,16 @@ var (
 	ErrUnknownUnlockBlockType = errors.New("unknown unlock block type")
 	// Returned for unknown signature types.
 	ErrUnknownSignatureType = errors.New("unknown signature type")
+	// Returned for unknown array validation modes.
+	ErrUnknownArrayValidationMode = errors.New("unknown array validation mode")
+	// Returned if the count of elements is too small.
+	ErrArrayValidationMinElementsNotReached = errors.New("min count of elements within the array not reached")
+	// Returned if the count of elements is too big.
+	ErrArrayValidationMaxElementsExceeded = errors.New("max count of elements within the array exceeded")
+	// Returned if the array elements are not unique.
+	ErrArrayValidationViolatesUniqueness = errors.New("array elements must be unique when serialized")
+	// Returned if the array elements are not in lexical order when serialized.
+	ErrArrayValidationOrderViolatesLexicalOrder = errors.New("array elements must be in their lexical order (byte wise) when serialized")
 	// Returned if there is not enough data available to deserialize a given object.
 	ErrDeserializationNotEnoughData = errors.New("not enough data for deserialization")
 	// Returned if a length denotation exceeds a specified limit.

--- a/example_test.go
+++ b/example_test.go
@@ -11,8 +11,7 @@ import (
 func TestSerializedTransactionSize(t *testing.T) {
 	sigTxPayload := oneInputOutputTransaction()
 	m := &iota.Message{
-		Parent1: rand32ByteHash(),
-		Parent2: rand32ByteHash(),
+		Parents: iota.MessageIDs{rand32ByteHash(), rand32ByteHash()},
 		Payload: sigTxPayload,
 		Nonce:   0,
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ import (
 func TestSerializedTransactionSize(t *testing.T) {
 	sigTxPayload := oneInputOutputTransaction()
 	m := &iota.Message{
-		Parents: iota.MessageIDs{rand32ByteHash(), rand32ByteHash()},
+		Parents: sortedRand32ByteHashes(2),
 		Payload: sigTxPayload,
 		Nonce:   0,
 	}

--- a/message.go
+++ b/message.go
@@ -138,6 +138,11 @@ func (m *Message) Deserialize(data []byte, deSeriMode DeSerializationMode) (int,
 
 func (m *Message) Serialize(deSeriMode DeSerializationMode) ([]byte, error) {
 	data, err := NewSerializer().
+		Do(func() {
+			if deSeriMode.HasMode(DeSeriModePerformLexicalOrdering) {
+				m.Parents = RemoveDupsAndSortByLexicalOrderArrayOf32Bytes(m.Parents)
+			}
+		}).
 		WriteNum(m.NetworkID, func(err error) error {
 			return fmt.Errorf("unable to serialize message network ID: %w", err)
 		}).

--- a/message.go
+++ b/message.go
@@ -16,15 +16,26 @@ const (
 	MessageIDLength = blake2b.Size256
 	// Defines the length of the network ID in bytes.
 	MessageNetworkIDLength = UInt64ByteSize
-	// Defines the minimum size of a message: network ID + 2 msg IDs + uint16 payload length + nonce
-	MessageBinSerializedMinSize = MessageNetworkIDLength + 2*MessageIDLength + UInt32ByteSize + UInt64ByteSize
+	// Defines the minimum size of a message: network ID + parent count + 1 parent + uint16 payload length + nonce
+	MessageBinSerializedMinSize = MessageNetworkIDLength + OneByte + MessageIDLength + UInt32ByteSize + UInt64ByteSize
 	// Defines the maximum size of a message.
 	MessageBinSerializedMaxSize = 32768
+	// Defines the minimum amount of parents in a message.
+	MinParentsInAMessage = 1
+	// Defines the maximum amount of parents in a message.
+	MaxParentsInAMessage = 8
 )
 
 var (
 	// Returned when a serialized message exceeds MessageBinSerializedMaxSize.
 	ErrMessageExceedsMaxSize = errors.New("message exceeds max size")
+
+	// restrictions around parents within a message.
+	messageParentArrayRules = ArrayRules{
+		Min:            MinParentsInAMessage,
+		Max:            MaxParentsInAMessage,
+		ValidationMode: ArrayValidModeDuplicates | ArrayValidModeLexicalOrdering,
+	}
 )
 
 // PayloadSelector implements SerializableSelectorFunc for payload types.
@@ -67,10 +78,8 @@ func MessageIDFromHexString(messageIDHex string) (MessageID, error) {
 type Message struct {
 	// The network ID for which this message is meant for.
 	NetworkID uint64
-	// The 1st parent the message references.
-	Parent1 [MessageIDLength]byte
-	// The 2nd parent the message references.
-	Parent2 [MessageIDLength]byte
+	// The parents the message references.
+	Parents MessageIDs
 	// The inner payload of the message. Can be nil.
 	Payload Serializable
 	// The nonce which lets this message fulfill the PoW requirements.
@@ -112,11 +121,8 @@ func (m *Message) Deserialize(data []byte, deSeriMode DeSerializationMode) (int,
 		ReadNum(&m.NetworkID, func(err error) error {
 			return fmt.Errorf("unable to deserialize message network ID: %w", err)
 		}).
-		ReadArrayOf32Bytes(&m.Parent1, func(err error) error {
-			return fmt.Errorf("unable to deserialize message parent 1: %w", err)
-		}).
-		ReadArrayOf32Bytes(&m.Parent2, func(err error) error {
-			return fmt.Errorf("unable to deserialize message parent 2: %w", err)
+		ReadSliceOfArraysOf32Bytes(&m.Parents, deSeriMode, SeriSliceLengthAsByte, &messageParentArrayRules, func(err error) error {
+			return fmt.Errorf("unable to deserialize message parents: %w", err)
 		}).
 		ReadPayload(func(seri Serializable) { m.Payload = seri }, deSeriMode, func(err error) error {
 			return fmt.Errorf("unable to deserialize message's inner payload: %w", err)
@@ -135,11 +141,8 @@ func (m *Message) Serialize(deSeriMode DeSerializationMode) ([]byte, error) {
 		WriteNum(m.NetworkID, func(err error) error {
 			return fmt.Errorf("unable to serialize message network ID: %w", err)
 		}).
-		WriteBytes(m.Parent1[:], func(err error) error {
-			return fmt.Errorf("unable to serialize message parent 1: %w", err)
-		}).
-		WriteBytes(m.Parent2[:], func(err error) error {
-			return fmt.Errorf("unable to serialize message parent 2: %w", err)
+		Write32BytesArraySlice(m.Parents, deSeriMode, SeriSliceLengthAsByte, &messageParentArrayRules, func(err error) error {
+			return fmt.Errorf("unable to serialize message parents: %w", err)
 		}).
 		WritePayload(m.Payload, deSeriMode, func(err error) error {
 			return fmt.Errorf("unable to serialize message inner payload: %w", err)
@@ -160,8 +163,10 @@ func (m *Message) Serialize(deSeriMode DeSerializationMode) ([]byte, error) {
 func (m *Message) MarshalJSON() ([]byte, error) {
 	jsonMsg := &jsonmessage{}
 	jsonMsg.NetworkID = strconv.FormatUint(m.NetworkID, 10)
-	jsonMsg.Parent1 = hex.EncodeToString(m.Parent1[:])
-	jsonMsg.Parent2 = hex.EncodeToString(m.Parent2[:])
+	jsonMsg.Parents = []string{}
+	for _, parent := range m.Parents {
+		jsonMsg.Parents = append(jsonMsg.Parents, hex.EncodeToString(parent[:]))
+	}
 	jsonMsg.Nonce = strconv.FormatUint(m.Nonce, 10)
 	if m.Payload != nil {
 		jsonPayload, err := m.Payload.MarshalJSON()
@@ -207,10 +212,8 @@ func jsonpayloadselector(ty int) (JSONSerializable, error) {
 type jsonmessage struct {
 	// The network ID identifying the network for this message.
 	NetworkID string `json:"networkId"`
-	// The hex encoded message ID of the first referenced parent.
-	Parent1 string `json:"parent1MessageId"`
-	// The hex encoded message ID of the second referenced parent.
-	Parent2 string `json:"parent2MessageId"`
+	// The hex encoded message IDs of the referenced parents.
+	Parents []string `json:"parentMessageIds"`
 	// The payload within the message.
 	Payload *json.RawMessage `json:"payload"`
 	// The nonce the message used to fulfill the PoW requirement.
@@ -218,23 +221,9 @@ type jsonmessage struct {
 }
 
 func (jm *jsonmessage) ToSerializable() (Serializable, error) {
-	parent1, err := hex.DecodeString(jm.Parent1)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode hex parent 1 from JSON: %w", err)
-	}
+	var err error
 
-	parent2, err := hex.DecodeString(jm.Parent2)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode hex parent 2 from JSON: %w", err)
-	}
-
-	var parsedNonce uint64
-	if len(jm.Nonce) != 0 {
-		parsedNonce, err = strconv.ParseUint(jm.Nonce, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse message nonce from JSON: %w", err)
-		}
-	}
+	m := &Message{}
 
 	var parsedNetworkID uint64
 	if len(jm.NetworkID) != 0 {
@@ -243,8 +232,29 @@ func (jm *jsonmessage) ToSerializable() (Serializable, error) {
 			return nil, fmt.Errorf("unable to parse message network ID from JSON: %w", err)
 		}
 	}
+	m.NetworkID = parsedNetworkID
 
-	m := &Message{NetworkID: parsedNetworkID, Nonce: parsedNonce}
+	var parsedNonce uint64
+	if len(jm.Nonce) != 0 {
+		parsedNonce, err = strconv.ParseUint(jm.Nonce, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse message nonce from JSON: %w", err)
+		}
+	}
+	m.Nonce = parsedNonce
+
+	m.Parents = MessageIDs{}
+	for nr, jparent := range jm.Parents {
+		parent := MessageID{}
+
+		parentBytes, err := hex.DecodeString(jparent)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode hex parent %d from JSON: %w", nr+1, err)
+		}
+
+		copy(parent[:], parentBytes)
+		m.Parents = append(m.Parents, parent)
+	}
 
 	if jm.Payload != nil {
 		jsonPayload, err := DeserializeObjectFromJSON(jm.Payload, jsonpayloadselector)
@@ -257,9 +267,6 @@ func (jm *jsonmessage) ToSerializable() (Serializable, error) {
 			return nil, err
 		}
 	}
-
-	copy(m.Parent1[:], parent1)
-	copy(m.Parent2[:], parent2)
 
 	return m, nil
 }

--- a/message_builder.go
+++ b/message_builder.go
@@ -70,41 +70,39 @@ func (mb *MessageBuilder) Tips(nodeAPI *NodeAPI) *MessageBuilder {
 	if mb.err != nil {
 		return mb
 	}
+
 	tips, err := nodeAPI.Tips()
 	if err != nil {
 		mb.err = fmt.Errorf("unable to fetch tips from node API: %w", err)
 		return mb
 	}
-	parent1, err := hex.DecodeString(tips.Tip1)
-	if err != nil {
-		mb.err = fmt.Errorf("unable to decode parent 1 from hex: %w", err)
-		return mb
+
+	parents := [][]byte{}
+	for nr, tip := range tips.Tips {
+		parent, err := hex.DecodeString(tip)
+		if err != nil {
+			mb.err = fmt.Errorf("unable to decode parent %d from hex: %w", nr+1, err)
+			return mb
+		}
+		parents = append(parents, parent)
 	}
-	parent2, err := hex.DecodeString(tips.Tip2)
-	if err != nil {
-		mb.err = fmt.Errorf("unable to decode parent 2 from hex: %w", err)
-		return mb
-	}
-	mb.Parent1(parent1)
-	mb.Parent2(parent2)
+	mb.Parents(parents)
+
 	return mb
 }
 
-// Parent1 sets the first parent of the message.
-func (mb *MessageBuilder) Parent1(parent1 []byte) *MessageBuilder {
+// Parents sets the parents of the message.
+func (mb *MessageBuilder) Parents(parents [][]byte) *MessageBuilder {
 	if mb.err != nil {
 		return mb
 	}
-	copy(mb.msg.Parent1[:], parent1)
-	return mb
-}
 
-// Parent2 sets the second parent of the message.
-func (mb *MessageBuilder) Parent2(parent2 []byte) *MessageBuilder {
-	if mb.err != nil {
-		return mb
+	for _, parentBytes := range parents {
+		parent := MessageID{}
+		copy(parent[:], parentBytes)
+		mb.msg.Parents = append(mb.msg.Parents, parent)
 	}
-	copy(mb.msg.Parent2[:], parent2)
+
 	return mb
 }
 

--- a/message_builder.go
+++ b/message_builder.go
@@ -77,14 +77,14 @@ func (mb *MessageBuilder) Tips(nodeAPI *NodeAPI) *MessageBuilder {
 		return mb
 	}
 
-	parents := [][]byte{}
-	for nr, tip := range tips.Tips {
+	parents := make([][]byte, len(tips.Tips))
+	for i, tip := range tips.Tips {
 		parent, err := hex.DecodeString(tip)
 		if err != nil {
-			mb.err = fmt.Errorf("unable to decode parent %d from hex: %w", nr+1, err)
+			mb.err = fmt.Errorf("unable to decode parent %d from hex: %w", i+1, err)
 			return mb
 		}
-		parents = append(parents, parent)
+		parents[i] = parent
 	}
 	mb.Parents(parents)
 
@@ -97,12 +97,13 @@ func (mb *MessageBuilder) Parents(parents [][]byte) *MessageBuilder {
 		return mb
 	}
 
-	for _, parentBytes := range parents {
+	pars := make(MessageIDs, len(parents))
+	for i, parentBytes := range parents {
 		parent := MessageID{}
 		copy(parent[:], parentBytes)
-		mb.msg.Parents = append(mb.msg.Parents, parent)
+		pars[i] = parent
 	}
-
+	mb.msg.Parents = RemoveDupsAndSortByLexicalOrderArrayOf32Bytes(pars)
 	return mb
 }
 

--- a/message_builder_test.go
+++ b/message_builder_test.go
@@ -10,13 +10,15 @@ import (
 
 func TestMessageBuilder(t *testing.T) {
 	const targetPoWScore float64 = 4000
+
 	parent1 := rand32ByteHash()
 	parent2 := rand32ByteHash()
+	parent3 := rand32ByteHash()
+	parent4 := rand32ByteHash()
 
 	msg, err := iota.NewMessageBuilder().
 		Payload(&iota.Indexation{Index: "hello world", Data: []byte{1, 2, 3, 4}}).
-		Parent1(parent1[:]).
-		Parent2(parent2[:]).
+		Parents([][]byte{parent1[:], parent2[:], parent3[:], parent4[:]}).
 		ProofOfWork(context.Background(), targetPoWScore).
 		Build()
 	require.NoError(t, err)

--- a/message_builder_test.go
+++ b/message_builder_test.go
@@ -15,7 +15,7 @@ func TestMessageBuilder(t *testing.T) {
 
 	msg, err := iota.NewMessageBuilder().
 		Payload(&iota.Indexation{Index: "hello world", Data: []byte{1, 2, 3, 4}}).
-		Parents([][]byte{parents[0][:], parents[1][:], parents[2][:], parents[3][:]}).
+		Parents([][]byte{parents[0][:], parents[0][:], parents[1][:], parents[2][:], parents[3][:]}).
 		ProofOfWork(context.Background(), targetPoWScore).
 		Build()
 	require.NoError(t, err)

--- a/message_builder_test.go
+++ b/message_builder_test.go
@@ -9,16 +9,13 @@ import (
 )
 
 func TestMessageBuilder(t *testing.T) {
-	const targetPoWScore float64 = 4000
+	const targetPoWScore float64 = 500
 
-	parent1 := rand32ByteHash()
-	parent2 := rand32ByteHash()
-	parent3 := rand32ByteHash()
-	parent4 := rand32ByteHash()
+	parents := sortedRand32ByteHashes(4)
 
 	msg, err := iota.NewMessageBuilder().
 		Payload(&iota.Indexation{Index: "hello world", Data: []byte{1, 2, 3, 4}}).
-		Parents([][]byte{parent1[:], parent2[:], parent3[:], parent4[:]}).
+		Parents([][]byte{parents[0][:], parents[1][:], parents[2][:], parents[3][:]}).
 		ProofOfWork(context.Background(), targetPoWScore).
 		Build()
 	require.NoError(t, err)

--- a/message_test.go
+++ b/message_test.go
@@ -82,8 +82,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 		{
 		  "version": 1,
           "networkId": "1337133713371337",
-		  "parent1MessageId": "f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d",
-		  "parent2MessageId": "78d546b46aec4557872139a48f66bc567687e8413578a14323548732358914a2",
+		  "parentMessageIds": ["f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d", "78d546b46aec4557872139a48f66bc567687e8413578a14323548732358914a2"],
 		  "payload": {
 			"type": 0,
 			"essence": {
@@ -127,9 +126,11 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 
 	msg := &iota.Message{}
 	assert.NoError(t, json.Unmarshal([]byte(data), msg))
+
 	var emptyID = [32]byte{}
-	assert.False(t, bytes.Equal(msg.Parent1[:], emptyID[:]))
-	assert.False(t, bytes.Equal(msg.Parent2[:], emptyID[:]))
+	for _, parent := range msg.Parents {
+		assert.False(t, bytes.Equal(parent[:], emptyID[:]))
+	}
 
 	msgJson, err := json.Marshal(msg)
 	assert.NoError(t, err)
@@ -145,8 +146,12 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 		}`
 	msgMinimal := &iota.Message{}
 	assert.NoError(t, json.Unmarshal([]byte(minimal), msgMinimal))
-	assert.True(t, bytes.Equal(msgMinimal.Parent1[:], emptyID[:]))
-	assert.True(t, bytes.Equal(msgMinimal.Parent2[:], emptyID[:]))
+
+	assert.Len(t, msgMinimal.Parents, 2)
+	for _, parent := range msgMinimal.Parents {
+		assert.True(t, bytes.Equal(parent[:], emptyID[:]))
+	}
+
 	assert.Nil(t, msgMinimal.Payload)
 	assert.Equal(t, msgMinimal.Nonce, uint64(0))
 }

--- a/message_test.go
+++ b/message_test.go
@@ -142,6 +142,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 
 	minimal := `
 		{
+		  "parentMessageIds": ["0000000000000000000000000000000000000000000000000000000000000000", "0000000000000000000000000000000000000000000000000000000000000000"],
 		  "payload": null
 		}`
 	msgMinimal := &iota.Message{}

--- a/milestone_test.go
+++ b/milestone_test.go
@@ -75,8 +75,7 @@ func TestMilestone_MarshalUnmarshalJSON(t *testing.T) {
 	ms := &iota.Milestone{
 		Index:                1337,
 		Timestamp:            13371337,
-		Parent1:              rand32ByteHash(),
-		Parent2:              rand32ByteHash(),
+		Parents:              iota.MilestoneParentMessageIDs{rand32ByteHash(), rand32ByteHash()},
 		InclusionMerkleProof: rand32ByteHash(),
 		PublicKeys: []iota.MilestonePublicKey{
 			rand32ByteHash(),
@@ -124,8 +123,10 @@ func TestMilestoneSigning(t *testing.T) {
 			pubKeys := []iota.MilestonePublicKey{pubKey1}
 
 			msPayload := &iota.Milestone{
-				Index: 1000, Timestamp: uint64(time.Now().Unix()), PublicKeys: pubKeys,
-				Parent1: rand32ByteHash(), Parent2: rand32ByteHash(),
+				Parents:              iota.MilestoneParentMessageIDs{rand32ByteHash(), rand32ByteHash()},
+				Index:                1000,
+				Timestamp:            uint64(time.Now().Unix()),
+				PublicKeys:           pubKeys,
 				InclusionMerkleProof: rand32ByteHash(),
 			}
 
@@ -153,8 +154,10 @@ func TestMilestoneSigning(t *testing.T) {
 			// only 1 and 2
 			pubKeys := []iota.MilestonePublicKey{pubKey1, pubKey2}
 			msPayload := &iota.Milestone{
-				Index: 1000, Timestamp: uint64(time.Now().Unix()), PublicKeys: pubKeys,
-				Parent1: rand32ByteHash(), Parent2: rand32ByteHash(),
+				Parents:              iota.MilestoneParentMessageIDs{rand32ByteHash(), rand32ByteHash()},
+				Index:                1000,
+				Timestamp:            uint64(time.Now().Unix()),
+				PublicKeys:           pubKeys,
 				InclusionMerkleProof: rand32ByteHash(),
 			}
 
@@ -179,8 +182,10 @@ func TestMilestoneSigning(t *testing.T) {
 			pubKeys := []iota.MilestonePublicKey{pubKey1}
 
 			msPayload := &iota.Milestone{
-				Index: 1000, Timestamp: uint64(time.Now().Unix()), PublicKeys: pubKeys,
-				Parent1: rand32ByteHash(), Parent2: rand32ByteHash(),
+				Parents:              iota.MilestoneParentMessageIDs{rand32ByteHash(), rand32ByteHash()},
+				Index:                1000,
+				Timestamp:            uint64(time.Now().Unix()),
+				PublicKeys:           pubKeys,
 				InclusionMerkleProof: rand32ByteHash(),
 			}
 
@@ -219,19 +224,18 @@ func TestMilestoneSigning(t *testing.T) {
 }
 
 func TestNewMilestone(t *testing.T) {
-	parent1, parent2 := rand32ByteHash(), rand32ByteHash()
+	parents := iota.MilestoneParentMessageIDs{rand32ByteHash(), rand32ByteHash()}
 	inclusionMerkleProof := rand32ByteHash()
 	const msIndex, timestamp = 1000, 133713371337
 	unsortedPubKeys := []iota.MilestonePublicKey{{3}, {2}, {1}, {5}}
 
-	ms, err := iota.NewMilestone(msIndex, timestamp, parent1, parent2, inclusionMerkleProof, unsortedPubKeys)
+	ms, err := iota.NewMilestone(msIndex, timestamp, parents, inclusionMerkleProof, unsortedPubKeys)
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, &iota.Milestone{
 		Index:                msIndex,
 		Timestamp:            timestamp,
-		Parent1:              parent1,
-		Parent2:              parent2,
+		Parents:              parents,
 		InclusionMerkleProof: inclusionMerkleProof,
 		PublicKeys:           []iota.MilestonePublicKey{{1}, {2}, {3}, {5}},
 		Signatures:           nil,

--- a/node_api_client.go
+++ b/node_api_client.go
@@ -292,10 +292,8 @@ func (api *NodeAPI) Info() (*NodeInfoResponse, error) {
 
 // NodeTipsResponse defines the response of a GET tips REST API call.
 type NodeTipsResponse struct {
-	// The hex encoded message ID of the 1st tip.
-	Tip1 string `json:"tip1MessageId"`
-	// The hex encoded message ID of the 2nd tip.
-	Tip2 string `json:"tip2MessageId"`
+	// The hex encoded message IDs of the tips.
+	Tips []string `json:"tipMessageIds"`
 }
 
 // Tips gets the two tips from the node.
@@ -368,10 +366,8 @@ func (api *NodeAPI) MessageIDsByIndex(index string) (*MessageIDsByIndexResponse,
 type MessageMetadataResponse struct {
 	// The hex encoded message ID of the message.
 	MessageID string `json:"messageId"`
-	// The hex encoded message ID of the 1st parent the message references.
-	Parent1 string `json:"parent1MessageId"`
-	// The hex encoded message ID of the 2nd parent the message references.
-	Parent2 string `json:"parent2MessageId"`
+	// The hex encoded message IDs of the parents the message references.
+	Parents []string `json:"parentMessageIds"`
 	// Whether the message is solid.
 	Solid bool `json:"isSolid"`
 	// The milestone index that references this message.

--- a/node_api_client_test.go
+++ b/node_api_client_test.go
@@ -68,8 +68,7 @@ func TestNodeAPI_Tips(t *testing.T) {
 	defer gock.Off()
 
 	originRes := &iota.NodeTipsResponse{
-		Tip1: "733ed2810f2333e9d6cd702c7d5c8264cd9f1ae454b61e75cf702c451f68611d",
-		Tip2: "5e4a89c549456dbec74ce3a21bde719e9cd84e655f3b1c5a09058d0fbf9417fe",
+		Tips: []string{"733ed2810f2333e9d6cd702c7d5c8264cd9f1ae454b61e75cf702c451f68611d", "5e4a89c549456dbec74ce3a21bde719e9cd84e655f3b1c5a09058d0fbf9417fe"},
 	}
 
 	gock.New(nodeAPIUrl).
@@ -91,8 +90,7 @@ func TestNodeAPI_SubmitMessage(t *testing.T) {
 
 	incompleteMsg := &iota.Message{}
 	completeMsg := &iota.Message{
-		Parent1: rand32ByteHash(),
-		Parent2: rand32ByteHash(),
+		Parents: iota.MessageIDs{rand32ByteHash(), rand32ByteHash()},
 		Payload: nil,
 		Nonce:   3495721389537486,
 	}
@@ -160,17 +158,18 @@ func TestNodeAPI_MessageMetadataByMessageID(t *testing.T) {
 	defer gock.Off()
 
 	identifier := rand32ByteHash()
-	parent1 := rand32ByteHash()
-	parent2 := rand32ByteHash()
+	parents := iota.MessageIDs{rand32ByteHash(), rand32ByteHash()}
 
 	queryHash := hex.EncodeToString(identifier[:])
-	parent1MessageID := hex.EncodeToString(parent1[:])
-	parent2MessageID := hex.EncodeToString(parent2[:])
+
+	parentMessageIDs := []string{}
+	for _, p := range parents {
+		parentMessageIDs = append(parentMessageIDs, hex.EncodeToString(p[:]))
+	}
 
 	originRes := &iota.MessageMetadataResponse{
 		MessageID:                  queryHash,
-		Parent1:                    parent1MessageID,
-		Parent2:                    parent2MessageID,
+		Parents:                    parentMessageIDs,
 		Solid:                      true,
 		ReferencedByMilestoneIndex: nil,
 		LedgerInclusionState:       nil,
@@ -196,8 +195,7 @@ func TestNodeAPI_MessageByMessageID(t *testing.T) {
 	queryHash := hex.EncodeToString(identifier[:])
 
 	originMsg := &iota.Message{
-		Parent1: rand32ByteHash(),
-		Parent2: rand32ByteHash(),
+		Parents: iota.MessageIDs{rand32ByteHash(), rand32ByteHash()},
 		Payload: nil,
 		Nonce:   16345984576234,
 	}

--- a/node_api_client_test.go
+++ b/node_api_client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -88,9 +89,12 @@ func TestNodeAPI_SubmitMessage(t *testing.T) {
 	msgHash := rand32ByteHash()
 	msgHashStr := hex.EncodeToString(msgHash[:])
 
-	incompleteMsg := &iota.Message{}
+	incompleteMsg := &iota.Message{
+		Parents: sortedRand32ByteHashes(1),
+	}
+
 	completeMsg := &iota.Message{
-		Parents: iota.MessageIDs{rand32ByteHash(), rand32ByteHash()},
+		Parents: sortedRand32ByteHashes(1 + rand.Intn(7)),
 		Payload: nil,
 		Nonce:   3495721389537486,
 	}
@@ -158,7 +162,7 @@ func TestNodeAPI_MessageMetadataByMessageID(t *testing.T) {
 	defer gock.Off()
 
 	identifier := rand32ByteHash()
-	parents := iota.MessageIDs{rand32ByteHash(), rand32ByteHash()}
+	parents := sortedRand32ByteHashes(1 + rand.Intn(7))
 
 	queryHash := hex.EncodeToString(identifier[:])
 
@@ -195,7 +199,7 @@ func TestNodeAPI_MessageByMessageID(t *testing.T) {
 	queryHash := hex.EncodeToString(identifier[:])
 
 	originMsg := &iota.Message{
-		Parents: iota.MessageIDs{rand32ByteHash(), rand32ByteHash()},
+		Parents: sortedRand32ByteHashes(1 + rand.Intn(7)),
 		Payload: nil,
 		Nonce:   16345984576234,
 	}

--- a/node_api_client_test.go
+++ b/node_api_client_test.go
@@ -166,9 +166,9 @@ func TestNodeAPI_MessageMetadataByMessageID(t *testing.T) {
 
 	queryHash := hex.EncodeToString(identifier[:])
 
-	parentMessageIDs := []string{}
-	for _, p := range parents {
-		parentMessageIDs = append(parentMessageIDs, hex.EncodeToString(p[:]))
+	parentMessageIDs := make([]string, len(parents))
+	for i, p := range parents {
+		parentMessageIDs[i] = hex.EncodeToString(p[:])
 	}
 
 	originRes := &iota.MessageMetadataResponse{

--- a/serializable.go
+++ b/serializable.go
@@ -159,6 +159,21 @@ func (l LexicalOrderedByteSlices) Swap(i, j int) {
 	l[i], l[j] = l[j], l[i]
 }
 
+// LexicalOrdered32ByteArrays are 32 byte arrays ordered in lexical order.
+type LexicalOrdered32ByteArrays [][32]byte
+
+func (l LexicalOrdered32ByteArrays) Len() int {
+	return len(l)
+}
+
+func (l LexicalOrdered32ByteArrays) Less(i, j int) bool {
+	return bytes.Compare(l[i][:], l[j][:]) < 0
+}
+
+func (l LexicalOrdered32ByteArrays) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
 // SortedSerializables are Serializables sorted by their serialized form.
 type SortedSerializables Serializables
 

--- a/serializable_test.go
+++ b/serializable_test.go
@@ -209,20 +209,20 @@ func TestArrayValidationMode_HasMode(t *testing.T) {
 	}{
 		{
 			"has no validation",
-			iota.ArrayValidModeNoValidation,
-			args{mode: iota.ArrayValidModeDuplicates},
+			iota.ArrayValidationModeNone,
+			args{mode: iota.ArrayValidationModeNoDuplicates},
 			false,
 		},
 		{
 			"has mode duplicates",
-			iota.ArrayValidModeDuplicates,
-			args{mode: iota.ArrayValidModeDuplicates},
+			iota.ArrayValidationModeNoDuplicates,
+			args{mode: iota.ArrayValidationModeNoDuplicates},
 			true,
 		},
 		{
 			"has mode lexical order",
-			iota.ArrayValidModeLexicalOrdering,
-			args{mode: iota.ArrayValidModeLexicalOrdering},
+			iota.ArrayValidationModeLexicalOrdering,
+			args{mode: iota.ArrayValidationModeLexicalOrdering},
 			true,
 		},
 	}
@@ -274,7 +274,6 @@ func TestArrayRules_ElementUniqueValidator(t *testing.T) {
 			for i := range tt.args {
 				element := tt.args[i]
 
-				// check array element validation against previous element
 				if err := arrayElementValidator(i, element); err != nil {
 					valid = false
 				}
@@ -398,7 +397,6 @@ func TestArrayRules_LexicalOrderValidator(t *testing.T) {
 			for i := range tt.args {
 				element := tt.args[i]
 
-				// check array element validation against previous element
 				if err := arrayElementValidator(i, element); err != nil {
 					valid = false
 				}
@@ -466,7 +464,6 @@ func TestArrayRules_LexicalOrderWithoutDupsValidator(t *testing.T) {
 			for i := range tt.args {
 				element := tt.args[i]
 
-				// check array element validation against previous element
 				if err := arrayElementValidator(i, element); err != nil {
 					valid = false
 				}

--- a/serializer.go
+++ b/serializer.go
@@ -172,24 +172,13 @@ func (s *Serializer) Write32BytesArraySlice(data SliceOfArraysOf32Bytes, deSeriM
 			return s
 		}
 
-		switch arrayRules.ValidationMode {
-		case ArrayValidModeNoValidation:
-		case ArrayValidModeDuplicates:
-			arrayElementValidator = arrayRules.ElementUniqueValidator()
-		case ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderValidator()
-		case ArrayValidModeDuplicates | ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderWithoutDupsValidator()
-		default:
-			panic(ErrUnknownArrayValidationMode)
-		}
+		arrayElementValidator = arrayRules.ElementValidationFunc(arrayRules.ValidationMode)
 	}
 
 	_ = s.writeSliceLength(sliceLength, lenType, errProducer)
 	for i := range data {
 		element := data[i][:]
 
-		// check array element validation against previous element
 		if arrayElementValidator != nil {
 			if err := arrayElementValidator(i, element); err != nil {
 				s.err = errProducer(err)
@@ -220,24 +209,13 @@ func (s *Serializer) Write64BytesArraySlice(data SliceOfArraysOf64Bytes, deSeriM
 			return s
 		}
 
-		switch arrayRules.ValidationMode {
-		case ArrayValidModeNoValidation:
-		case ArrayValidModeDuplicates:
-			arrayElementValidator = arrayRules.ElementUniqueValidator()
-		case ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderValidator()
-		case ArrayValidModeDuplicates | ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderWithoutDupsValidator()
-		default:
-			panic(ErrUnknownArrayValidationMode)
-		}
+		arrayElementValidator = arrayRules.ElementValidationFunc(arrayRules.ValidationMode)
 	}
 
 	_ = s.writeSliceLength(sliceLength, lenType, errProducer)
 	for i := range data {
 		element := data[i][:]
 
-		// check array element validation against previous element
 		if arrayElementValidator != nil {
 			if err := arrayElementValidator(i, element); err != nil {
 				s.err = errProducer(err)
@@ -563,17 +541,7 @@ func (d *Deserializer) ReadSliceOfArraysOf32Bytes(slice *SliceOfArraysOf32Bytes,
 			return d
 		}
 
-		switch arrayRules.ValidationMode {
-		case ArrayValidModeNoValidation:
-		case ArrayValidModeDuplicates:
-			arrayElementValidator = arrayRules.ElementUniqueValidator()
-		case ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderValidator()
-		case ArrayValidModeDuplicates | ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderWithoutDupsValidator()
-		default:
-			panic(ErrUnknownArrayValidationMode)
-		}
+		arrayElementValidator = arrayRules.ElementValidationFunc(arrayRules.ValidationMode)
 	}
 
 	s := make(SliceOfArraysOf32Bytes, sliceLength)
@@ -583,7 +551,6 @@ func (d *Deserializer) ReadSliceOfArraysOf32Bytes(slice *SliceOfArraysOf32Bytes,
 			return d
 		}
 
-		// check array element validation against previous element
 		if arrayElementValidator != nil {
 			if err := arrayElementValidator(i, d.src[:length]); err != nil {
 				d.err = errProducer(err)
@@ -621,17 +588,7 @@ func (d *Deserializer) ReadSliceOfArraysOf64Bytes(slice *SliceOfArraysOf64Bytes,
 			return d
 		}
 
-		switch arrayRules.ValidationMode {
-		case ArrayValidModeNoValidation:
-		case ArrayValidModeDuplicates:
-			arrayElementValidator = arrayRules.ElementUniqueValidator()
-		case ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderValidator()
-		case ArrayValidModeDuplicates | ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderWithoutDupsValidator()
-		default:
-			panic(ErrUnknownArrayValidationMode)
-		}
+		arrayElementValidator = arrayRules.ElementValidationFunc(arrayRules.ValidationMode)
 	}
 
 	s := make(SliceOfArraysOf64Bytes, sliceLength)
@@ -641,7 +598,6 @@ func (d *Deserializer) ReadSliceOfArraysOf64Bytes(slice *SliceOfArraysOf64Bytes,
 			return d
 		}
 
-		// check array element validation against previous element
 		if arrayElementValidator != nil {
 			if err := arrayElementValidator(i, d.src[:length]); err != nil {
 				d.err = errProducer(err)
@@ -724,17 +680,7 @@ func (d *Deserializer) ReadSliceOfObjects(f ReadObjectsConsumerFunc, deSeriMode 
 			return d
 		}
 
-		switch arrayRules.ValidationMode {
-		case ArrayValidModeNoValidation:
-		case ArrayValidModeDuplicates:
-			arrayElementValidator = arrayRules.ElementUniqueValidator()
-		case ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderValidator()
-		case ArrayValidModeDuplicates | ArrayValidModeLexicalOrdering:
-			arrayElementValidator = arrayRules.LexicalOrderWithoutDupsValidator()
-		default:
-			panic(ErrUnknownArrayValidationMode)
-		}
+		arrayElementValidator = arrayRules.ElementValidationFunc(arrayRules.ValidationMode)
 	}
 
 	var seris Serializables
@@ -759,7 +705,6 @@ func (d *Deserializer) ReadSliceOfObjects(f ReadObjectsConsumerFunc, deSeriMode 
 
 		bytesConsumed := d.offset - offsetBefore
 
-		// check array element validation against previous element
 		if arrayElementValidator != nil {
 			if err := arrayElementValidator(i, srcBefore[:bytesConsumed]); err != nil {
 				d.err = errProducer(err)

--- a/transaction.go
+++ b/transaction.go
@@ -66,10 +66,7 @@ func (t *Transaction) ID() (*TransactionID, error) {
 }
 
 func (t *Transaction) Deserialize(data []byte, deSeriMode DeSerializationMode) (int, error) {
-	unlockBlockArrayRules := &ArrayRules{
-		MinErr: ErrUnlockBlocksMustMatchInputCount,
-		MaxErr: ErrUnlockBlocksMustMatchInputCount,
-	}
+	unlockBlockArrayRules := &ArrayRules{}
 
 	return NewDeserializer(data).
 		AbortIf(func(err error) error {

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -56,14 +56,14 @@ var (
 	inputsArrayBound = ArrayRules{
 		Min:            MinInputsCount,
 		Max:            MaxInputsCount,
-		ValidationMode: ArrayValidModeLexicalOrdering,
+		ValidationMode: ArrayValidationModeLexicalOrdering,
 	}
 
 	// restrictions around outputs within a transaction.
 	outputsArrayBound = ArrayRules{
 		Min:            MinInputsCount,
 		Max:            MaxInputsCount,
-		ValidationMode: ArrayValidModeLexicalOrdering,
+		ValidationMode: ArrayValidationModeLexicalOrdering,
 	}
 )
 
@@ -154,7 +154,7 @@ func (u *TransactionEssence) Deserialize(data []byte, deSeriMode DeSerialization
 func (u *TransactionEssence) Serialize(deSeriMode DeSerializationMode) (data []byte, err error) {
 	var inputsWrittenConsumer, outputsWrittenConsumer WrittenObjectConsumer
 	if deSeriMode.HasMode(DeSeriModePerformValidation) {
-		if inputsArrayBound.ValidationMode.HasMode(ArrayValidModeLexicalOrdering) {
+		if inputsArrayBound.ValidationMode.HasMode(ArrayValidationModeLexicalOrdering) {
 			inputsLexicalOrderValidator := inputsArrayBound.LexicalOrderValidator()
 			inputsWrittenConsumer = func(index int, written []byte) error {
 				if err := inputsLexicalOrderValidator(index, written); err != nil {
@@ -163,7 +163,7 @@ func (u *TransactionEssence) Serialize(deSeriMode DeSerializationMode) (data []b
 				return nil
 			}
 		}
-		if outputsArrayBound.ValidationMode.HasMode(ArrayValidModeLexicalOrdering) {
+		if outputsArrayBound.ValidationMode.HasMode(ArrayValidationModeLexicalOrdering) {
 			outputsLexicalOrderValidator := outputsArrayBound.LexicalOrderValidator()
 			outputsWrittenConsumer = func(index int, written []byte) error {
 				if err := outputsLexicalOrderValidator(index, written); err != nil {

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -54,22 +54,16 @@ var (
 
 	// restrictions around input within a transaction.
 	inputsArrayBound = ArrayRules{
-		Min:                         MinInputsCount,
-		Max:                         MaxInputsCount,
-		MinErr:                      ErrMinInputsNotReached,
-		MaxErr:                      ErrMaxInputsExceeded,
-		ElementBytesLexicalOrder:    true,
-		ElementBytesLexicalOrderErr: ErrInputsOrderViolatesLexicalOrder,
+		Min:            MinInputsCount,
+		Max:            MaxInputsCount,
+		ValidationMode: ArrayValidModeLexicalOrdering,
 	}
 
 	// restrictions around outputs within a transaction.
 	outputsArrayBound = ArrayRules{
-		Min:                         MinInputsCount,
-		Max:                         MaxInputsCount,
-		MinErr:                      ErrMinOutputsNotReached,
-		MaxErr:                      ErrMaxOutputsExceeded,
-		ElementBytesLexicalOrder:    true,
-		ElementBytesLexicalOrderErr: ErrOutputsOrderViolatesLexicalOrder,
+		Min:            MinInputsCount,
+		Max:            MaxInputsCount,
+		ValidationMode: ArrayValidModeLexicalOrdering,
 	}
 )
 
@@ -160,7 +154,7 @@ func (u *TransactionEssence) Deserialize(data []byte, deSeriMode DeSerialization
 func (u *TransactionEssence) Serialize(deSeriMode DeSerializationMode) (data []byte, err error) {
 	var inputsWrittenConsumer, outputsWrittenConsumer WrittenObjectConsumer
 	if deSeriMode.HasMode(DeSeriModePerformValidation) {
-		if inputsArrayBound.ElementBytesLexicalOrder {
+		if inputsArrayBound.ValidationMode.HasMode(ArrayValidModeLexicalOrdering) {
 			inputsLexicalOrderValidator := inputsArrayBound.LexicalOrderValidator()
 			inputsWrittenConsumer = func(index int, written []byte) error {
 				if err := inputsLexicalOrderValidator(index, written); err != nil {
@@ -169,7 +163,7 @@ func (u *TransactionEssence) Serialize(deSeriMode DeSerializationMode) (data []b
 				return nil
 			}
 		}
-		if outputsArrayBound.ElementBytesLexicalOrder {
+		if outputsArrayBound.ValidationMode.HasMode(ArrayValidModeLexicalOrdering) {
 			outputsLexicalOrderValidator := outputsArrayBound.LexicalOrderValidator()
 			outputsWrittenConsumer = func(index int, written []byte) error {
 				if err := outputsLexicalOrderValidator(index, written); err != nil {

--- a/util_test.go
+++ b/util_test.go
@@ -47,12 +47,12 @@ func rand32ByteHash() [32]byte {
 }
 
 func sortedRand32ByteHashes(count int) [][32]byte {
-	msgs := iota.LexicalOrdered32ByteArrays{}
+	hashes := make(iota.LexicalOrdered32ByteArrays, count)
 	for i := 0; i < count; i++ {
-		msgs = append(msgs, rand32ByteHash())
+		hashes[i] = rand32ByteHash()
 	}
-	sort.Sort(msgs)
-	return msgs
+	sort.Sort(hashes)
+	return hashes
 }
 
 func rand64ByteHash() [64]byte {


### PR DESCRIPTION
# Description of change

This PR increases the number of parents of an IOTA message.
Parents must be at least 1, and a maximum of 8.
Parents must be unique and sorted by lexical order of their hashes.

The number was limited to two parents in former times, because tip selection was too slow and without the whiteflag approach, there was an attack vector that could render large parts of the tangle invalid. Since these problems are now gone, increasing the number of parents should increase the confirmation rate, mitigate blowball attacks and decrease the confirmation time.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How the change has been tested

Tests have been modified.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
