### PR TITLE
Add test vectors from RFC-28

### DIFF
--- a/signature_test.go
+++ b/signature_test.go
@@ -73,20 +73,20 @@ func TestEd25519Signature_Serialize(t *testing.T) {
 	}
 }
 
-type validTest struct {
-	Address   tpkg.HexBytes `json:"address"`
-	Message   tpkg.HexBytes `json:"message"`
-	PublicKey tpkg.HexBytes `json:"pub_key"`
-	Signature tpkg.HexBytes `json:"signature"`
-	Valid     bool          `json:"valid"`
-}
-
 func TestEd25519Signature_Valid(t *testing.T) {
+	type test struct {
+		Address   tpkg.HexBytes `json:"address"`
+		Message   tpkg.HexBytes `json:"message"`
+		PublicKey tpkg.HexBytes `json:"pub_key"`
+		Signature tpkg.HexBytes `json:"signature"`
+		Valid     bool          `json:"valid"`
+	}
+	var tests []test
+	// load the tests from file
 	b, err := ioutil.ReadFile(filepath.Join("testdata", t.Name()+".json"))
 	require.NoError(t, err)
-
-	var tests []validTest
 	require.NoError(t, json.Unmarshal(b, &tests))
+
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			// deserialize the address from the test

--- a/signature_test.go
+++ b/signature_test.go
@@ -3,7 +3,7 @@ package iotago_test
 import (
 	"encoding/json"
 	"errors"
-	"os"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -82,7 +82,7 @@ type validTest struct {
 }
 
 func TestEd25519Signature_Valid(t *testing.T) {
-	b, err := os.ReadFile(filepath.Join("testdata", t.Name()+".json"))
+	b, err := ioutil.ReadFile(filepath.Join("testdata", t.Name()+".json"))
 	require.NoError(t, err)
 
 	var tests []validTest

--- a/signature_test.go
+++ b/signature_test.go
@@ -1,13 +1,17 @@
 package iotago_test
 
 import (
+	"encoding/json"
 	"errors"
-	"github.com/iotaledger/hive.go/serializer"
-	"github.com/iotaledger/iota.go/v2/tpkg"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/iotaledger/hive.go/serializer"
 	"github.com/iotaledger/iota.go/v2"
+	"github.com/iotaledger/iota.go/v2/tpkg"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSignatureSelector(t *testing.T) {
@@ -65,6 +69,42 @@ func TestEd25519Signature_Serialize(t *testing.T) {
 			edData, err := tt.source.Serialize(serializer.DeSeriModePerformValidation)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.target, edData)
+		})
+	}
+}
+
+type validTest struct {
+	Address   tpkg.HexBytes `json:"address"`
+	Message   tpkg.HexBytes `json:"message"`
+	PublicKey tpkg.HexBytes `json:"pub_key"`
+	Signature tpkg.HexBytes `json:"signature"`
+	Valid     bool          `json:"valid"`
+}
+
+func TestEd25519Signature_Valid(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("testdata", t.Name()+".json"))
+	require.NoError(t, err)
+
+	var tests []validTest
+	require.NoError(t, json.Unmarshal(b, &tests))
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			// deserialize the address from the test
+			addr := &iotago.Ed25519Address{}
+			_, err = addr.Deserialize(tt.Address, serializer.DeSeriModePerformValidation)
+			require.NoError(t, err)
+			// create the signature type
+			sig := &iotago.Ed25519Signature{}
+			copy(sig.PublicKey[:], tt.PublicKey)
+			copy(sig.Signature[:], tt.Signature)
+
+			sigError := sig.Valid(tt.Message, addr)
+			switch tt.Valid {
+			case true:
+				assert.NoError(t, sigError)
+			case false:
+				assert.Error(t, sigError)
+			}
 		})
 	}
 }

--- a/testdata/TestEd25519Signature_Valid.json
+++ b/testdata/TestEd25519Signature_Valid.json
@@ -1,0 +1,86 @@
+[
+  {
+    "address": "008f5a6fdcfef8989fb88312cbc956ccc54dceb9c693ec99c08a28bdda5f11da44",
+    "message": "8c93255d71dcab10e8f379c26200f3c7bd5f09d9bc3068d3ef4edeb4853022b6",
+    "pub_key": "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa",
+    "signature": "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a0000000000000000000000000000000000000000000000000000000000000000",
+    "valid": true
+  },
+  {
+    "address": "008f5a6fdcfef8989fb88312cbc956ccc54dceb9c693ec99c08a28bdda5f11da44",
+    "message": "9bd9f44f4dcc75bd531b56b2cd280b0bb38fc1cd6d1230e14861d861de092e79",
+    "pub_key": "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa",
+    "signature": "f7badec5b8abeaf699583992219b7b223f1df3fbbea919844e3f7c554a43dd43a5bb704786be79fc476f91d3f3f89b03984d8068dcf1bb7dfc6637b45450ac04",
+    "valid": true
+  },
+  {
+    "address": "00df7de50e110ead8cb83451a503dbe03cc5edb2eced7e35212ae10af28d38c000",
+    "message": "aebf3f2601a0c8c5d39cc7d8911642f740b78168218da8471772b35f9d35b9ab",
+    "pub_key": "f7badec5b8abeaf699583992219b7b223f1df3fbbea919844e3f7c554a43dd43",
+    "signature": "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa8c4bd45aecaca5b24fb97bc10ac27ac8751a7dfe1baff8b953ec9f5833ca260e",
+    "valid": true
+  },
+  {
+    "address": "001482f60b75cc1a6b1fe9810b64b95a978c35ed73ff371cb99f6f1fd0479d7b21",
+    "message": "9bd9f44f4dcc75bd531b56b2cd280b0bb38fc1cd6d1230e14861d861de092e79",
+    "pub_key": "cdb267ce40c5cd45306fa5d2f29731459387dbf9eb933b7bd5aed9a765b88d4d",
+    "signature": "9046a64750444938de19f227bb80485e92b83fdb4b6506c160484c016cc1852f87909e14428a7a1d62e9f22f3d3ad7802db02eb2e688b6c52fcd6648a98bd009",
+    "valid": true
+  },
+  {
+    "address": "001482f60b75cc1a6b1fe9810b64b95a978c35ed73ff371cb99f6f1fd0479d7b21",
+    "message": "e47d62c63f830dc7a6851a0b1f33ae4bb2f507fb6cffec4011eaccd55b53f56c",
+    "pub_key": "cdb267ce40c5cd45306fa5d2f29731459387dbf9eb933b7bd5aed9a765b88d4d",
+    "signature": "160a1cb0dc9c0258cd0a7d23e94d8fa878bcb1925f2c64246b2dee1796bed5125ec6bc982a269b723e0668e540911a9a6a58921d6925e434ab10aa7940551a09",
+    "valid": true
+  },
+  {
+    "address": "001482f60b75cc1a6b1fe9810b64b95a978c35ed73ff371cb99f6f1fd0479d7b21",
+    "message": "e47d62c63f830dc7a6851a0b1f33ae4bb2f507fb6cffec4011eaccd55b53f56c",
+    "pub_key": "cdb267ce40c5cd45306fa5d2f29731459387dbf9eb933b7bd5aed9a765b88d4d",
+    "signature": "21122a84e0b5fca4052f5b1235c80a537878b38f3142356b2c2384ebad4668b7e40bc836dac0f71076f9abe3a53f9c03c1ceeeddb658d0030494ace586687405",
+    "valid": true
+  },
+  {
+    "address": "002aeb2a345ceecd740ffa7cd891ac0116dd10fe169079d158e492043ec49b834d",
+    "message": "85e241a07d148b41e47d62c63f830dc7a6851a0b1f33ae4bb2f507fb6cffec40",
+    "pub_key": "442aad9f089ad9e14647b1ef9099a1ff4798d78589e66f28eca69c11f582a623",
+    "signature": "e96f66be976d82e60150baecff9906684aebb1ef181f67a7189ac78ea23b6c0e547f7690a0e2ddcd04d87dbc3490dc19b3b3052f7ff0538cb68afb369ba3a514",
+    "valid": false
+  },
+  {
+    "address": "002aeb2a345ceecd740ffa7cd891ac0116dd10fe169079d158e492043ec49b834d",
+    "message": "85e241a07d148b41e47d62c63f830dc7a6851a0b1f33ae4bb2f507fb6cffec40",
+    "pub_key": "442aad9f089ad9e14647b1ef9099a1ff4798d78589e66f28eca69c11f582a623",
+    "signature": "8ce5b96c8f26d0ab6c47958c9e68b937104cd36e13c33566acd2fe8d38aa19427e71f98a473474f2f13f06f97c20d58cc3f54b8bd0d272f42b695dd7e89a8c22",
+    "valid": false
+  },
+  {
+    "address": "00df7de50e110ead8cb83451a503dbe03cc5edb2eced7e35212ae10af28d38c000",
+    "message": "9bedc267423725d473888631ebf45988bad3db83851ee85c85e241a07d148b41",
+    "pub_key": "f7badec5b8abeaf699583992219b7b223f1df3fbbea919844e3f7c554a43dd43",
+    "signature": "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff03be9678ac102edcd92b0210bb34d7428d12ffc5df5f37e359941266a4e35f0f",
+    "valid": false
+  },
+  {
+    "address": "00df7de50e110ead8cb83451a503dbe03cc5edb2eced7e35212ae10af28d38c000",
+    "message": "9bedc267423725d473888631ebf45988bad3db83851ee85c85e241a07d148b41",
+    "pub_key": "f7badec5b8abeaf699583992219b7b223f1df3fbbea919844e3f7c554a43dd43",
+    "signature": "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffca8c5b64cd208982aa38d4936621a4775aa233aa0505711d8fdcfdaa943d4908",
+    "valid": true
+  },
+  {
+    "address": "00f25275baf4e267a1ec213dfd8283e9c97bf8c3494752c1c14b4bd5e5f9bfa9d8",
+    "message": "e96b7021eb39c1a163b6da4e3093dcd3f21387da4cc4572be588fafae23c155b",
+    "pub_key": "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "signature": "a9d55260f765261eb9b84e106f665e00b867287a761990d7135963ee0a7d59dca5bb704786be79fc476f91d3f3f89b03984d8068dcf1bb7dfc6637b45450ac04",
+    "valid": false
+  },
+  {
+    "address": "003e7cca5d2979e71caa7325ce147026402da2aec6f95586be89e24f84bfb7f8fc",
+    "message": "39a591f5321bbe07fd5a23dc2f39d025d74526615746727ceefd6e82ae65c06f",
+    "pub_key": "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "signature": "a9d55260f765261eb9b84e106f665e00b867287a761990d7135963ee0a7d59dca5bb704786be79fc476f91d3f3f89b03984d8068dcf1bb7dfc6637b45450ac04",
+    "valid": true
+  }
+]

--- a/tpkg/hex_bytes.go
+++ b/tpkg/hex_bytes.go
@@ -1,0 +1,29 @@
+package tpkg
+
+import (
+	"encoding/hex"
+)
+
+// HexBytes is a slice of bytes that marshals/unmarshals as a string in hexadecimal encoding.
+// It is a simple utility to parse hex encoded test vectors.
+type HexBytes []byte
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (b HexBytes) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (b *HexBytes) UnmarshalText(text []byte) (err error) {
+	dec := make([]byte, hex.DecodedLen(len(text)))
+	if _, err = hex.Decode(dec, text); err != nil {
+		return err
+	}
+	*b = dec
+	return
+}
+
+// String returns the hex encoding of b.
+func (b HexBytes) String() string {
+	return hex.EncodeToString(b)
+}


### PR DESCRIPTION
# Description of change

Adds the test vectors from the IOTA protocol RFC-0028 provided in https://github.com/iotaledger/protocol-rfcs/pull/28.

To be able to conveniently parse the JSON test file from the RFC, a small test util struct was added that supports hex-encoded byte slices. 

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
