### PR TITLE
Avoid using Serializable interface as the map key for the address signer

### DIFF
--- a/address_signer.go
+++ b/address_signer.go
@@ -14,20 +14,20 @@ var (
 // AddressSigner produces signatures for messages which get verified against a given address.
 type AddressSigner interface {
 	// Sign produces the signature for the given message.
-	Sign(addr Serializable, msg []byte) (signature Serializable, err error)
+	Sign(addr Address, msg []byte) (signature Serializable, err error)
 }
 
 // AddressSignerFunc implements the AddressSigner interface.
-type AddressSignerFunc func(addr Serializable, msg []byte) (signature Serializable, err error)
+type AddressSignerFunc func(addr Address, msg []byte) (signature Serializable, err error)
 
-func (s AddressSignerFunc) Sign(addr Serializable, msg []byte) (signature Serializable, err error) {
+func (s AddressSignerFunc) Sign(addr Address, msg []byte) (signature Serializable, err error) {
 	return s(addr, msg)
 }
 
 // AddressKeys pairs an address and its source key(s).
 type AddressKeys struct {
 	// The target address.
-	Address Serializable `json:"address"`
+	Address Address `json:"address"`
 	// The signing keys.
 	Keys interface{} `json:"keys"`
 }
@@ -35,26 +35,26 @@ type AddressKeys struct {
 // NewInMemoryAddressSigner creates a new InMemoryAddressSigner holding the given AddressKeys.
 func NewInMemoryAddressSigner(addrKeys ...AddressKeys) AddressSigner {
 	ss := &InMemoryAddressSigner{
-		addrKeys: map[Serializable]interface{}{},
+		addrKeys: map[string]interface{}{},
 	}
 	for _, c := range addrKeys {
-		ss.addrKeys[c.Address] = c.Keys
+		ss.addrKeys[c.Address.String()] = c.Keys
 	}
 	return ss
 }
 
 // InMemoryAddressSigner implements AddressSigner by holding keys simply in-memory.
 type InMemoryAddressSigner struct {
-	addrKeys map[Serializable]interface{}
+	addrKeys map[string]interface{}
 }
 
-func (s *InMemoryAddressSigner) Sign(addr Serializable, msg []byte) (signature Serializable, err error) {
+func (s *InMemoryAddressSigner) Sign(addr Address, msg []byte) (signature Serializable, err error) {
 	switch addr.(type) {
 	case *WOTSAddress:
 		// TODO: implement
 		return nil, ErrWOTSNotImplemented
 	case *Ed25519Address:
-		prvKey, ok := s.addrKeys[addr].(ed25519.PrivateKey)
+		prvKey, ok := s.addrKeys[addr.String()].(ed25519.PrivateKey)
 		if !ok {
 			return nil, fmt.Errorf("%w: can't sign message for Ed25519 address", ErrAddressKeysMissing)
 		}

--- a/transaction_builder.go
+++ b/transaction_builder.go
@@ -12,20 +12,20 @@ func NewTransactionBuilder() *TransactionBuilder {
 			Outputs: Serializables{},
 			Payload: nil,
 		},
-		inputToAddr: map[UTXOInputID]Serializable{},
+		inputToAddr: map[UTXOInputID]Address{},
 	}
 }
 
 // TransactionBuilder is used to easily build up a Transaction.
 type TransactionBuilder struct {
 	essence     *TransactionEssence
-	inputToAddr map[UTXOInputID]Serializable
+	inputToAddr map[UTXOInputID]Address
 }
 
 // ToBeSignedUTXOInput defines a UTXO input which needs to be signed.
 type ToBeSignedUTXOInput struct {
 	// The address to which this input belongs to.
-	Address Serializable `json:"address"`
+	Address Address `json:"address"`
 	// The actual UTXO input.
 	Input *UTXOInput `json:"input"`
 }


### PR DESCRIPTION
Avoid using Serializable interface as the map key for the address signer

Also replace Serializable interface with Address interface in the address signer and transaction builder, since only something conforming to Address is actually allowed and expected

This fix follows the same pattern as #238 