### PR TITLE
fix: nil pointer access in NewSemValiContextWorkingSet

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -269,6 +269,7 @@ func NewSemValiContextWorkingSet(t *Transaction, inputs OutputSet) (*SemValiCont
 	workingSet := &SemValiContextWorkingSet{}
 	workingSet.UnlockedIdents = make(UnlockedIdentities)
 	workingSet.InputSet = inputs
+	workingSet.Tx = t
 	workingSet.InputIDToIndex = func() map[OutputID]uint16 {
 		m := make(map[OutputID]uint16)
 		for inputIndex, inputRef := range workingSet.Tx.Essence.Inputs {
@@ -276,7 +277,6 @@ func NewSemValiContextWorkingSet(t *Transaction, inputs OutputSet) (*SemValiCont
 		}
 		return m
 	}()
-	workingSet.Tx = t
 	workingSet.EssenceMsgToSign, err = t.Essence.SigningMessage()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description of change

fix: nil pointer access in `NewSemValiContextWorkingSet`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Just running `NewSemValiContextWorkingSet` would panic. This change fixes that.
(I'm using the `iota.go` code as a library from outside).
