### PR TITLE
Fix Curl.CopyState

### DIFF
--- a/curl/curl.go
+++ b/curl/curl.go
@@ -33,7 +33,7 @@ func (c *Curl) CopyState(s Trits) {
 			} else if c.n[i].bit(j) != 0 {
 				s[j] = -1
 			} else {
-				s[i] = 0
+				s[j] = 0
 			}
 		}
 		s = s[HashTrinarySize:]

--- a/curl/curl_test.go
+++ b/curl/curl_test.go
@@ -76,18 +76,23 @@ var _ = Describe("Curl", func() {
 		Entry("long absorb", strings.Repeat("ABC", consts.TransactionTrytesSize/3), "UHZVKZCGDIPNGFNPBNFZGIM9GAKYLCPTHTRFRXMNDJLZNXSGRPREFWTBKZWVTKV9BISPXEECVIXFJERAC"),
 	)
 
-	It("CopyState", func() {
-		a := strings.Repeat("A", consts.HashTrytesSize)
+	DescribeTable("CopyState",
+		func(in trinary.Trytes) {
+			c := NewCurlP81().(*Curl)
+			err := c.AbsorbTrytes(trinary.MustPad(in, consts.HashTrytesSize))
+			Expect(err).ToNot(HaveOccurred())
 
-		c := NewCurlP81().(*Curl)
-		err := c.AbsorbTrytes(a)
-		Expect(err).ToNot(HaveOccurred())
+			state := make(trinary.Trits, StateSize)
+			c.CopyState(state[:])
 
-		state := make(trinary.Trits, StateSize)
-		c.CopyState(state[:])
-
-		Expect(c.MustSqueeze(consts.HashTrinarySize)).To(Equal(state[:consts.HashTrinarySize]))
-	})
+			// the first 243 trits of the state should exactly match the hash
+			Expect(c.MustSqueeze(consts.HashTrinarySize)).To(Equal(state[:consts.HashTrinarySize]))
+		},
+		Entry("empty trytes", ""),
+		Entry("normal trytes", "A"),
+		Entry("normal trytes #2", "Z"),
+		Entry("normal trytes #3", "NOPQRSTUVWXYZ9ABSDEFGHIJKLM"),
+	)
 
 	It("Reset", func() {
 		a := strings.Repeat("A", consts.HashTrytesSize)


### PR DESCRIPTION
# Description of change

Fixes an issue with the `Curl.CopyState` returning the wrong state. As this function is used in the PoW mining, it leads to invalid nonces...

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
