### PR TITLE
Bump types

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,6 @@ github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19y
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
-github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220119141545-2dab9f1c12a5 h1:idKV+D527d+lywQSh0G+fM3SOu3jzhh4tUtB4hskXMM=
-github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220119141545-2dab9f1c12a5/go.mod h1:Aw7fS+UjhMBj4hxTBxSG8Ti/5ifp1SWFpyapGZFuzdc=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220209164443-53ca2b8201b4 h1:OayOb1hDkItzIoNl49dh1pAxuKxPWcT9K91ONwYOd3g=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220209164443-53ca2b8201b4/go.mod h1:Aw7fS+UjhMBj4hxTBxSG8Ti/5ifp1SWFpyapGZFuzdc=
 github.com/iotaledger/iota.go v1.0.0 h1:tqm1FxJ/zOdzbrAaQ5BQpVF8dUy2eeGlSeWlNG8GoXY=

--- a/message_test.go
+++ b/message_test.go
@@ -45,7 +45,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 		  "protocolVersion": 1,
 		  "parentMessageIds": ["f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d", "78d546b46aec4557872139a48f66bc567687e8413578a14323548732358914a2"],
 		  "payload": {
-			"type": 0,
+			"type": 6,
 			"essence": {
 			  "type": 0,
               "networkId": "1337133713371337",

--- a/message_test.go
+++ b/message_test.go
@@ -47,7 +47,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 		  "payload": {
 			"type": 6,
 			"essence": {
-			  "type": 0,
+			  "type": 1,
               "networkId": "1337133713371337",
 			  "inputs": [
 				{

--- a/payload.go
+++ b/payload.go
@@ -12,16 +12,20 @@ import (
 type PayloadType uint32
 
 const (
-	// PayloadTransaction denotes a Transaction.
-	PayloadTransaction PayloadType = iota
+	// Deprecated payload types
+	// PayloadTransactionTIP7 = 0
+	// PayloadIndexationTIP6 = 2
+
 	// PayloadMilestone denotes a Milestone.
-	PayloadMilestone
+	PayloadMilestone PayloadType = 1
 	// PayloadReceipt denotes a Receipt.
-	PayloadReceipt
+	PayloadReceipt PayloadType = 3
 	// PayloadTreasuryTransaction denotes a TreasuryTransaction.
-	PayloadTreasuryTransaction
+	PayloadTreasuryTransaction PayloadType = 4
 	// PayloadTaggedData denotes a TaggedData payload.
 	PayloadTaggedData PayloadType = 5
+	// PayloadTransaction denotes a Transaction.
+	PayloadTransaction PayloadType = 6
 )
 
 func (payloadType PayloadType) String() string {
@@ -32,13 +36,14 @@ func (payloadType PayloadType) String() string {
 }
 
 var (
-	payloadNames = [PayloadTaggedData + 1]string{
-		"Transaction",
+	payloadNames = [PayloadTransaction + 1]string{
+		"Deprecated-TransactionTIP7",
 		"Milestone",
+		"Deprecated-Indexation",
 		"Receipt",
 		"TreasuryTransaction",
-		"Deprecated-Indexation",
 		"TaggedData",
+		"Transaction",
 	}
 )
 

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -17,7 +17,7 @@ type TransactionEssenceType = byte
 
 const (
 	// TransactionEssenceNormal denotes a standard transaction essence.
-	TransactionEssenceNormal TransactionEssenceType = iota
+	TransactionEssenceNormal TransactionEssenceType = 1
 
 	// MaxInputsCount defines the maximum amount of inputs within a TransactionEssence.
 	MaxInputsCount = 128


### PR DESCRIPTION
# Description of change

Bumps version numbers for:
 - `Transaction Payload Type`: `6` as in [TIP-20](https://github.com/iotaledger/tips/pull/40)
 - `Transaction Essence Type`: `1` as in [TIP-20](https://github.com/iotaledger/tips/pull/40)
 - "Old" transaction payload type is deprecated.

