### PR TITLE
isc vm use case test failing

### DIFF
--- a/isc_usecase_test.go
+++ b/isc_usecase_test.go
@@ -1,0 +1,69 @@
+package iotago_test
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/iota.go/v3/tpkg"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumeRequest(t *testing.T) {
+	stateController := tpkg.RandEd25519PrivateKey()
+	stateControllerAddr := iotago.Ed25519AddressFromPubKey(stateController.Public().(ed25519.PublicKey))
+	addrKeys := iotago.AddressKeys{Address: &stateControllerAddr, Keys: stateController}
+
+	aliasOut1 := &iotago.AliasOutput{
+		Amount:               1337,
+		AliasID:              tpkg.RandAliasAddress().AliasID(),
+		StateController:      &stateControllerAddr,
+		GovernanceController: &stateControllerAddr,
+		StateIndex:           1,
+	}
+	aliasOut1Inp := tpkg.RandUTXOInput()
+
+	req := &iotago.ExtendedOutput{
+		Amount:  1337,
+		Address: aliasOut1.AliasID.ToAddress(),
+	}
+	reqInp := tpkg.RandUTXOInput()
+
+	aliasOut2 := &iotago.AliasOutput{
+		Amount:               1337 * 2,
+		AliasID:              aliasOut1.AliasID,
+		StateController:      &stateControllerAddr,
+		GovernanceController: &stateControllerAddr,
+		StateIndex:           2,
+	}
+	txb := iotago.NewTransactionBuilder()
+	txb.AddInput(&iotago.ToBeSignedUTXOInput{
+		Address: &stateControllerAddr,
+		Input:   aliasOut1Inp,
+	})
+	txb.AddInput(&iotago.ToBeSignedUTXOInput{
+		Address: &stateControllerAddr,
+		Input:   reqInp,
+	})
+	txb.AddOutput(aliasOut2)
+	deSeriParams := &iotago.DeSerializationParameters{
+		RentStructure: &iotago.RentStructure{1, 1, 1},
+	}
+	signer := iotago.NewInMemoryAddressSigner(addrKeys)
+	tx, err := txb.Build(deSeriParams, signer)
+	require.NoError(t, err)
+
+	semValCtx := &iotago.SemanticValidationContext{
+		ExtParas: &iotago.ExternalUnlockParameters{
+			ConfMsIndex: 1,
+			ConfUnix:    uint64(time.Now().Unix()),
+		},
+	}
+	outset := iotago.OutputSet{
+		aliasOut1Inp.ID(): aliasOut1,
+		reqInp.ID():       req,
+	}
+	err = tx.SemanticallyValidate(semValCtx, outset)
+	require.NoError(t, err)
+}

--- a/tpkg/util1.go
+++ b/tpkg/util1.go
@@ -1,7 +1,0 @@
-package tpkg
-
-import "fmt"
-
-func MyNewFun() {
-	fmt.Println("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&7")
-}

--- a/transaction.go
+++ b/transaction.go
@@ -467,7 +467,8 @@ func unlockOutput(svCtx *SemanticValidationContext, output Output, inputIndex ui
 	switch owner := ownerIdent.(type) {
 	case ChainConstrainedAddress:
 		referentialUnlockBlock, isReferentialUnlockBlock := unlockBlock.(ReferentialUnlockBlock)
-		if !isReferentialUnlockBlock || !referentialUnlockBlock.Chainable() || !referentialUnlockBlock.SourceAllowed(ownerIdent) {
+		//if !isReferentialUnlockBlock || !referentialUnlockBlock.Chainable() || !referentialUnlockBlock.SourceAllowed(ownerIdent) {
+		if !isReferentialUnlockBlock || !referentialUnlockBlock.SourceAllowed(ownerIdent) {
 			return fmt.Errorf("%w: input %d has a chain constrained address (%T) but its corresponding unlock block is of type %T", ErrInvalidInputUnlock, inputIndex, owner, unlockBlock)
 		}
 

--- a/transaction.go
+++ b/transaction.go
@@ -467,6 +467,7 @@ func unlockOutput(svCtx *SemanticValidationContext, output Output, inputIndex ui
 	switch owner := ownerIdent.(type) {
 	case ChainConstrainedAddress:
 		referentialUnlockBlock, isReferentialUnlockBlock := unlockBlock.(ReferentialUnlockBlock)
+
 		//if !isReferentialUnlockBlock || !referentialUnlockBlock.Chainable() || !referentialUnlockBlock.SourceAllowed(ownerIdent) {
 
 		if !isReferentialUnlockBlock {
@@ -474,7 +475,7 @@ func unlockOutput(svCtx *SemanticValidationContext, output Output, inputIndex ui
 				ErrInvalidInputUnlock, inputIndex, owner, unlockBlock)
 		}
 		if !referentialUnlockBlock.SourceAllowed(ownerIdent) {
-			return fmt.Errorf("%w: input %d has a chain constrained address (%T) but its unlock block references ident ((%T) which not allowed",
+			return fmt.Errorf("%w: input %d has a chain constrained address (%T) but its unlock block references ident (%T) which not allowed",
 				ErrInvalidInputUnlock, inputIndex, owner, ownerIdent)
 		}
 

--- a/transaction.go
+++ b/transaction.go
@@ -470,6 +470,8 @@ func unlockOutput(svCtx *SemanticValidationContext, output Output, inputIndex ui
 
 		//if !isReferentialUnlockBlock || !referentialUnlockBlock.Chainable() || !referentialUnlockBlock.SourceAllowed(ownerIdent) {
 
+		// FIXME changes do not fix the bug
+
 		if !isReferentialUnlockBlock {
 			return fmt.Errorf("%w: input %d has a chain constrained address (%T) but its corresponding unlock block is of type %T, while reference is expected",
 				ErrInvalidInputUnlock, inputIndex, owner, unlockBlock)

--- a/transaction.go
+++ b/transaction.go
@@ -468,8 +468,14 @@ func unlockOutput(svCtx *SemanticValidationContext, output Output, inputIndex ui
 	case ChainConstrainedAddress:
 		referentialUnlockBlock, isReferentialUnlockBlock := unlockBlock.(ReferentialUnlockBlock)
 		//if !isReferentialUnlockBlock || !referentialUnlockBlock.Chainable() || !referentialUnlockBlock.SourceAllowed(ownerIdent) {
-		if !isReferentialUnlockBlock || !referentialUnlockBlock.SourceAllowed(ownerIdent) {
-			return fmt.Errorf("%w: input %d has a chain constrained address (%T) but its corresponding unlock block is of type %T", ErrInvalidInputUnlock, inputIndex, owner, unlockBlock)
+
+		if !isReferentialUnlockBlock {
+			return fmt.Errorf("%w: input %d has a chain constrained address (%T) but its corresponding unlock block is of type %T, while reference is expected",
+				ErrInvalidInputUnlock, inputIndex, owner, unlockBlock)
+		}
+		if !referentialUnlockBlock.SourceAllowed(ownerIdent) {
+			return fmt.Errorf("%w: input %d has a chain constrained address (%T) but its unlock block references ident ((%T) which not allowed",
+				ErrInvalidInputUnlock, inputIndex, owner, ownerIdent)
 		}
 
 		unlockedIndices, wasUnlocked := svCtx.WorkingSet.UnlockedIdents[owner.Key()]


### PR DESCRIPTION
A test covering a bug in tx semantical validation on the main use case when alias output consumes. See issue https://github.com/iotaledger/iota.go/issues/298
The test fail because semantical validation code changes do not fixed it completely.
