### PR TITLE
refactor: rename OutputsQuery to BasicOutputsQuery

### DIFF
--- a/nodeclient/indexer_client_test.go
+++ b/nodeclient/indexer_client_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/iotaledger/iota.go/v3"
+	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/iotaledger/iota.go/v3/nodeclient"
 	"github.com/iotaledger/iota.go/v3/tpkg"
 	"github.com/stretchr/testify/require"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestOutputsQuery_Build(t *testing.T) {
-	query := &nodeclient.OutputsQuery{
+	query := &nodeclient.BasicOutputsQuery{
 		IndexerTimelockParas: nodeclient.IndexerTimelockParas{
 			HasTimelockCondition:      true,
 			TimelockedBefore:          1,
@@ -159,7 +159,7 @@ func TestIndexerClient_Outputs(t *testing.T) {
 	indexer, err := client.Indexer(context.TODO())
 	require.NoError(t, err)
 
-	resultSet, err := indexer.Outputs(context.TODO(), &nodeclient.OutputsQuery{Tag: "some-tag"})
+	resultSet, err := indexer.Outputs(context.TODO(), &nodeclient.BasicOutputsQuery{Tag: "some-tag"})
 	require.NoError(t, err)
 
 	var runs int

--- a/nodeclient/indexer_models.go
+++ b/nodeclient/indexer_models.go
@@ -1,7 +1,7 @@
 package nodeclient
 
 import (
-	"github.com/iotaledger/iota.go/v3"
+	iotago "github.com/iotaledger/iota.go/v3"
 	"github.com/pasztorpisti/qs"
 )
 
@@ -71,8 +71,8 @@ type IndexerStorageDepositParas struct {
 	StorageDepositReturnAddressBech32 string `qs:"storageDepositAddress,omitempty"`
 }
 
-// OutputsQuery defines parameters for an outputs query.
-type OutputsQuery struct {
+// BasicOutputsQuery defines parameters for an basic outputs query.
+type BasicOutputsQuery struct {
 	IndexerCursorParas
 	IndexerTimelockParas
 	IndexerExpirationParas
@@ -87,15 +87,15 @@ type OutputsQuery struct {
 	Tag string `qs:"tag,omitempty"`
 }
 
-func (query *OutputsQuery) OutputType() iotago.OutputType {
+func (query *BasicOutputsQuery) OutputType() iotago.OutputType {
 	return iotago.OutputBasic
 }
 
-func (query *OutputsQuery) SetOffset(cursor *string) {
+func (query *BasicOutputsQuery) SetOffset(cursor *string) {
 	query.Cursor = cursor
 }
 
-func (query *OutputsQuery) URLParas() (string, error) {
+func (query *BasicOutputsQuery) URLParas() (string, error) {
 	return qs.Marshal(query)
 }
 


### PR DESCRIPTION
# Description of change
`OutputsQuery` was very generic and gives the impression that it can be used to query ANY output type. Renamed it to `BasicOutputsQuery` so its more descriptive

## Type of change

- Rename
