### PR TITLE
Optimize Curl multiplexing

### DIFF
--- a/curl/bct/curl.go
+++ b/curl/bct/curl.go
@@ -96,40 +96,22 @@ func (c *Curl) Squeeze(dst []trinary.Trits, tritsCount int) error {
 
 // in sets the idx-th entry of the internal state to src.
 func (c *Curl) in(src trinary.Trits, idx uint) {
-	// bounds check hint to compiler
-	if len(src) < consts.HashTrinarySize {
-		panic(consts.ErrInvalidTritsLength)
-	}
-
-	idx &= bits.UintSize - 1 // hint to the compiler that shifts don't need guard code
+	src = src[:consts.HashTrinarySize] // bounds check hint to compiler
+	idx &= bits.UintSize - 1           // hint to the compiler that shifts don't need guard code
 	m := ^(uint(1) << idx)
 	for i := 0; i < consts.HashTrinarySize; i++ {
-		switch src[i] {
-		case 1:
-			c.l[i] &= m
-		case -1:
-			c.h[i] &= m
-		}
+		s := src[i]                    // avoid branching
+		c.l[i] &= bool2int(s <= 0) | m // if s > 0, clear the l-bit
+		c.h[i] &= bool2int(s >= 0) | m // if s < 0, clear the h-bit
 	}
 }
 
 // out extracts the idx-th entry of the internal state to dst.
 func (c *Curl) out(dst trinary.Trits, idx uint) {
-	// bounds check hint to compiler
-	if len(dst) < consts.HashTrinarySize {
-		panic(consts.ErrInvalidTritsLength)
-	}
-
-	idx &= bits.UintSize - 1 // hint to the compiler that idx is always smaller UintSize
-	m := uint(1) << idx
+	dst = dst[:consts.HashTrinarySize] // bounds check hint to compiler
+	idx &= bits.UintSize - 1           // hint to the compiler that shifts don't need guard code
 	for i := 0; i < consts.HashTrinarySize; i++ {
-		l, h := c.l[i]&m, c.h[i]&m
-		switch {
-		case l == 0:
-			dst[i] = 1
-		case h == 0:
-			dst[i] = -1
-		}
+		dst[i] = int8((c.h[i]>>idx)&1) - int8((c.l[i]>>idx)&1) // avoid branching
 	}
 }
 
@@ -138,4 +120,13 @@ func (c *Curl) transform() {
 	var ltmp, htmp [curl.StateSize]uint
 	transform(&ltmp, &htmp, &c.l, &c.h, curl.NumRounds)
 	c.l, c.h = ltmp, htmp
+}
+
+// bool2int returns 0 when b is false and -1 otherwise.
+// bool2int can be optimized by the compiler to not use conditional branching.
+func bool2int(b bool) uint {
+	if b {
+		return ^uint(0)
+	}
+	return 0
 }

--- a/curl/bct/curl.go
+++ b/curl/bct/curl.go
@@ -42,6 +42,12 @@ func (c *Curl) Clone() *Curl {
 	}
 }
 
+// CopyState copies the content of the Curl state buffer into l and h.
+func (c *Curl) CopyState(l, h []uint) {
+	copy(l, c.l[:])
+	copy(h, c.h[:])
+}
+
 // Absorb fills the states of the sponge with src; each element of src must have the length tritsCount.
 // The value tritsCount has to be a multiple of HashTrinarySize.
 func (c *Curl) Absorb(src []trinary.Trits, tritsCount int) error {

--- a/curl/curl.go
+++ b/curl/curl.go
@@ -61,13 +61,9 @@ func (c *Curl) squeeze(hash Trits) {
 	}
 	c.direction = SpongeSqueezing
 
-	_ = hash[HashTrinarySize-1]
-	for i := uint(0); i <= HashTrinarySize-1; i++ {
-		if c.p[0].bit(i) != 0 {
-			hash[i] = 1
-		} else if c.n[0].bit(i) != 0 {
-			hash[i] = -1
-		}
+	hash = hash[:HashTrinarySize]
+	for i := uint(0); i < HashTrinarySize; i++ {
+		hash[i] = int8(c.p[0].bit(i)) - int8(c.n[0].bit(i)) // avoid branching
 	}
 }
 
@@ -114,10 +110,11 @@ func (c *Curl) Absorb(in Trits) error {
 	for len(in) >= HashTrinarySize {
 		var p, n uint256
 		for i := uint(0); i < HashTrinarySize; i++ {
-			switch in[i] {
-			case 1:
+			v := in[i]
+			switch {
+			case v > 0:
 				p.setBit(i)
-			case -1:
+			case v < 0:
 				n.setBit(i)
 			}
 		}


### PR DESCRIPTION
# Description of change

This PR avoids conditional branching during multiplexing and de-multiplexing.

This achieves a 2x speedup for batched Curl on amd64 over current `master`:
```
name                old time/op  new time/op  delta
CurlTransaction     6.03ms ± 3%  3.49ms ± 6%  -42.17%
CurlHash             299µs ± 4%   132µs ± 6%  -56.05%
```
It also achieves a minor speedup for the regular Curl on amd64 over current `master`:
```
name                old time/op  new time/op  delta
CurlTransaction      338µs ± 4%   339µs ± 6%     ~
CurlHash            12.5µs ± 6%  10.9µs ± 4%  -12.86%
```

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
