### PR TITLE
Do not use indices LUT in Batched Curl

### DIFF
--- a/curl/bct/curl.go
+++ b/curl/bct/curl.go
@@ -124,7 +124,7 @@ func (c *Curl) out(dst trinary.Trits, idx uint) {
 // transform transforms the sponge.
 func (c *Curl) transform() {
 	var ltmp, htmp [curl.StateSize]uint
-	transform(&ltmp, &htmp, &c.l, &c.h, curl.NumRounds)
+	transform(&ltmp, &htmp, &c.l, &c.h)
 	c.l, c.h = ltmp, htmp
 }
 

--- a/curl/bct/transform.go
+++ b/curl/bct/transform.go
@@ -4,23 +4,21 @@ import (
 	"github.com/iotaledger/iota.go/curl"
 )
 
-func transformGeneric(lto, hto, lfrom, hfrom *[curl.StateSize]uint, rounds uint) {
-	for r := rounds; r > 0; r-- {
-		// three iterations unrolled
-		for i := 0; i <= curl.StateSize-3; i += 3 {
-			t0 := curl.Indices[i+0]
-			t1 := curl.Indices[i+1]
-			t2 := curl.Indices[i+2]
-			t3 := curl.Indices[i+3]
+func transformGeneric(lto, hto, lfrom, hfrom *[curl.StateSize]uint) {
+	for r := curl.NumRounds; r > 0; r-- {
+		l0, h0 := lfrom[0], hfrom[0]
+		l1, h1 := lfrom[364], hfrom[364]
+		lto[0], hto[0] = sBox(l0, h0, l1, h1)
 
-			l0, h0 := lfrom[t0], hfrom[t0]
-			l1, h1 := lfrom[t1], hfrom[t1]
-			l2, h2 := lfrom[t2], hfrom[t2]
-			l3, h3 := lfrom[t3], hfrom[t3]
+		t := 364
+		for i := 1; i < curl.StateSize-1; i += 2 {
+			t += 364
+			l0, h0 = lfrom[t], hfrom[t]
+			lto[i+0], hto[i+0] = sBox(l1, h1, l0, h0)
 
-			lto[i+0], hto[i+0] = sBox(l0, h0, l1, h1)
-			lto[i+1], hto[i+1] = sBox(l1, h1, l2, h2)
-			lto[i+2], hto[i+2] = sBox(l2, h2, l3, h3)
+			t -= 365
+			l1, h1 = lfrom[t], hfrom[t]
+			lto[i+1], hto[i+1] = sBox(l0, h0, l1, h1)
 		}
 		// swap buffers
 		lfrom, lto = lto, lfrom

--- a/curl/bct/transform.go
+++ b/curl/bct/transform.go
@@ -11,7 +11,7 @@ func transformGeneric(lto, hto, lfrom, hfrom *[curl.StateSize]uint) {
 		lto[0], hto[0] = sBox(l0, h0, l1, h1)
 
 		t := 364
-		for i := 1; i < curl.StateSize-1; i += 2 {
+		for i := 1; i <= curl.StateSize-4; i += 4 {
 			t += 364
 			l0, h0 = lfrom[t], hfrom[t]
 			lto[i+0], hto[i+0] = sBox(l1, h1, l0, h0)
@@ -19,6 +19,14 @@ func transformGeneric(lto, hto, lfrom, hfrom *[curl.StateSize]uint) {
 			t -= 365
 			l1, h1 = lfrom[t], hfrom[t]
 			lto[i+1], hto[i+1] = sBox(l0, h0, l1, h1)
+
+			t += 364
+			l0, h0 = lfrom[t], hfrom[t]
+			lto[i+2], hto[i+2] = sBox(l1, h1, l0, h0)
+
+			t -= 365
+			l1, h1 = lfrom[t], hfrom[t]
+			lto[i+3], hto[i+3] = sBox(l0, h0, l1, h1)
 		}
 		// swap buffers
 		lfrom, lto = lto, lfrom

--- a/curl/bct/transform_amd64.s
+++ b/curl/bct/transform_amd64.s
@@ -2,75 +2,62 @@
 
 #include "textflag.h"
 
-// func transform(lto, hto, lfrom, hfrom *[729]uint, rounds uint)
+#define SBOX(la, ha, lb, hb) \
+    MOVQ lb, R14; \             // a := (lb ^ ha) & la
+    XORQ ha, R14; \
+    ANDQ la, R14; \
+    MOVQ hb, R15; \             // b := (hb ^ la) | a
+    XORQ la, R15; \
+    ORQ R14, R15
+
+// func transform(lto, hto, lfrom, hfrom *[729]uint)
 TEXT ·transform(SB),NOSPLIT,$0
     MOVQ lto+0(FP), AX
     MOVQ hto+8(FP), BX
     MOVQ lfrom+16(FP), CX
     MOVQ hfrom+24(FP), DX
-    MOVQ rounds+32(FP), SI      // r = rounds
-    TESTQ SI, SI                // if r == 0 goto DONE
-    JZ DONE
-
-LOOP:
-    MOVQ $·Indices(SB), R8
-    MOVQ (R8), R8
-    MOVQ (CX)(R8*8), R14        // ltmp := lfrom[Indices[0]]
-    MOVQ (DX)(R8*8), R15        // htmp := hfrom[Indices[0]]
-
-    XORQ DI, DI                 // i := 0
+    MOVQ $81, SI                // r := curl.NumRounds
 
 ROUND:
-    MOVQ $·Indices(SB), R12
-    MOVQ 8(R12)(DI*8), R9       // t1 := Indices[i+1]
-    MOVQ 16(R12)(DI*8), R10     // t2 := Indices[i+2]
-    MOVQ 24(R12)(DI*8), R11     // t3 := Indices[i+3]
+    MOVQ (CX), R10              // l0 := lfrom[0]
+    MOVQ (DX), R11              // h0 := hfrom[0]
+    MOVQ 2912(CX), R12          // l1 := lfrom[364]
+    MOVQ 2912(DX), R13          // h1 := hfrom[364]
 
-    MOVQ R14, R12               // l0 := ltmp
-    MOVQ R15, R13               // h0 := htmp
-    MOVQ (CX)(R9*8), R14        // l1 := lfrom[t1]
-    MOVQ (DX)(R9*8), R15        // h1 := hfrom[t1]
-    MOVQ (CX)(R10*8), R8
-    MOVQ (DX)(R10*8), R9
-    MOVQ (CX)(R11*8), R10
-    MOVQ (DX)(R11*8), R11
+    SBOX(R10, R11, R12, R13)    // a, b := sBox(l0, h0, l1, h1)
+    MOVQ R15, (BX)              // hto[0] = b
+    NOTQ R14                    // lto[0] = ^a
+    MOVQ R14, (AX)
 
-    XORQ R14, R13               // a0 := (l1 ^ h0) & l0
-    ANDQ R12, R13
-    XORQ R15, R12               // b0 := (h1 ^ l0) | a0
-    ORQ R13, R12
-    MOVQ R12, (BX)(DI*8)        // hto[i] = b0
-    NOTQ R13                    // lto[i] = ^a0
-    MOVQ R13, (AX)(DI*8)
+    MOVQ $364, R8               // t := 364
+    MOVQ $1, DI                 // i := 1
 
-    XORQ R8, R15
-    ANDQ R14, R15
-    XORQ R9, R14
-    ORQ R15, R14
-    MOVQ R14, 8(BX)(DI*8)
-    NOTQ R15
-    MOVQ R15, 8(AX)(DI*8)
+LOOP:
+    MOVQ 2912(CX)(R8*8), R10    // l0 = lfrom[t+364]
+    MOVQ 2912(DX)(R8*8), R11    // h0 = hfrom[t+364]
 
-    XORQ R10, R9
-    ANDQ R8, R9
-    XORQ R11, R8
-    ORQ R9, R8
-    MOVQ R8, 16(BX)(DI*8)
-    NOTQ R9
-    MOVQ R9, 16(AX)(DI*8)
+    SBOX(R12, R13, R10, R11)    // a, b = sBox(l1, h1, l0, h0)
+    MOVQ R15, (BX)(DI*8)        // hto[i] = b
+    NOTQ R14                    // lto[i] = ^a
+    MOVQ R14, (AX)(DI*8)
 
-    MOVQ R10, R14               // ltmp = lfrom[t3]
-    MOVQ R11, R15               // htmp = hfrom[t3]
+    MOVQ -8(CX)(R8*8), R12       // l1 := lfrom[t-1]
+    MOVQ -8(DX)(R8*8), R13       // h1 := hfrom[t-1]
 
-    ADDQ $3, DI                 // i += 3
-    CMPQ DI, $727               // if i < 727 goto ROUND
-    JL ROUND
+    SBOX(R10, R11, R12, R13)    // a, b = sBox(l0, h0, l1, h1)
+    MOVQ R15, 8(BX)(DI*8)       // hto[i+1] = b
+    NOTQ R14                    // lto[i+1] = ^a
+    MOVQ R14, 8(AX)(DI*8)
+
+    DECQ R8                     // t--
+    ADDQ $2, DI                 // i += 2
+    CMPQ DI, $728               // if i < 728 goto ROUND
+    JL LOOP
 
     XCHGQ AX, CX                // lfrom, lto = lto, lfrom
     XCHGQ BX, DX                // hfrom, hto = hto, hfrom
 
     DECQ SI                     // r--
-    JNZ LOOP                    // if r != 0 goto LOOP
+    JNZ ROUND                   // if r != 0 goto LOOP
 
-DONE:
     RET

--- a/curl/bct/transform_amd64.s
+++ b/curl/bct/transform_amd64.s
@@ -49,9 +49,25 @@ LOOP:
     NOTQ R14                    // lto[i+1] = ^a
     MOVQ R14, 8(AX)(DI*8)
 
-    DECQ R8                     // t--
-    ADDQ $2, DI                 // i += 2
-    CMPQ DI, $728               // if i < 728 goto ROUND
+    MOVQ 2904(CX)(R8*8), R10    // l0 = lfrom[t+363]
+    MOVQ 2904(DX)(R8*8), R11    // h0 = hfrom[t+363]
+
+    SBOX(R12, R13, R10, R11)    // a, b = sBox(l1, h1, l0, h0)
+    MOVQ R15, 16(BX)(DI*8)      // hto[i+2] = b
+    NOTQ R14                    // lto[i+2] = ^a
+    MOVQ R14, 16(AX)(DI*8)
+
+    MOVQ -16(CX)(R8*8), R12     // l1 := lfrom[t-2]
+    MOVQ -16(DX)(R8*8), R13     // h1 := hfrom[t-2]
+
+    SBOX(R10, R11, R12, R13)    // a, b = sBox(l0, h0, l1, h1)
+    MOVQ R15, 24(BX)(DI*8)      // hto[i+3] = b
+    NOTQ R14                    // lto[i+3] = ^a
+    MOVQ R14, 24(AX)(DI*8)
+
+    SUBQ $2, R8                 // t -= 2
+    ADDQ $4, DI                 // i += 4
+    CMPQ DI, $726               // if i < 726 goto ROUND
     JL LOOP
 
     XCHGQ AX, CX                // lfrom, lto = lto, lfrom

--- a/curl/bct/transform_decl.go
+++ b/curl/bct/transform_decl.go
@@ -5,7 +5,5 @@ package bct
 
 import "github.com/iotaledger/iota.go/curl"
 
-var Indices = curl.Indices
-
 //go:noescape
-func transform(lto, hto, lfrom, hfrom *[curl.StateSize]uint, rounds uint)
+func transform(lto, hto, lfrom, hfrom *[curl.StateSize]uint)

--- a/curl/bct/transform_generic.go
+++ b/curl/bct/transform_generic.go
@@ -2,10 +2,6 @@
 
 package bct
 
-import (
-	"github.com/iotaledger/iota.go/curl"
-)
-
-func transform(lto, hto, lfrom, hfrom *[curl.StateSize]uint, rounds uint) {
-	transformGeneric(lto, hto, lfrom, hfrom, rounds)
+func transform(lto, hto, lfrom, hfrom *[729]uint) {
+	transformGeneric(lto, hto, lfrom, hfrom)
 }

--- a/curl/bct/transform_generic.go
+++ b/curl/bct/transform_generic.go
@@ -2,6 +2,10 @@
 
 package bct
 
-func transform(lto, hto, lfrom, hfrom *[729]uint) {
+import (
+	"github.com/iotaledger/iota.go/curl"
+)
+
+func transform(lto, hto, lfrom, hfrom *[curl.StateSize]uint) {
 	transformGeneric(lto, hto, lfrom, hfrom)
 }


### PR DESCRIPTION
# Description of change

This PR gets rid of the LUT `curl.Indices` in the batched Curl transpose and computes it value on the fly. In order to avoid costly modulo operations or conditionals it unrolls an even number of iterations in the state loop. That way, the indices can be computed by alternately add 364 or subtract 365.

The leads to a 10% speedup on `amd64` compared to the current master:
```
name                old time/op  new time/op  delta
CurlTransaction     3.18ms ±10%  2.86ms ± 5%  -10.29%
CurlHash             115µs ± 4%   106µs ± 6%   -7.85%
```
By default, `amd64` uses the Assembly version; the speedup of the pure Go implementation is even 20%:
```
name                old time/op  new time/op  delta
CurlTransaction     3.87ms ± 4%  3.05ms ± 5%  -21.25%
CurlHash             140µs ± 8%   115µs ± 7%  -18.31%
```
## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

The existing test suite has been extended to test the batched Curl also against the regular Curl golden test vectors as single input.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
