### PR TITLE
Add SeriSliceLengthType to Serializer SliceOfObjects and String Read/Write funcs

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -23,10 +23,6 @@ const (
 	TypeDenotationByteSize = UInt32ByteSize
 	// SmallTypeDenotationByteSize is the size of a type denotation for a small range of possible values.
 	SmallTypeDenotationByteSize = OneByte
-	// StructArrayLengthByteSize is the byte size of struct array lengths.
-	StructArrayLengthByteSize = UInt16ByteSize
-	// ByteArrayLengthByteSize is the byte size of byte array lengths.
-	ByteArrayLengthByteSize = UInt32ByteSize
 	// PayloadLengthByteSize is the size of the payload length denoting bytes.
 	PayloadLengthByteSize = UInt32ByteSize
 	// MinPayloadByteSize is the minimum size of a payload (together with its length denotation).

--- a/receipt.go
+++ b/receipt.go
@@ -87,7 +87,7 @@ func (r *Receipt) Deserialize(data []byte, deSeriMode DeSerializationMode) (int,
 			return fmt.Errorf("unable to deserialize receipt final flag: %w", err)
 		}).
 		// special as the MigratedFundsEntry has no type denotation byte
-		ReadSliceOfObjects(func(seri Serializables) { r.Funds = seri }, deSeriMode, TypeDenotationNone, func(_ uint32) (Serializable, error) {
+		ReadSliceOfObjects(func(seri Serializables) { r.Funds = seri }, deSeriMode, SeriSliceLengthAsUint16, TypeDenotationNone, func(_ uint32) (Serializable, error) {
 			// there is no real selector, so we always return a fresh MigratedFundsEntry
 			return &MigratedFundsEntry{}, nil
 		}, migratedFundEntriesArrayRules, func(err error) error {
@@ -141,7 +141,7 @@ func (r *Receipt) Serialize(deSeriMode DeSerializationMode) ([]byte, error) {
 		WriteBool(r.Final, func(err error) error {
 			return fmt.Errorf("unable to serialize receipt final flag: %w", err)
 		}).
-		WriteSliceOfObjects(r.Funds, deSeriMode, migratedFundsEntriesWrittenConsumer, func(err error) error {
+		WriteSliceOfObjects(r.Funds, deSeriMode, SeriSliceLengthAsUint16, migratedFundsEntriesWrittenConsumer, func(err error) error {
 			return fmt.Errorf("unable to serialize receipt funds: %w", err)
 		}).
 		WritePayload(r.Transaction, deSeriMode, func(err error) error {

--- a/serializable.go
+++ b/serializable.go
@@ -67,15 +67,15 @@ func (av ArrayValidationMode) HasMode(mode ArrayValidationMode) bool {
 // Min and Max at 0 define an unbounded array.
 type ArrayRules struct {
 	// The min array bound.
-	Min uint16
+	Min uint
 	// The max array bound.
-	Max uint16
+	Max uint
 	// The mode of validation.
 	ValidationMode ArrayValidationMode
 }
 
 // CheckBounds checks whether the given count violates the array bounds.
-func (ar *ArrayRules) CheckBounds(count uint16) error {
+func (ar *ArrayRules) CheckBounds(count uint) error {
 	if ar.Min != 0 && count < ar.Min {
 		return fmt.Errorf("%w: min is %d but count is %d", ErrArrayValidationMinElementsNotReached, ar.Min, count)
 	}

--- a/serializable_test.go
+++ b/serializable_test.go
@@ -392,9 +392,9 @@ func TestArrayRules_Bounds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			arrayRules.Min = uint16(tt.min)
-			arrayRules.Max = uint16(tt.max)
-			err := arrayRules.CheckBounds(uint16(len(tt.args)))
+			arrayRules.Min = uint(tt.min)
+			arrayRules.Max = uint(tt.max)
+			err := arrayRules.CheckBounds(uint(len(tt.args)))
 			assert.Equal(t, tt.valid, err == nil)
 		})
 	}

--- a/serializer.go
+++ b/serializer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 )
 
 type (
@@ -144,16 +145,28 @@ func (s *Serializer) writeSliceLength(l int, lenType SeriSliceLengthType, errPro
 	}
 	switch lenType {
 	case SeriSliceLengthAsByte:
+		if l > math.MaxUint8 {
+			s.err = errProducer(fmt.Errorf("unable to serialize slice length: length %d is out of range (0-%d)", l, math.MaxUint8))
+			return s
+		}
 		if err := s.buf.WriteByte(byte(l)); err != nil {
 			s.err = errProducer(err)
 			return s
 		}
 	case SeriSliceLengthAsUint16:
+		if l > math.MaxUint16 {
+			s.err = errProducer(fmt.Errorf("unable to serialize slice length: length %d is out of range (0-%d)", l, math.MaxUint16))
+			return s
+		}
 		if err := binary.Write(&s.buf, binary.LittleEndian, uint16(l)); err != nil {
 			s.err = errProducer(err)
 			return s
 		}
 	case SeriSliceLengthAsUint32:
+		if l > math.MaxUint32 {
+			s.err = errProducer(fmt.Errorf("unable to serialize slice length: length %d is out of range (0-%d)", l, math.MaxUint32))
+			return s
+		}
 		if err := binary.Write(&s.buf, binary.LittleEndian, uint32(l)); err != nil {
 			s.err = errProducer(err)
 			return s
@@ -187,7 +200,7 @@ func (s *Serializer) Write32BytesArraySlice(data SliceOfArraysOf32Bytes, deSeriM
 
 	var arrayElementValidator ElementValidationFunc
 	if arrayRules != nil && deSeriMode.HasMode(DeSeriModePerformValidation) {
-		if err := arrayRules.CheckBounds(uint16(sliceLength)); err != nil {
+		if err := arrayRules.CheckBounds(uint(sliceLength)); err != nil {
 			s.err = errProducer(err)
 			return s
 		}
@@ -224,7 +237,7 @@ func (s *Serializer) Write64BytesArraySlice(data SliceOfArraysOf64Bytes, deSeriM
 
 	var arrayElementValidator ElementValidationFunc
 	if arrayRules != nil && deSeriMode.HasMode(DeSeriModePerformValidation) {
-		if err := arrayRules.CheckBounds(uint16(sliceLength)); err != nil {
+		if err := arrayRules.CheckBounds(uint(sliceLength)); err != nil {
 			s.err = errProducer(err)
 			return s
 		}
@@ -272,16 +285,12 @@ func (s *Serializer) WriteObject(seri Serializable, deSeriMode DeSerializationMo
 
 // WriteSliceOfObjects writes Serializables into the Serializer.
 // For every written Serializable, the given WrittenObjectConsumer is called if it isn't nil.
-func (s *Serializer) WriteSliceOfObjects(seris Serializables, deSeriMode DeSerializationMode, woc WrittenObjectConsumer, errProducer ErrProducer) *Serializer {
+func (s *Serializer) WriteSliceOfObjects(seris Serializables, deSeriMode DeSerializationMode, lenType SeriSliceLengthType, woc WrittenObjectConsumer, errProducer ErrProducer) *Serializer {
 	if s.err != nil {
 		return s
 	}
 
-	if err := binary.Write(&s.buf, binary.LittleEndian, uint16(len(seris))); err != nil {
-		s.err = errProducer(err)
-		return s
-	}
-
+	_ = s.writeSliceLength(len(seris), lenType, errProducer)
 	for i, seri := range seris {
 		ser, err := seri.Serialize(deSeriMode)
 		if err != nil {
@@ -312,7 +321,7 @@ func (s *Serializer) WritePayload(payload Serializable, deSeriMode DeSerializati
 
 	if payload == nil {
 		if err := binary.Write(&s.buf, binary.LittleEndian, uint32(0)); err != nil {
-			s.err = errProducer(fmt.Errorf("unable to serialize zero paylaod length: %w", err))
+			s.err = errProducer(fmt.Errorf("unable to serialize zero payload length: %w", err))
 		}
 		return s
 	}
@@ -324,7 +333,7 @@ func (s *Serializer) WritePayload(payload Serializable, deSeriMode DeSerializati
 	}
 
 	if err := binary.Write(&s.buf, binary.LittleEndian, uint32(len(payloadBytes))); err != nil {
-		s.err = errProducer(fmt.Errorf("unable to serialize paylaod length: %w", err))
+		s.err = errProducer(fmt.Errorf("unable to serialize payload length: %w", err))
 		return s
 	}
 
@@ -336,16 +345,12 @@ func (s *Serializer) WritePayload(payload Serializable, deSeriMode DeSerializati
 }
 
 // WriteString writes the given string to the Serializer.
-func (s *Serializer) WriteString(str string, errProducer ErrProducer) *Serializer {
+func (s *Serializer) WriteString(str string, lenType SeriSliceLengthType, errProducer ErrProducer) *Serializer {
 	if s.err != nil {
 		return s
 	}
 
-	if err := binary.Write(&s.buf, binary.LittleEndian, uint16(len(str))); err != nil {
-		s.err = errProducer(err)
-		return s
-	}
-
+	_ = s.writeSliceLength(len(str), lenType, errProducer)
 	if _, err := s.buf.Write([]byte(str)); err != nil {
 		s.err = errProducer(err)
 	}
@@ -601,7 +606,7 @@ func (d *Deserializer) ReadSliceOfArraysOf32Bytes(slice *SliceOfArraysOf32Bytes,
 
 	var arrayElementValidator ElementValidationFunc
 	if arrayRules != nil && deSeriMode.HasMode(DeSeriModePerformValidation) {
-		if err := arrayRules.CheckBounds(uint16(sliceLength)); err != nil {
+		if err := arrayRules.CheckBounds(uint(sliceLength)); err != nil {
 			d.err = errProducer(err)
 			return d
 		}
@@ -648,7 +653,7 @@ func (d *Deserializer) ReadSliceOfArraysOf64Bytes(slice *SliceOfArraysOf64Bytes,
 
 	var arrayElementValidator ElementValidationFunc
 	if arrayRules != nil && deSeriMode.HasMode(DeSeriModePerformValidation) {
-		if err := arrayRules.CheckBounds(uint16(sliceLength)); err != nil {
+		if err := arrayRules.CheckBounds(uint(sliceLength)); err != nil {
 			d.err = errProducer(err)
 			return d
 		}
@@ -726,23 +731,20 @@ func (d *Deserializer) ReadObject(f ReadObjectConsumerFunc, deSeriMode DeSeriali
 }
 
 // ReadSliceOfObjects reads a slice of objects.
-func (d *Deserializer) ReadSliceOfObjects(f ReadObjectsConsumerFunc, deSeriMode DeSerializationMode, typeDen TypeDenotationType, serSel SerializableSelectorFunc, arrayRules *ArrayRules, errProducer ErrProducer) *Deserializer {
+func (d *Deserializer) ReadSliceOfObjects(f ReadObjectsConsumerFunc, deSeriMode DeSerializationMode, lenType SeriSliceLengthType, typeDen TypeDenotationType, serSel SerializableSelectorFunc, arrayRules *ArrayRules, errProducer ErrProducer) *Deserializer {
 	if d.err != nil {
 		return d
 	}
 
-	if len(d.src) < StructArrayLengthByteSize {
-		d.err = errProducer(fmt.Errorf("%w: not enough data to deserialize struct array", ErrDeserializationNotEnoughData))
+	sliceLength, err := d.readSliceLength(lenType, errProducer)
+	if err != nil {
+		d.err = err
 		return d
 	}
 
-	seriCount := binary.LittleEndian.Uint16(d.src)
-	d.offset += StructArrayLengthByteSize
-	d.src = d.src[StructArrayLengthByteSize:]
-
 	var arrayElementValidator ElementValidationFunc
 	if arrayRules != nil && deSeriMode.HasMode(DeSeriModePerformValidation) {
-		if err := arrayRules.CheckBounds(seriCount); err != nil {
+		if err := arrayRules.CheckBounds(uint(sliceLength)); err != nil {
 			d.err = errProducer(err)
 			return d
 		}
@@ -751,7 +753,7 @@ func (d *Deserializer) ReadSliceOfObjects(f ReadObjectsConsumerFunc, deSeriMode 
 	}
 
 	var seris Serializables
-	for i := 0; i < int(seriCount); i++ {
+	for i := 0; i < int(sliceLength); i++ {
 
 		// remember where we were before reading the object
 		srcBefore := d.src
@@ -845,23 +847,20 @@ func (d *Deserializer) ReadPayload(f ReadObjectConsumerFunc, deSeriMode DeSerial
 }
 
 // ReadString reads a string.
-func (d *Deserializer) ReadString(s *string, errProducer ErrProducer, maxSize ...uint16) *Deserializer {
+func (d *Deserializer) ReadString(s *string, lenType SeriSliceLengthType, errProducer ErrProducer, maxSize ...int) *Deserializer {
 	if d.err != nil {
 		return d
 	}
 
-	if len(d.src) < UInt16ByteSize {
-		d.err = errProducer(fmt.Errorf("%w: can't read string length", ErrDeserializationNotEnoughData))
+	strLen, err := d.readSliceLength(lenType, errProducer)
+	if err != nil {
+		d.err = err
 		return d
 	}
 
-	strLen := binary.LittleEndian.Uint16(d.src)
 	if len(maxSize) > 0 && strLen > maxSize[0] {
 		d.err = errProducer(fmt.Errorf("%w: string defined to be of %d bytes length but max %d is allowed", ErrDeserializationLengthInvalid, strLen, maxSize[0]))
 	}
-
-	d.offset += UInt16ByteSize
-	d.src = d.src[UInt16ByteSize:]
 
 	if len(d.src) < int(strLen) {
 		d.err = errProducer(fmt.Errorf("%w: data is smaller than (%d) denoted string length of %d", ErrDeserializationNotEnoughData, len(d.src), strLen))

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -45,7 +45,7 @@ func TestDeserializer_ReadSliceOfObjects(t *testing.T) {
 	bytesRead, err := iotago.NewDeserializer(data).
 		ReadSliceOfObjects(func(seri iotago.Serializables) {
 			readObjects = seri
-		}, iotago.DeSeriModePerformValidation, iotago.TypeDenotationByte, DummyTypeSelector, nil, func(err error) error { return err }).
+		}, iotago.DeSeriModePerformValidation, iotago.SeriSliceLengthAsUint16, iotago.TypeDenotationByte, DummyTypeSelector, nil, func(err error) error { return err }).
 		ConsumedAll(func(left int, err error) error { return err }).
 		Done()
 
@@ -93,7 +93,7 @@ func TestDeserializer_ReadString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var s string
 			_, err := iotago.NewDeserializer(tt.args.data).
-				ReadString(&s, func(err error) error {
+				ReadString(&s, iotago.SeriSliceLengthAsUint16, func(err error) error {
 					return err
 				}).
 				ConsumedAll(func(left int, err error) error { return err }).

--- a/transaction.go
+++ b/transaction.go
@@ -89,11 +89,11 @@ func (t *Transaction) Deserialize(data []byte, deSeriMode DeSerializationMode) (
 			return fmt.Errorf("%w: unable to deserialize transaction essence within transaction", err)
 		}).
 		Do(func() {
-			inputCount := uint16(len(t.Essence.(*TransactionEssence).Inputs))
+			inputCount := uint(len(t.Essence.(*TransactionEssence).Inputs))
 			unlockBlockArrayRules.Min = inputCount
 			unlockBlockArrayRules.Max = inputCount
 		}).
-		ReadSliceOfObjects(func(seri Serializables) { t.UnlockBlocks = seri }, deSeriMode, TypeDenotationByte, UnlockBlockSelector, unlockBlockArrayRules, func(err error) error {
+		ReadSliceOfObjects(func(seri Serializables) { t.UnlockBlocks = seri }, deSeriMode, SeriSliceLengthAsUint16, TypeDenotationByte, UnlockBlockSelector, unlockBlockArrayRules, func(err error) error {
 			return fmt.Errorf("%w: unable to deserialize unlock blocks", err)
 		}).
 		AbortIf(func(err error) error {
@@ -119,7 +119,7 @@ func (t *Transaction) Serialize(deSeriMode DeSerializationMode) ([]byte, error) 
 		WriteObject(t.Essence, deSeriMode, func(err error) error {
 			return fmt.Errorf("%w: unable to serialize transaction's essence", err)
 		}).
-		WriteSliceOfObjects(t.UnlockBlocks, deSeriMode, nil, func(err error) error {
+		WriteSliceOfObjects(t.UnlockBlocks, deSeriMode, SeriSliceLengthAsUint16, nil, func(err error) error {
 			return fmt.Errorf("%w: unable to serialize transaction's unlock blocks", err)
 		}).
 		Serialize()

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -17,7 +17,7 @@ const (
 	TransactionEssenceNormal TransactionEssenceType = iota
 
 	// TransactionEssenceMinByteSize defines the minimum size of a TransactionEssence.
-	TransactionEssenceMinByteSize = TypeDenotationByteSize + StructArrayLengthByteSize + StructArrayLengthByteSize + PayloadLengthByteSize
+	TransactionEssenceMinByteSize = TypeDenotationByteSize + UInt16ByteSize + UInt16ByteSize + PayloadLengthByteSize
 
 	// MaxInputsCount defines the maximum amount of inputs within a TransactionEssence.
 	MaxInputsCount = 127
@@ -115,7 +115,7 @@ func (u *TransactionEssence) Deserialize(data []byte, deSeriMode DeSerialization
 		Skip(SmallTypeDenotationByteSize, func(err error) error {
 			return fmt.Errorf("unable to skip transaction essence ID during deserialization: %w", err)
 		}).
-		ReadSliceOfObjects(func(seri Serializables) { u.Inputs = seri }, deSeriMode, TypeDenotationByte, func(ty uint32) (Serializable, error) {
+		ReadSliceOfObjects(func(seri Serializables) { u.Inputs = seri }, deSeriMode, SeriSliceLengthAsUint16, TypeDenotationByte, func(ty uint32) (Serializable, error) {
 			switch ty {
 			case uint32(InputUTXO):
 			default:
@@ -133,7 +133,7 @@ func (u *TransactionEssence) Deserialize(data []byte, deSeriMode DeSerialization
 			}
 			return nil
 		}).
-		ReadSliceOfObjects(func(seri Serializables) { u.Outputs = seri }, deSeriMode, TypeDenotationByte, func(ty uint32) (Serializable, error) {
+		ReadSliceOfObjects(func(seri Serializables) { u.Outputs = seri }, deSeriMode, SeriSliceLengthAsUint16, TypeDenotationByte, func(ty uint32) (Serializable, error) {
 			switch ty {
 			case uint32(OutputSigLockedSingleOutput):
 			case uint32(OutputSigLockedDustAllowanceOutput):
@@ -220,10 +220,10 @@ func (u *TransactionEssence) Serialize(deSeriMode DeSerializationMode) (data []b
 		WriteNum(TransactionEssenceNormal, func(err error) error {
 			return fmt.Errorf("unable to serialize transaction essence type ID: %w", err)
 		}).
-		WriteSliceOfObjects(u.Inputs, deSeriMode, inputsWrittenConsumer, func(err error) error {
+		WriteSliceOfObjects(u.Inputs, deSeriMode, SeriSliceLengthAsUint16, inputsWrittenConsumer, func(err error) error {
 			return fmt.Errorf("unable to serialize transaction essence inputs: %w", err)
 		}).
-		WriteSliceOfObjects(u.Outputs, deSeriMode, outputsWrittenConsumer, func(err error) error {
+		WriteSliceOfObjects(u.Outputs, deSeriMode, SeriSliceLengthAsUint16, outputsWrittenConsumer, func(err error) error {
 			return fmt.Errorf("unable to serialize transaction essence outputs: %w", err)
 		}).
 		WritePayload(u.Payload, deSeriMode, func(err error) error {


### PR DESCRIPTION
This PR adds the possibility to change the slice length type for SliceOfObjects and String Read/Write serializer functions according to the other serializer functions.