### PR TITLE
Refactored number formatting in JSON api (hex and strings)

### DIFF
--- a/address_alias.go
+++ b/address_alias.go
@@ -1,7 +1,6 @@
 package iotago
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -22,7 +21,7 @@ var (
 
 // ParseAliasAddressFromHexString parses the given hex string into an AliasAddress.
 func ParseAliasAddressFromHexString(hexAddr string) (*AliasAddress, error) {
-	addrBytes, err := hex.DecodeString(hexAddr)
+	addrBytes, err := DecodeHex(hexAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +83,7 @@ func (aliasAddr *AliasAddress) Bech32(hrp NetworkPrefix) string {
 }
 
 func (aliasAddr *AliasAddress) String() string {
-	return hex.EncodeToString(aliasAddr[:])
+	return EncodeHex(aliasAddr[:])
 }
 
 func (aliasAddr *AliasAddress) Deserialize(data []byte, deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) (int, error) {
@@ -113,7 +112,7 @@ func (aliasAddr *AliasAddress) Serialize(_ serializer.DeSerializationMode, deSer
 
 func (aliasAddr *AliasAddress) MarshalJSON() ([]byte, error) {
 	jAliasAddress := &jsonAliasAddress{}
-	jAliasAddress.AliasId = hex.EncodeToString(aliasAddr[:])
+	jAliasAddress.AliasId = EncodeHex(aliasAddr[:])
 	jAliasAddress.Type = int(AddressAlias)
 	return json.Marshal(jAliasAddress)
 }
@@ -150,7 +149,7 @@ type jsonAliasAddress struct {
 }
 
 func (j *jsonAliasAddress) ToSerializable() (serializer.Serializable, error) {
-	addrBytes, err := hex.DecodeString(j.AliasId)
+	addrBytes, err := DecodeHex(j.AliasId)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode address from JSON for alias address: %w", err)
 	}

--- a/address_ed25519.go
+++ b/address_ed25519.go
@@ -2,7 +2,6 @@ package iotago
 
 import (
 	"crypto/ed25519"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -19,7 +18,7 @@ const (
 
 // ParseEd25519AddressFromHexString parses the given hex string into an Ed25519Address.
 func ParseEd25519AddressFromHexString(hexAddr string) (*Ed25519Address, error) {
-	addrBytes, err := hex.DecodeString(hexAddr)
+	addrBytes, err := DecodeHex(hexAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +80,7 @@ func (edAddr *Ed25519Address) Bech32(hrp NetworkPrefix) string {
 }
 
 func (edAddr *Ed25519Address) String() string {
-	return hex.EncodeToString(edAddr[:])
+	return EncodeHex(edAddr[:])
 }
 
 func (edAddr *Ed25519Address) Deserialize(data []byte, deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) (int, error) {
@@ -110,7 +109,7 @@ func (edAddr *Ed25519Address) Size() int {
 
 func (edAddr *Ed25519Address) MarshalJSON() ([]byte, error) {
 	jEd25519Address := &jsonEd25519Address{}
-	jEd25519Address.PubKeyHash = hex.EncodeToString(edAddr[:])
+	jEd25519Address.PubKeyHash = EncodeHex(edAddr[:])
 	jEd25519Address.Type = int(AddressEd25519)
 	return json.Marshal(jEd25519Address)
 }
@@ -140,7 +139,7 @@ type jsonEd25519Address struct {
 }
 
 func (j *jsonEd25519Address) ToSerializable() (serializer.Serializable, error) {
-	addrBytes, err := hex.DecodeString(j.PubKeyHash)
+	addrBytes, err := DecodeHex(j.PubKeyHash)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode address from JSON for Ed25519 address: %w", err)
 	}

--- a/address_nft.go
+++ b/address_nft.go
@@ -1,7 +1,6 @@
 package iotago
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -22,7 +21,7 @@ var (
 
 // ParseNFTAddressFromHexString parses the given hex string into an NFTAddress.
 func ParseNFTAddressFromHexString(hexAddr string) (*NFTAddress, error) {
-	addrBytes, err := hex.DecodeString(hexAddr)
+	addrBytes, err := DecodeHex(hexAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +83,7 @@ func (nftAddr *NFTAddress) Bech32(hrp NetworkPrefix) string {
 }
 
 func (nftAddr *NFTAddress) String() string {
-	return hex.EncodeToString(nftAddr[:])
+	return EncodeHex(nftAddr[:])
 }
 
 func (nftAddr *NFTAddress) Deserialize(data []byte, deSeriMode serializer.DeSerializationMode, deSeriCtx interface{}) (int, error) {
@@ -113,7 +112,7 @@ func (nftAddr *NFTAddress) Size() int {
 
 func (nftAddr *NFTAddress) MarshalJSON() ([]byte, error) {
 	jNFTAddress := &jsonNFTAddress{}
-	jNFTAddress.NFTId = hex.EncodeToString(nftAddr[:])
+	jNFTAddress.NFTId = EncodeHex(nftAddr[:])
 	jNFTAddress.Type = int(AddressNFT)
 	return json.Marshal(jNFTAddress)
 }
@@ -150,7 +149,7 @@ type jsonNFTAddress struct {
 }
 
 func (j *jsonNFTAddress) ToSerializable() (serializer.Serializable, error) {
-	addrBytes, err := hex.DecodeString(j.NFTId)
+	addrBytes, err := DecodeHex(j.NFTId)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode address from JSON for NFT address: %w", err)
 	}

--- a/feat_block_metadata.go
+++ b/feat_block_metadata.go
@@ -2,7 +2,6 @@ package iotago
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -92,7 +91,7 @@ func (s *MetadataFeatureBlock) Size() int {
 func (s *MetadataFeatureBlock) MarshalJSON() ([]byte, error) {
 	jMetadataFeatBlock := &jsonMetadataFeatureBlock{}
 	jMetadataFeatBlock.Type = int(FeatureBlockMetadata)
-	jMetadataFeatBlock.Data = hex.EncodeToString(s.Data)
+	jMetadataFeatBlock.Data = EncodeHex(s.Data)
 	return json.Marshal(jMetadataFeatBlock)
 }
 
@@ -116,7 +115,7 @@ type jsonMetadataFeatureBlock struct {
 }
 
 func (j *jsonMetadataFeatureBlock) ToSerializable() (serializer.Serializable, error) {
-	dataBytes, err := hex.DecodeString(j.Data)
+	dataBytes, err := DecodeHex(j.Data)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode data from JSON for metadata feature block: %w", err)
 	}

--- a/feat_block_tag.go
+++ b/feat_block_tag.go
@@ -2,7 +2,6 @@ package iotago
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -94,7 +93,7 @@ func (s *TagFeatureBlock) Size() int {
 func (s *TagFeatureBlock) MarshalJSON() ([]byte, error) {
 	jTagFeatBlock := &jsonTagFeatureBlock{}
 	jTagFeatBlock.Type = int(FeatureBlockTag)
-	jTagFeatBlock.Tag = hex.EncodeToString(s.Tag)
+	jTagFeatBlock.Tag = EncodeHex(s.Tag)
 	return json.Marshal(jTagFeatBlock)
 }
 
@@ -118,7 +117,7 @@ type jsonTagFeatureBlock struct {
 }
 
 func (j *jsonTagFeatureBlock) ToSerializable() (serializer.Serializable, error) {
-	dataBytes, err := hex.DecodeString(j.Tag)
+	dataBytes, err := DecodeHex(j.Tag)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode tag from JSON for tag feature block: %w", err)
 	}

--- a/hex.go
+++ b/hex.go
@@ -1,0 +1,22 @@
+package iotago
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// EncodeHex encodes the bytes string to a hex string. It always adds the 0x prefix.
+func EncodeHex(b []byte) string {
+	return hexutil.Encode(b)
+}
+
+// DecodeHex decodes the given hex string to bytes. It expects the 0x prefix.
+func DecodeHex(s string) ([]byte, error) {
+	b, err := hexutil.Decode(s)
+	if err != nil {
+		if err == hexutil.ErrEmptyString {
+			return []byte{}, nil
+		}
+		return nil, err
+	}
+	return b, nil
+}

--- a/input_treasury.go
+++ b/input_treasury.go
@@ -1,7 +1,6 @@
 package iotago
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -51,7 +50,7 @@ func (ti *TreasuryInput) Size() int {
 func (ti *TreasuryInput) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&jsonTreasuryInput{
 		Type:        int(InputTreasury),
-		MilestoneID: hex.EncodeToString(ti[:]),
+		MilestoneID: EncodeHex(ti[:]),
 	})
 }
 
@@ -75,7 +74,7 @@ type jsonTreasuryInput struct {
 }
 
 func (j *jsonTreasuryInput) ToSerializable() (serializer.Serializable, error) {
-	msHash, err := hex.DecodeString(j.MilestoneID)
+	msHash, err := DecodeHex(j.MilestoneID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode milestone hash from JSON for treasury input: %w", err)
 	}

--- a/input_utxo.go
+++ b/input_utxo.go
@@ -2,7 +2,6 @@ package iotago
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -106,7 +105,7 @@ func (u *UTXOInput) Size() int {
 
 func (u *UTXOInput) MarshalJSON() ([]byte, error) {
 	jUTXOInput := &jsonUTXOInput{}
-	jUTXOInput.TransactionID = hex.EncodeToString(u.TransactionID[:])
+	jUTXOInput.TransactionID = EncodeHex(u.TransactionID[:])
 	jUTXOInput.TransactionOutputIndex = int(u.TransactionOutputIndex)
 	jUTXOInput.Type = int(InputUTXO)
 	return json.Marshal(jUTXOInput)
@@ -137,7 +136,7 @@ func (j *jsonUTXOInput) ToSerializable() (serializer.Serializable, error) {
 		TransactionID:          [32]byte{},
 		TransactionOutputIndex: uint16(j.TransactionOutputIndex),
 	}
-	transactionIDBytes, err := hex.DecodeString(j.TransactionID)
+	transactionIDBytes, err := DecodeHex(j.TransactionID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode transaction ID from JSON for UTXO input: %w", err)
 	}

--- a/message.go
+++ b/message.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/iotaledger/hive.go/serializer/v2"
 	"github.com/iotaledger/iota.go/v3/pow"
@@ -210,7 +209,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	for i, parent := range m.Parents {
 		jMessage.Parents[i] = EncodeHex(parent[:])
 	}
-	jMessage.Nonce = strconv.FormatUint(m.Nonce, 10)
+	jMessage.Nonce = EncodeUint64(m.Nonce)
 	if m.Payload != nil {
 		jsonPayload, err := m.Payload.MarshalJSON()
 		if err != nil {
@@ -255,7 +254,7 @@ func (jm *jsonMessage) ToSerializable() (serializer.Serializable, error) {
 
 	var parsedNonce uint64
 	if len(jm.Nonce) != 0 {
-		parsedNonce, err = strconv.ParseUint(jm.Nonce, 10, 64)
+		parsedNonce, err = DecodeUint64(jm.Nonce)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse message nonce from JSON: %w", err)
 		}

--- a/message.go
+++ b/message.go
@@ -1,7 +1,6 @@
 package iotago
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -79,7 +78,7 @@ type MessageIDs = []MessageID
 // MessageIDFromHexString converts the given message IDs from their hex
 // to MessageID representation.
 func MessageIDFromHexString(messageIDHex string) (MessageID, error) {
-	messageIDBytes, err := hex.DecodeString(messageIDHex)
+	messageIDBytes, err := DecodeHex(messageIDHex)
 	if err != nil {
 		return MessageID{}, err
 	}
@@ -92,7 +91,7 @@ func MessageIDFromHexString(messageIDHex string) (MessageID, error) {
 
 // MessageIDToHexString converts the given message ID to their hex representation.
 func MessageIDToHexString(msgID MessageID) string {
-	return hex.EncodeToString(msgID[:])
+	return EncodeHex(msgID[:])
 }
 
 // MustMessageIDFromHexString converts the given message IDs from their hex
@@ -209,7 +208,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	}
 	jMessage.Parents = make([]string, len(m.Parents))
 	for i, parent := range m.Parents {
-		jMessage.Parents[i] = hex.EncodeToString(parent[:])
+		jMessage.Parents[i] = EncodeHex(parent[:])
 	}
 	jMessage.Nonce = strconv.FormatUint(m.Nonce, 10)
 	if m.Payload != nil {
@@ -265,7 +264,7 @@ func (jm *jsonMessage) ToSerializable() (serializer.Serializable, error) {
 
 	m.Parents = make(MessageIDs, len(jm.Parents))
 	for i, jparent := range jm.Parents {
-		parentBytes, err := hex.DecodeString(jparent)
+		parentBytes, err := DecodeHex(jparent)
 		if err != nil {
 			return nil, fmt.Errorf("unable to decode hex parent %d from JSON: %w", i+1, err)
 		}

--- a/message_test.go
+++ b/message_test.go
@@ -63,7 +63,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 					"type": 0,
 					"address": "0x5f24ebcb5d48acbbfe6e7401b502ba7bb93acb3591d55eda7d32c37306cc805f"
 				  },
-				  "amount": 5710
+				  "amount": "5710"
 				}
 			  ],
 			  "payload": {

--- a/message_test.go
+++ b/message_test.go
@@ -43,7 +43,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 	data := `
 		{
 		  "protocolVersion": 1,
-		  "parentMessageIds": ["f532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d", "78d546b46aec4557872139a48f66bc567687e8413578a14323548732358914a2"],
+		  "parentMessageIds": ["0xf532a53545103276b46876c473846d98648ee418468bce76df4868648dd73e5d", "0x78d546b46aec4557872139a48f66bc567687e8413578a14323548732358914a2"],
 		  "payload": {
 			"type": 0,
 			"essence": {
@@ -52,7 +52,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 			  "inputs": [
 				{
 				  "type": 0,
-				  "transactionId": "162863a2f4b134d352a886bf9cfb08788735499694864753ee686e02b3763d9d",
+				  "transactionId": "0x162863a2f4b134d352a886bf9cfb08788735499694864753ee686e02b3763d9d",
 				  "transactionOutputIndex": 3
 				}
 			  ],
@@ -61,15 +61,15 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 				  "type": 3,
 				  "address": {
 					"type": 0,
-					"address": "5f24ebcb5d48acbbfe6e7401b502ba7bb93acb3591d55eda7d32c37306cc805f"
+					"address": "0x5f24ebcb5d48acbbfe6e7401b502ba7bb93acb3591d55eda7d32c37306cc805f"
 				  },
 				  "amount": 5710
 				}
 			  ],
 			  "payload": {
 				"type": 5,
-				"tag": "616c6c796f7572747269747362656c6f6e67746f7573",
-				"data": "a487f431d852b060b49427f513dca1d5288e697e8bd9eb062534d09e7cb337ac"
+				"tag": "0x616c6c796f7572747269747362656c6f6e67746f7573",
+				"data": "0xa487f431d852b060b49427f513dca1d5288e697e8bd9eb062534d09e7cb337ac"
 			  }
 			},
 			"unlockBlocks": [
@@ -77,8 +77,8 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 				"type": 0,
 				"signature": {
 				  "type": 0,
-				  "publicKey": "ed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c",
-				  "signature": "651941eddb3e68cb1f6ef4ef5b04625dcf5c70de1fdc4b1c9eadb2c219c074e0ed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c"
+				  "publicKey": "0xed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c",
+				  "signature": "0x651941eddb3e68cb1f6ef4ef5b04625dcf5c70de1fdc4b1c9eadb2c219c074e0ed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c"
 				}
 			  }
 			]
@@ -104,7 +104,7 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 
 	minimal := `
 		{
-		  "parentMessageIds": ["0000000000000000000000000000000000000000000000000000000000000000", "0000000000000000000000000000000000000000000000000000000000000000"],
+		  "parentMessageIds": ["0x0000000000000000000000000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000000000000000000000000"],
 		  "payload": null
 		}`
 	msgMinimal := &iotago.Message{}

--- a/migrated_funds_entry.go
+++ b/migrated_funds_entry.go
@@ -1,7 +1,6 @@
 package iotago
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -81,7 +80,7 @@ func (m *MigratedFundsEntry) Serialize(deSeriMode serializer.DeSerializationMode
 
 func (m *MigratedFundsEntry) MarshalJSON() ([]byte, error) {
 	jMigratedFundsEntry := &jsonMigratedFundsEntry{}
-	jMigratedFundsEntry.TailTransactionHash = hex.EncodeToString(m.TailTransactionHash[:])
+	jMigratedFundsEntry.TailTransactionHash = EncodeHex(m.TailTransactionHash[:])
 	addrJsonBytes, err := m.Address.MarshalJSON()
 	if err != nil {
 		return nil, err
@@ -115,7 +114,7 @@ type jsonMigratedFundsEntry struct {
 
 func (j *jsonMigratedFundsEntry) ToSerializable() (serializer.Serializable, error) {
 	payload := &MigratedFundsEntry{}
-	tailTransactionHash, err := hex.DecodeString(j.TailTransactionHash)
+	tailTransactionHash, err := DecodeHex(j.TailTransactionHash)
 	if err != nil {
 		return nil, fmt.Errorf("can't decode tail transaction hash for migrated funds entry from JSON: %w", err)
 	}

--- a/native_token.go
+++ b/native_token.go
@@ -2,7 +2,6 @@ package iotago
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -66,7 +65,7 @@ func NativeTokenArrayRules() serializer.ArrayRules {
 type NativeTokenID [NativeTokenIDLength]byte
 
 func (ntID NativeTokenID) String() string {
-	return hex.EncodeToString(ntID[:])
+	return EncodeHex(ntID[:])
 }
 
 // FoundryID returns the FoundryID to which this NativeTokenID belongs to.
@@ -260,7 +259,7 @@ func (n *NativeToken) Size() int {
 
 func (n *NativeToken) MarshalJSON() ([]byte, error) {
 	jNativeToken := &jsonNativeToken{}
-	jNativeToken.ID = hex.EncodeToString(n.ID[:])
+	jNativeToken.ID = EncodeHex(n.ID[:])
 	jNativeToken.Amount = n.Amount.String()
 	return json.Marshal(jNativeToken)
 }
@@ -299,7 +298,7 @@ type jsonNativeToken struct {
 func (j *jsonNativeToken) ToSerializable() (serializer.Serializable, error) {
 	n := &NativeToken{}
 
-	nftIDBytes, err := hex.DecodeString(j.ID)
+	nftIDBytes, err := DecodeHex(j.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/nodeclient/core_models.go
+++ b/nodeclient/core_models.go
@@ -1,7 +1,6 @@
 package nodeclient
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -231,7 +230,7 @@ type (
 
 // TxID returns the TransactionID.
 func (nor *OutputResponse) TxID() (*iotago.TransactionID, error) {
-	txIDBytes, err := hex.DecodeString(nor.TransactionID)
+	txIDBytes, err := iotago.DecodeHex(nor.TransactionID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode raw transaction ID from JSON to transaction ID: %w", err)
 	}

--- a/nodeclient/core_models.go
+++ b/nodeclient/core_models.go
@@ -115,7 +115,7 @@ type (
 	// TreasuryResponse defines the response of a GET treasury REST API call.
 	TreasuryResponse struct {
 		MilestoneID string `json:"milestoneId"`
-		Amount      uint64 `json:"amount"`
+		Amount      string `json:"amount"`
 	}
 
 	// ReceiptsResponse defines the response for receipts GET related REST API calls.

--- a/nodeclient/http_api_client.go
+++ b/nodeclient/http_api_client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/iotaledger/hive.go/serializer/v2"
 	iotago "github.com/iotaledger/iota.go/v3"
@@ -345,7 +344,7 @@ func (client *Client) Receipts(ctx context.Context) ([]*ReceiptTuple, error) {
 
 // ReceiptsByMigratedAtIndex gets all receipts for the given migrated at index persisted on the node.
 func (client *Client) ReceiptsByMigratedAtIndex(ctx context.Context, index uint32) ([]*ReceiptTuple, error) {
-	query := fmt.Sprintf(NodeAPIRouteReceiptsByMigratedAtIndex, strconv.FormatUint(uint64(index), 10))
+	query := fmt.Sprintf(NodeAPIRouteReceiptsByMigratedAtIndex, iotago.EncodeUint64(uint64(index)))
 
 	res := &ReceiptsResponse{}
 	_, err := do(client.opts.httpClient, client.BaseURL, ctx, client.opts.userInfo, http.MethodGet, query, nil, res)
@@ -358,7 +357,7 @@ func (client *Client) ReceiptsByMigratedAtIndex(ctx context.Context, index uint3
 
 // MilestoneByIndex gets a milestone by its index.
 func (client *Client) MilestoneByIndex(ctx context.Context, index uint32) (*MilestoneResponse, error) {
-	query := fmt.Sprintf(NodeAPIRouteMilestone, strconv.FormatUint(uint64(index), 10))
+	query := fmt.Sprintf(NodeAPIRouteMilestone, iotago.EncodeUint64(uint64(index)))
 
 	res := &MilestoneResponse{}
 	_, err := do(client.opts.httpClient, client.BaseURL, ctx, client.opts.userInfo, http.MethodGet, query, nil, res)
@@ -371,7 +370,7 @@ func (client *Client) MilestoneByIndex(ctx context.Context, index uint32) (*Mile
 
 // MilestoneUTXOChangesByIndex returns all UTXO changes of a milestone by its milestoneIndex.
 func (client *Client) MilestoneUTXOChangesByIndex(ctx context.Context, index uint32) (*MilestoneUTXOChangesResponse, error) {
-	query := fmt.Sprintf(NodeAPIRouteMilestoneUTXOChanges, strconv.FormatUint(uint64(index), 10))
+	query := fmt.Sprintf(NodeAPIRouteMilestoneUTXOChanges, iotago.EncodeUint64(uint64(index)))
 
 	res := &MilestoneUTXOChangesResponse{}
 	_, err := do(client.opts.httpClient, client.BaseURL, ctx, client.opts.userInfo, http.MethodGet, query, nil, res)

--- a/nodeclient/http_api_client.go
+++ b/nodeclient/http_api_client.go
@@ -2,7 +2,6 @@ package nodeclient
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -217,7 +216,7 @@ type NodeTipsResponse struct {
 func (ntr *NodeTipsResponse) Tips() (iotago.MessageIDs, error) {
 	msgIDs := make(iotago.MessageIDs, len(ntr.TipsHex))
 	for i, tip := range ntr.TipsHex {
-		msgID, err := hex.DecodeString(tip)
+		msgID, err := iotago.DecodeHex(tip)
 		if err != nil {
 			return nil, err
 		}
@@ -269,7 +268,7 @@ func (client *Client) SubmitMessage(ctx context.Context, m *iotago.Message) (*io
 
 // MessageMetadataByMessageID gets the metadata of a message by its message ID from the node.
 func (client *Client) MessageMetadataByMessageID(ctx context.Context, msgID iotago.MessageID) (*MessageMetadataResponse, error) {
-	query := fmt.Sprintf(NodeAPIRouteMessageMetadata, hex.EncodeToString(msgID[:]))
+	query := fmt.Sprintf(NodeAPIRouteMessageMetadata, iotago.EncodeHex(msgID[:]))
 
 	res := &MessageMetadataResponse{}
 	_, err := do(client.opts.httpClient, client.BaseURL, ctx, client.opts.userInfo, http.MethodGet, query, nil, res)
@@ -282,7 +281,7 @@ func (client *Client) MessageMetadataByMessageID(ctx context.Context, msgID iota
 
 // MessageByMessageID get a message by its message ID from the node.
 func (client *Client) MessageByMessageID(ctx context.Context, msgID iotago.MessageID) (*iotago.Message, error) {
-	query := fmt.Sprintf(NodeAPIRouteMessageBytes, hex.EncodeToString(msgID[:]))
+	query := fmt.Sprintf(NodeAPIRouteMessageBytes, iotago.EncodeHex(msgID[:]))
 
 	res := &RawDataEnvelope{}
 	_, err := do(client.opts.httpClient, client.BaseURL, ctx, client.opts.userInfo, http.MethodGet, query, nil, res)
@@ -299,7 +298,7 @@ func (client *Client) MessageByMessageID(ctx context.Context, msgID iotago.Messa
 
 // ChildrenByMessageID gets the MessageIDs of the child messages of a given message.
 func (client *Client) ChildrenByMessageID(ctx context.Context, parentMsgID iotago.MessageID) (*ChildrenResponse, error) {
-	query := fmt.Sprintf(NodeAPIRouteMessageChildren, hex.EncodeToString(parentMsgID[:]))
+	query := fmt.Sprintf(NodeAPIRouteMessageChildren, iotago.EncodeHex(parentMsgID[:]))
 
 	res := &ChildrenResponse{}
 	_, err := do(client.opts.httpClient, client.BaseURL, ctx, client.opts.userInfo, http.MethodGet, query, nil, res)

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -283,7 +283,7 @@ func TestNodeHTTPAPIClient_Treasury(t *testing.T) {
 
 	originRes := &nodeclient.TreasuryResponse{
 		MilestoneID: "733ed2810f2333e9d6cd702c7d5c8264cd9f1ae454b61e75cf702c451f68611d",
-		Amount:      133713371337,
+		Amount:      "133713371337",
 	}
 
 	gock.New(nodeAPIUrl).
@@ -363,7 +363,7 @@ func TestNodeHTTPAPIClient_ReceiptsByMigratedAtIndex(t *testing.T) {
 	}
 
 	gock.New(nodeAPIUrl).
-		Get(fmt.Sprintf(nodeclient.NodeAPIRouteReceiptsByMigratedAtIndex, strconv.FormatUint(uint64(index), 10))).
+		Get(fmt.Sprintf(nodeclient.NodeAPIRouteReceiptsByMigratedAtIndex, iotago.EncodeUint64(uint64(index)))).
 		Reply(200).
 		JSON(originRes)
 

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -3,7 +3,6 @@ package nodeclient_test
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -109,7 +108,7 @@ func TestClient_SubmitMessage(t *testing.T) {
 	defer gock.Off()
 
 	msgHash := tpkg.Rand32ByteArray()
-	msgHashStr := hex.EncodeToString(msgHash[:])
+	msgHashStr := iotago.EncodeHex(msgHash[:])
 
 	incompleteMsg := &iotago.Message{
 		Parents: tpkg.SortedRand32BytArray(1),
@@ -155,11 +154,11 @@ func TestClient_MessageMetadataByMessageID(t *testing.T) {
 	identifier := tpkg.Rand32ByteArray()
 	parents := tpkg.SortedRand32BytArray(1 + rand.Intn(7))
 
-	queryHash := hex.EncodeToString(identifier[:])
+	queryHash := iotago.EncodeHex(identifier[:])
 
 	parentMessageIDs := make([]string, len(parents))
 	for i, p := range parents {
-		parentMessageIDs[i] = hex.EncodeToString(p[:])
+		parentMessageIDs[i] = iotago.EncodeHex(p[:])
 	}
 
 	originRes := &nodeclient.MessageMetadataResponse{
@@ -189,7 +188,7 @@ func TestClient_MessageByMessageID(t *testing.T) {
 	defer gock.Off()
 
 	identifier := tpkg.Rand32ByteArray()
-	queryHash := hex.EncodeToString(identifier[:])
+	queryHash := iotago.EncodeHex(identifier[:])
 
 	originMsg := &iotago.Message{
 		Parents: tpkg.SortedRand32BytArray(1 + rand.Intn(7)),
@@ -215,7 +214,7 @@ func TestClient_ChildrenByMessageID(t *testing.T) {
 	defer gock.Off()
 
 	msgID := tpkg.Rand32ByteArray()
-	hexMsgID := hex.EncodeToString(msgID[:])
+	hexMsgID := iotago.EncodeHex(msgID[:])
 
 	child1 := tpkg.Rand32ByteArray()
 	child2 := tpkg.Rand32ByteArray()
@@ -226,9 +225,9 @@ func TestClient_ChildrenByMessageID(t *testing.T) {
 		MaxResults: 1000,
 		Count:      3,
 		Children: []string{
-			hex.EncodeToString(child1[:]),
-			hex.EncodeToString(child2[:]),
-			hex.EncodeToString(child3[:]),
+			iotago.EncodeHex(child1[:]),
+			iotago.EncodeHex(child2[:]),
+			iotago.EncodeHex(child3[:]),
 		},
 	}
 
@@ -252,7 +251,7 @@ func TestClient_OutputByID(t *testing.T) {
 	rawMsgSigDepJson := json.RawMessage(sigDepJson)
 
 	txID := tpkg.Rand32ByteArray()
-	hexTxID := hex.EncodeToString(txID[:])
+	hexTxID := iotago.EncodeHex(txID[:])
 	originRes := &nodeclient.OutputResponse{
 		TransactionID: hexTxID,
 		OutputIndex:   3,
@@ -383,7 +382,7 @@ func TestClient_MilestoneByIndex(t *testing.T) {
 
 	originRes := &nodeclient.MilestoneResponse{
 		Index:     milestoneIndex,
-		MessageID: hex.EncodeToString(msgID[:]),
+		MessageID: iotago.EncodeHex(msgID[:]),
 		Time:      time.Now().Unix(),
 	}
 

--- a/nodeclient/indexer_client.go
+++ b/nodeclient/indexer_client.go
@@ -2,7 +2,6 @@ package nodeclient
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -159,7 +158,7 @@ func (client *indexerClient) singleOutputQuery(ctx context.Context, route string
 }
 
 func (client *indexerClient) Alias(ctx context.Context, aliasID iotago.AliasID) (*iotago.AliasOutput, error) {
-	output, err := client.singleOutputQuery(ctx, fmt.Sprintf(IndexerAPIRouteAlias, hex.EncodeToString(aliasID[:])))
+	output, err := client.singleOutputQuery(ctx, fmt.Sprintf(IndexerAPIRouteAlias, iotago.EncodeHex(aliasID[:])))
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +166,7 @@ func (client *indexerClient) Alias(ctx context.Context, aliasID iotago.AliasID) 
 }
 
 func (client *indexerClient) Foundry(ctx context.Context, foundryID iotago.FoundryID) (*iotago.FoundryOutput, error) {
-	output, err := client.singleOutputQuery(ctx, fmt.Sprintf(IndexerAPIRouteFoundry, hex.EncodeToString(foundryID[:])))
+	output, err := client.singleOutputQuery(ctx, fmt.Sprintf(IndexerAPIRouteFoundry, iotago.EncodeHex(foundryID[:])))
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +174,7 @@ func (client *indexerClient) Foundry(ctx context.Context, foundryID iotago.Found
 }
 
 func (client *indexerClient) NFT(ctx context.Context, nftID iotago.NFTID) (*iotago.NFTOutput, error) {
-	output, err := client.singleOutputQuery(ctx, fmt.Sprintf(IndexerAPIRouteNFT, hex.EncodeToString(nftID[:])))
+	output, err := client.singleOutputQuery(ctx, fmt.Sprintf(IndexerAPIRouteNFT, iotago.EncodeHex(nftID[:])))
 	if err != nil {
 		return nil, err
 	}

--- a/nodeclient/indexer_client_test.go
+++ b/nodeclient/indexer_client_test.go
@@ -2,7 +2,6 @@ package nodeclient_test
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -65,7 +64,7 @@ func TestIndexerClient_Outputs(t *testing.T) {
 
 	txID := tpkg.Rand32ByteArray()
 	fakeOutputID := iotago.OutputIDFromTransactionIDAndIndex(txID, 1).ToHex()
-	hexTxID := hex.EncodeToString(txID[:])
+	hexTxID := iotago.EncodeHex(txID[:])
 
 	outputRes := &nodeclient.OutputResponse{
 		TransactionID: hexTxID,

--- a/numbers.go
+++ b/numbers.go
@@ -2,6 +2,7 @@ package iotago
 
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"strconv"
 )
 
 // EncodeHex encodes the bytes string to a hex string. It always adds the 0x prefix.
@@ -19,4 +20,14 @@ func DecodeHex(s string) ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+// EncodeUint64 encodes the uint64 to a base 10 string.
+func EncodeUint64(n uint64) string {
+	return strconv.FormatUint(n, 10)
+}
+
+// DecodeUint64 encodes the base 10 string to an uint64.
+func DecodeUint64(s string) (uint64, error) {
+	return strconv.ParseUint(s, 10, 64)
 }

--- a/output.go
+++ b/output.go
@@ -2,7 +2,6 @@ package iotago
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -38,7 +37,7 @@ type OutputID [OutputIDLength]byte
 
 // ToHex converts the OutputID to its hex representation.
 func (outputID OutputID) ToHex() string {
-	return fmt.Sprintf("%x", outputID)
+	return EncodeHex(outputID[:])
 }
 
 // Index returns the index of the Output this OutputID references.
@@ -77,7 +76,7 @@ func (ids HexOutputIDs) MustOutputIDs() OutputIDs {
 func (ids HexOutputIDs) OutputIDs() (OutputIDs, error) {
 	vals := make(OutputIDs, len(ids))
 	for i, v := range ids {
-		val, err := hex.DecodeString(v)
+		val, err := DecodeHex(v)
 		if err != nil {
 			return nil, err
 		}
@@ -96,7 +95,7 @@ func OutputIDFromTransactionIDAndIndex(txID TransactionID, index uint16) OutputI
 // OutputIDFromHex creates a OutputID from the given hex encoded OututID data.
 func OutputIDFromHex(hexStr string) (OutputID, error) {
 	var outputID OutputID
-	outputIDData, err := hex.DecodeString(hexStr)
+	outputIDData, err := DecodeHex(hexStr)
 	if err != nil {
 		return outputID, err
 	}
@@ -107,7 +106,7 @@ func OutputIDFromHex(hexStr string) (OutputID, error) {
 // MustOutputIDFromHex works like OutputIDFromHex but panics if an error is encountered.
 func MustOutputIDFromHex(hexStr string) (OutputID, error) {
 	var outputID OutputID
-	outputIDData, err := hex.DecodeString(hexStr)
+	outputIDData, err := DecodeHex(hexStr)
 	if err != nil {
 		return outputID, err
 	}
@@ -136,7 +135,7 @@ type OutputIDs []OutputID
 func (outputIDs OutputIDs) ToHex() []string {
 	ids := make([]string, len(outputIDs))
 	for i := range outputIDs {
-		ids[i] = fmt.Sprintf("%x", outputIDs[i])
+		ids[i] = EncodeHex(outputIDs[i][:])
 	}
 	return ids
 }
@@ -626,7 +625,7 @@ func (oih OutputIDHex) MustSplitParts() (*TransactionID, uint16) {
 
 // SplitParts returns the transaction ID and output index parts of the hex output ID.
 func (oih OutputIDHex) SplitParts() (*TransactionID, uint16, error) {
-	outputIDBytes, err := hex.DecodeString(string(oih))
+	outputIDBytes, err := DecodeHex(string(oih))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/output_alias.go
+++ b/output_alias.go
@@ -2,7 +2,6 @@ package iotago
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -148,7 +147,7 @@ func (id AliasID) Empty() bool {
 }
 
 func (id AliasID) String() string {
-	return hex.EncodeToString(id[:])
+	return EncodeHex(id[:])
 }
 
 func (id AliasID) Matches(other ChainID) bool {
@@ -551,9 +550,9 @@ func (a *AliasOutput) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	jAliasOutput.AliasID = hex.EncodeToString(a.AliasID[:])
+	jAliasOutput.AliasID = EncodeHex(a.AliasID[:])
 
-	jAliasOutput.StateMetadata = hex.EncodeToString(a.StateMetadata)
+	jAliasOutput.StateMetadata = EncodeHex(a.StateMetadata)
 
 	jAliasOutput.Conditions, err = serializablesToJSONRawMsgs(a.Conditions.ToSerializables())
 	if err != nil {
@@ -613,13 +612,13 @@ func (j *jsonAliasOutput) ToSerializable() (serializer.Serializable, error) {
 		return nil, err
 	}
 
-	aliasIDSlice, err := hex.DecodeString(j.AliasID)
+	aliasIDSlice, err := DecodeHex(j.AliasID)
 	if err != nil {
 		return nil, err
 	}
 	copy(e.AliasID[:], aliasIDSlice)
 
-	e.StateMetadata, err = hex.DecodeString(j.StateMetadata)
+	e.StateMetadata, err = DecodeHex(j.StateMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/output_alias.go
+++ b/output_alias.go
@@ -540,7 +540,7 @@ func (a *AliasOutput) MarshalJSON() ([]byte, error) {
 	var err error
 	jAliasOutput := &jsonAliasOutput{
 		Type:           int(OutputAlias),
-		Amount:         int(a.Amount),
+		Amount:         EncodeUint64(a.Amount),
 		StateIndex:     int(a.StateIndex),
 		FoundryCounter: int(a.FoundryCounter),
 	}
@@ -588,7 +588,7 @@ func (a *AliasOutput) UnmarshalJSON(bytes []byte) error {
 // jsonAliasOutput defines the json representation of an AliasOutput.
 type jsonAliasOutput struct {
 	Type            int                `json:"type"`
-	Amount          int                `json:"amount"`
+	Amount          string             `json:"amount"`
 	NativeTokens    []*json.RawMessage `json:"nativeTokens"`
 	AliasID         string             `json:"aliasId"`
 	StateIndex      int                `json:"stateIndex"`
@@ -602,9 +602,13 @@ type jsonAliasOutput struct {
 func (j *jsonAliasOutput) ToSerializable() (serializer.Serializable, error) {
 	var err error
 	e := &AliasOutput{
-		Amount:         uint64(j.Amount),
 		StateIndex:     uint32(j.StateIndex),
 		FoundryCounter: uint32(j.FoundryCounter),
+	}
+
+	e.Amount, err = DecodeUint64(j.Amount)
+	if err != nil {
+		return nil, err
 	}
 
 	e.NativeTokens, err = nativeTokensFromJSONRawMsg(j.NativeTokens)

--- a/output_basic.go
+++ b/output_basic.go
@@ -198,7 +198,7 @@ func (e *BasicOutput) MarshalJSON() ([]byte, error) {
 	var err error
 	jExtendedOutput := &jsonExtendedOutput{
 		Type:   int(OutputBasic),
-		Amount: int(e.Amount),
+		Amount: EncodeUint64(e.Amount),
 	}
 
 	jExtendedOutput.NativeTokens, err = serializablesToJSONRawMsgs(e.NativeTokens.ToSerializables())
@@ -235,7 +235,7 @@ func (e *BasicOutput) UnmarshalJSON(bytes []byte) error {
 // jsonExtendedOutput defines the json representation of a BasicOutput.
 type jsonExtendedOutput struct {
 	Type         int                `json:"type"`
-	Amount       int                `json:"amount"`
+	Amount       string             `json:"amount"`
 	NativeTokens []*json.RawMessage `json:"nativeTokens"`
 	Conditions   []*json.RawMessage `json:"unlockConditions"`
 	Blocks       []*json.RawMessage `json:"featureBlocks"`
@@ -243,8 +243,11 @@ type jsonExtendedOutput struct {
 
 func (j *jsonExtendedOutput) ToSerializable() (serializer.Serializable, error) {
 	var err error
-	e := &BasicOutput{
-		Amount: uint64(j.Amount),
+	e := &BasicOutput{}
+
+	e.Amount, err = DecodeUint64(j.Amount)
+	if err != nil {
+		return nil, err
 	}
 
 	e.NativeTokens, err = nativeTokensFromJSONRawMsg(j.NativeTokens)

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -504,7 +504,7 @@ func (f *FoundryOutput) MarshalJSON() ([]byte, error) {
 	var err error
 	jFoundryOutput := &jsonFoundryOutput{
 		Type:         int(OutputFoundry),
-		Amount:       int(f.Amount),
+		Amount:       EncodeUint64(f.Amount),
 		SerialNumber: int(f.SerialNumber),
 	}
 
@@ -559,7 +559,7 @@ func (f *FoundryOutput) UnmarshalJSON(bytes []byte) error {
 // jsonFoundryOutput defines the json representation of a FoundryOutput.
 type jsonFoundryOutput struct {
 	Type              int                `json:"type"`
-	Amount            int                `json:"amount"`
+	Amount            string             `json:"amount"`
 	NativeTokens      []*json.RawMessage `json:"nativeTokens"`
 	SerialNumber      int                `json:"serialNumber"`
 	TokenTag          string             `json:"tokenTag"`
@@ -574,8 +574,12 @@ type jsonFoundryOutput struct {
 func (j *jsonFoundryOutput) ToSerializable() (serializer.Serializable, error) {
 	var err error
 	e := &FoundryOutput{
-		Amount:       uint64(j.Amount),
 		SerialNumber: uint32(j.SerialNumber),
+	}
+
+	e.Amount, err = DecodeUint64(j.Amount)
+	if err != nil {
+		return nil, err
 	}
 
 	e.NativeTokens, err = nativeTokensFromJSONRawMsg(j.NativeTokens)

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -2,7 +2,6 @@ package iotago
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -152,7 +151,7 @@ func (fID FoundryID) Key() interface{} {
 }
 
 func (fID FoundryID) String() string {
-	return hex.EncodeToString(fID[:])
+	return EncodeHex(fID[:])
 }
 
 // FoundryOutputs is a slice of FoundryOutput(s).
@@ -514,7 +513,7 @@ func (f *FoundryOutput) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	jFoundryOutput.TokenTag = hex.EncodeToString(f.TokenTag[:])
+	jFoundryOutput.TokenTag = EncodeHex(f.TokenTag[:])
 
 	jFoundryOutput.CirculatingSupply = f.CirculatingSupply.String()
 	jFoundryOutput.MaximumSupply = f.MaximumSupply.String()
@@ -584,7 +583,7 @@ func (j *jsonFoundryOutput) ToSerializable() (serializer.Serializable, error) {
 		return nil, err
 	}
 
-	tokenTagBytes, err := hex.DecodeString(j.TokenTag)
+	tokenTagBytes, err := DecodeHex(j.TokenTag)
 	if err != nil {
 		return nil, err
 	}

--- a/output_nft.go
+++ b/output_nft.go
@@ -1,7 +1,6 @@
 package iotago
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -160,7 +159,7 @@ func (nftID NFTID) ToAddress() ChainConstrainedAddress {
 }
 
 func (nftID NFTID) String() string {
-	return hex.EncodeToString(nftID[:])
+	return EncodeHex(nftID[:])
 }
 
 // NFTOutput is an output type used to implement non-fungible tokens.
@@ -335,7 +334,7 @@ func (n *NFTOutput) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	jNFTOutput.NFTID = hex.EncodeToString(n.NFTID[:])
+	jNFTOutput.NFTID = EncodeHex(n.NFTID[:])
 
 	jNFTOutput.Conditions, err = serializablesToJSONRawMsgs(n.Conditions.ToSerializables())
 	if err != nil {
@@ -390,7 +389,7 @@ func (j *jsonNFTOutput) ToSerializable() (serializer.Serializable, error) {
 		return nil, err
 	}
 
-	nftIDBytes, err := hex.DecodeString(j.NFTID)
+	nftIDBytes, err := DecodeHex(j.NFTID)
 	if err != nil {
 		return nil, err
 	}

--- a/output_nft.go
+++ b/output_nft.go
@@ -326,7 +326,7 @@ func (n *NFTOutput) MarshalJSON() ([]byte, error) {
 	var err error
 	jNFTOutput := &jsonNFTOutput{
 		Type:   int(OutputNFT),
-		Amount: int(n.Amount),
+		Amount: EncodeUint64(n.Amount),
 	}
 
 	jNFTOutput.NativeTokens, err = serializablesToJSONRawMsgs(n.NativeTokens.ToSerializables())
@@ -370,7 +370,7 @@ func (n *NFTOutput) UnmarshalJSON(bytes []byte) error {
 // jsonNFTOutput defines the json representation of a NFTOutput.
 type jsonNFTOutput struct {
 	Type            int                `json:"type"`
-	Amount          int                `json:"amount"`
+	Amount          string             `json:"amount"`
 	NativeTokens    []*json.RawMessage `json:"nativeTokens"`
 	NFTID           string             `json:"nftId"`
 	Conditions      []*json.RawMessage `json:"unlockConditions"`
@@ -380,8 +380,11 @@ type jsonNFTOutput struct {
 
 func (j *jsonNFTOutput) ToSerializable() (serializer.Serializable, error) {
 	var err error
-	e := &NFTOutput{
-		Amount: uint64(j.Amount),
+	e := &NFTOutput{}
+
+	e.Amount, err = DecodeUint64(j.Amount)
+	if err != nil {
+		return nil, err
 	}
 
 	e.NativeTokens, err = nativeTokensFromJSONRawMsg(j.NativeTokens)

--- a/output_treasury.go
+++ b/output_treasury.go
@@ -70,7 +70,7 @@ func (t *TreasuryOutput) Size() int {
 func (t *TreasuryOutput) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&jsonTreasuryOutput{
 		Type:   int(OutputTreasury),
-		Amount: int(t.Amount),
+		Amount: EncodeUint64(t.Amount),
 	})
 }
 
@@ -89,10 +89,16 @@ func (t *TreasuryOutput) UnmarshalJSON(bytes []byte) error {
 
 // jsonTreasuryOutput defines the json representation of a TreasuryOutput.
 type jsonTreasuryOutput struct {
-	Type   int `json:"type"`
-	Amount int `json:"amount"`
+	Type   int    `json:"type"`
+	Amount string `json:"amount"`
 }
 
 func (j *jsonTreasuryOutput) ToSerializable() (serializer.Serializable, error) {
-	return &TreasuryOutput{Amount: uint64(j.Amount)}, nil
+	var err error
+	t := &TreasuryOutput{}
+	t.Amount, err = DecodeUint64(j.Amount)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
 }

--- a/signature_ed25519.go
+++ b/signature_ed25519.go
@@ -3,7 +3,6 @@ package iotago
 import (
 	"bytes"
 	"crypto/ed25519"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -80,8 +79,8 @@ func (e *Ed25519Signature) Size() int {
 func (e *Ed25519Signature) MarshalJSON() ([]byte, error) {
 	jEd25519Signature := &jsonEd25519Signature{}
 	jEd25519Signature.Type = int(SignatureEd25519)
-	jEd25519Signature.PublicKey = hex.EncodeToString(e.PublicKey[:])
-	jEd25519Signature.Signature = hex.EncodeToString(e.Signature[:])
+	jEd25519Signature.PublicKey = EncodeHex(e.PublicKey[:])
+	jEd25519Signature.Signature = EncodeHex(e.Signature[:])
 	return json.Marshal(jEd25519Signature)
 }
 
@@ -108,12 +107,12 @@ type jsonEd25519Signature struct {
 func (j *jsonEd25519Signature) ToSerializable() (serializer.Serializable, error) {
 	sig := &Ed25519Signature{}
 
-	pubKeyBytes, err := hex.DecodeString(j.PublicKey)
+	pubKeyBytes, err := DecodeHex(j.PublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode public key from JSON for Ed25519 signature: %w", err)
 	}
 
-	sigBytes, err := hex.DecodeString(j.Signature)
+	sigBytes, err := DecodeHex(j.Signature)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode signature from JSON for Ed25519 signature: %w", err)
 	}

--- a/tagged_data.go
+++ b/tagged_data.go
@@ -1,7 +1,6 @@
 package iotago
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -95,8 +94,8 @@ func (u *TaggedData) Size() int {
 func (u *TaggedData) MarshalJSON() ([]byte, error) {
 	jTaggedData := &jsonTaggedData{}
 	jTaggedData.Type = int(PayloadTaggedData)
-	jTaggedData.Tag = hex.EncodeToString(u.Tag)
-	jTaggedData.Data = hex.EncodeToString(u.Data)
+	jTaggedData.Tag = EncodeHex(u.Tag)
+	jTaggedData.Data = EncodeHex(u.Data)
 	return json.Marshal(jTaggedData)
 }
 
@@ -121,12 +120,12 @@ type jsonTaggedData struct {
 }
 
 func (j *jsonTaggedData) ToSerializable() (serializer.Serializable, error) {
-	tagBytes, err := hex.DecodeString(j.Tag)
+	tagBytes, err := DecodeHex(j.Tag)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode tag from JSON for tagged data payload: %w", err)
 	}
 
-	dataBytes, err := hex.DecodeString(j.Data)
+	dataBytes, err := DecodeHex(j.Data)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode data from JSON for tagged data payload: %w", err)
 	}

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -1,7 +1,6 @@
 package iotago
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -277,7 +276,7 @@ func (u *TransactionEssence) MarshalJSON() ([]byte, error) {
 	jTransactionEssence := &jsonTransactionEssence{
 		NetworkID:        strconv.FormatUint(u.NetworkID, 10),
 		Inputs:           make([]*json.RawMessage, len(u.Inputs)),
-		InputsCommitment: hex.EncodeToString(u.InputsCommitment[:]),
+		InputsCommitment: EncodeHex(u.InputsCommitment[:]),
 		Outputs:          make([]*json.RawMessage, len(u.Outputs)),
 		Payload:          nil,
 	}
@@ -395,7 +394,7 @@ func (j *jsonTransactionEssence) ToSerializable() (serializer.Serializable, erro
 		unsigTx.Inputs[i] = input.(Input)
 	}
 
-	inputsCommitmentSlice, err := hex.DecodeString(j.InputsCommitment)
+	inputsCommitmentSlice, err := DecodeHex(j.InputsCommitment)
 	if err != nil {
 		return unsigTx, fmt.Errorf("unable to decode JSON inputs commitment: %w", err)
 	}

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/iotaledger/hive.go/serializer/v2"
 	"github.com/iotaledger/iota.go/v3/util"
@@ -274,7 +273,7 @@ func (u *TransactionEssence) Size() int {
 
 func (u *TransactionEssence) MarshalJSON() ([]byte, error) {
 	jTransactionEssence := &jsonTransactionEssence{
-		NetworkID:        strconv.FormatUint(u.NetworkID, 10),
+		NetworkID:        EncodeUint64(u.NetworkID),
 		Inputs:           make([]*json.RawMessage, len(u.Inputs)),
 		InputsCommitment: EncodeHex(u.InputsCommitment[:]),
 		Outputs:          make([]*json.RawMessage, len(u.Outputs)),
@@ -377,7 +376,7 @@ func (j *jsonTransactionEssence) ToSerializable() (serializer.Serializable, erro
 	}
 
 	var err error
-	unsigTx.NetworkID, err = strconv.ParseUint(j.NetworkID, 10, 64)
+	unsigTx.NetworkID, err = DecodeUint64(j.NetworkID)
 	if err != nil {
 		return nil, err
 	}

--- a/unlock_cond_storage_return.go
+++ b/unlock_cond_storage_return.go
@@ -89,7 +89,7 @@ func (s *StorageDepositReturnUnlockCondition) Size() int {
 }
 
 func (s *StorageDepositReturnUnlockCondition) MarshalJSON() ([]byte, error) {
-	jUnlockCond := &jsonStorageDepositReturnUnlockCondition{Amount: int(s.Amount)}
+	jUnlockCond := &jsonStorageDepositReturnUnlockCondition{Amount: EncodeUint64(s.Amount)}
 	jUnlockCond.Type = int(UnlockConditionStorageDepositReturn)
 	var err error
 	jUnlockCond.ReturnAddress, err = addressToJSONRawMsg(s.ReturnAddress)
@@ -116,13 +116,18 @@ func (s *StorageDepositReturnUnlockCondition) UnmarshalJSON(bytes []byte) error 
 type jsonStorageDepositReturnUnlockCondition struct {
 	Type          int              `json:"type"`
 	ReturnAddress *json.RawMessage `json:"returnAddress"`
-	Amount        int              `json:"amount"`
+	Amount        string           `json:"amount"`
 }
 
 func (j *jsonStorageDepositReturnUnlockCondition) ToSerializable() (serializer.Serializable, error) {
-	unlockCond := &StorageDepositReturnUnlockCondition{Amount: uint64(j.Amount)}
-
 	var err error
+	unlockCond := &StorageDepositReturnUnlockCondition{}
+
+	unlockCond.Amount, err = DecodeUint64(j.Amount)
+	if err != nil {
+		return nil, err
+	}
+
 	unlockCond.ReturnAddress, err = addressFromJSONRawMsg(j.ReturnAddress)
 	if err != nil {
 		return nil, err

--- a/x/node_event_api_client.go
+++ b/x/node_event_api_client.go
@@ -2,7 +2,6 @@ package iotagox
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -283,7 +282,7 @@ func (neac *NodeEventAPIClient) TransactionIncludedMessage(txID iotago.Transacti
 func (neac *NodeEventAPIClient) Output(outputID iotago.OutputID) <-chan *nodeclient.OutputResponse {
 	panicIfNodeEventAPIClientInactive(neac)
 	channel := make(chan *nodeclient.OutputResponse)
-	topic := strings.Replace(NodeEventOutputs, "{outputId}", hex.EncodeToString(outputID[:]), 1)
+	topic := strings.Replace(NodeEventOutputs, "{outputId}", iotago.EncodeHex(outputID[:]), 1)
 	neac.MQTTClient.Subscribe(topic, 2, func(client mqtt.Client, mqttMsg mqtt.Message) {
 		res := &nodeclient.OutputResponse{}
 		if err := json.Unmarshal(mqttMsg.Payload(), res); err != nil {


### PR DESCRIPTION
- Centralized the hex string encoding/decoding into 2 public functions (`EncodeHex`, `DecodeHex`)
- Switched from using `encoding/hex` to use the `github.com/ethereum/go-ethereum/common/hexutil` pkg to enforce `0x` prefix usage
- Added helpers to encode/decode uint64 numbers (`EncodeUint64`, `DecodeUint64`)
- Encoding output amount fields as strings now