### PR TITLE
Remove MaxResults and Count from the balance API response

### DIFF
--- a/node_api_client.go
+++ b/node_api_client.go
@@ -500,10 +500,6 @@ type AddressBalanceResponse struct {
 	AddressType byte `json:"addressType"`
 	// The hex encoded address.
 	Address string `json:"address"`
-	// The maximum count of results that are returned by the node.
-	MaxResults uint32 `json:"maxResults"`
-	// The actual count of results that are returned.
-	Count uint32 `json:"count"`
 	// The balance of the address.
 	Balance uint64 `json:"balance"`
 }

--- a/node_api_client_test.go
+++ b/node_api_client_test.go
@@ -292,8 +292,6 @@ func TestNodeAPI_BalanceByEd25519Address(t *testing.T) {
 	originRes := &iota.AddressBalanceResponse{
 		AddressType: 1,
 		Address:     ed25519AddrHex,
-		MaxResults:  1000,
-		Count:       1337,
 		Balance:     13371337,
 	}
 


### PR DESCRIPTION
Remove MaxResults and Count from the balance API response.
HORNET now holds the balance in a separate ledger so that it does not need to be computed every time