### PR TITLE
Increases length of alias/nft ids to 32 bytes

### DIFF
--- a/address_alias.go
+++ b/address_alias.go
@@ -10,13 +10,13 @@ import (
 
 const (
 	// AliasAddressBytesLength is the length of an Alias address.
-	AliasAddressBytesLength = 20
+	AliasAddressBytesLength = blake2b.Size256
 	// AliasAddressSerializedBytesSize is the size of a serialized Alias address with its type denoting byte.
 	AliasAddressSerializedBytesSize = serializer.SmallTypeDenotationByteSize + AliasAddressBytesLength
 )
 
 var (
-	emptyAliasAddress = [20]byte{}
+	emptyAliasAddress = [AliasAddressBytesLength]byte{}
 )
 
 // ParseAliasAddressFromHexString parses the given hex string into an AliasAddress.
@@ -41,7 +41,7 @@ func MustParseAliasAddressFromHexString(hexAddr string) *AliasAddress {
 }
 
 // AliasAddress defines an Alias address.
-// An AliasAddress is the Blake2b-160 hash of the OutputID which created it.
+// An AliasAddress is the Blake2b-256 hash of the OutputID which created it.
 type AliasAddress [AliasAddressBytesLength]byte
 
 func (aliasAddr *AliasAddress) Clone() Address {
@@ -132,14 +132,7 @@ func (aliasAddr *AliasAddress) UnmarshalJSON(bytes []byte) error {
 
 // AliasAddressFromOutputID returns the alias address computed from a given OutputID.
 func AliasAddressFromOutputID(outputID OutputID) AliasAddress {
-	// TODO: maybe use pkg with Sum160 exposed
-	blake2b160, _ := blake2b.New(20, nil)
-	var aliasAddress AliasAddress
-	if _, err := blake2b160.Write(outputID[:]); err != nil {
-		panic(err)
-	}
-	copy(aliasAddress[:], blake2b160.Sum(nil))
-	return aliasAddress
+	return blake2b.Sum256(outputID[:])
 }
 
 // jsonAliasAddress defines the json representation of an AliasAddress.

--- a/address_nft.go
+++ b/address_nft.go
@@ -10,13 +10,13 @@ import (
 
 const (
 	// NFTAddressBytesLength is the length of an NFT address.
-	NFTAddressBytesLength = 20
+	NFTAddressBytesLength = blake2b.Size256
 	// NFTAddressSerializedBytesSize is the size of a serialized NFT address with its type denoting byte.
 	NFTAddressSerializedBytesSize = serializer.SmallTypeDenotationByteSize + NFTAddressBytesLength
 )
 
 var (
-	emptyNFTAddress = [20]byte{}
+	emptyNFTAddress = [NFTAddressBytesLength]byte{}
 )
 
 // ParseNFTAddressFromHexString parses the given hex string into an NFTAddress.
@@ -41,7 +41,7 @@ func MustParseNFTAddressFromHexString(hexAddr string) *NFTAddress {
 }
 
 // NFTAddress defines an NFT address.
-// An NFTAddress is the Blake2b-160 hash of the OutputID which created it.
+// An NFTAddress is the Blake2b-256 hash of the OutputID which created it.
 type NFTAddress [NFTAddressBytesLength]byte
 
 func (nftAddr *NFTAddress) Clone() Address {
@@ -132,14 +132,7 @@ func (nftAddr *NFTAddress) UnmarshalJSON(bytes []byte) error {
 
 // NFTAddressFromOutputID returns the NFT address computed from a given OutputID.
 func NFTAddressFromOutputID(outputID OutputID) NFTAddress {
-	// TODO: maybe use pkg with Sum160 exposed
-	blake2b160, _ := blake2b.New(20, nil)
-	var nftAddress NFTAddress
-	if _, err := blake2b160.Write(outputID[:]); err != nil {
-		panic(err)
-	}
-	copy(nftAddress[:], blake2b160.Sum(nil))
-	return nftAddress
+	return blake2b.Sum256(outputID[:])
 }
 
 // jsonNFTAddress defines the json representation of an NFTAddress.

--- a/native_token_test.go
+++ b/native_token_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNativeTokenDeSerialization(t *testing.T) {
 	ntIn := iotago.NativeToken{
-		ID:     tpkg.Rand38ByteArray(),
+		ID:     tpkg.Rand50ByteArray(),
 		Amount: new(big.Int).SetUint64(1000),
 	}
 

--- a/output_alias.go
+++ b/output_alias.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// AliasIDLength is the byte length of an AliasID.
-	AliasIDLength = 20
+	AliasIDLength = blake2b.Size256
 )
 
 var (
@@ -127,7 +127,7 @@ func AliasOutputImmutableFeatureBlocksArrayRules() serializer.ArrayRules {
 }
 
 // AliasID is the identifier for an alias account.
-// It is computed as the Blake2b-160 hash of the OutputID of the output which created the account.
+// It is computed as the Blake2b-256 hash of the OutputID of the output which created the account.
 type AliasID [AliasIDLength]byte
 
 func (id AliasID) Addressable() bool {
@@ -166,14 +166,7 @@ func (id AliasID) ToAddress() ChainConstrainedAddress {
 
 // AliasIDFromOutputID returns the AliasID computed from a given OutputID.
 func AliasIDFromOutputID(outputID OutputID) AliasID {
-	// TODO: maybe use pkg with Sum160 exposed
-	blake2b160, _ := blake2b.New(20, nil)
-	var aliasID AliasID
-	if _, err := blake2b160.Write(outputID[:]); err != nil {
-		panic(err)
-	}
-	copy(aliasID[:], blake2b160.Sum(nil))
-	return aliasID
+	return blake2b.Sum256(outputID[:])
 }
 
 // AliasOutputs is a slice of AliasOutput(s).

--- a/output_nft.go
+++ b/output_nft.go
@@ -3,14 +3,15 @@ package iotago
 import (
 	"encoding/json"
 	"fmt"
+	"golang.org/x/crypto/blake2b"
 
 	"github.com/iotaledger/hive.go/serializer/v2"
 	"github.com/iotaledger/iota.go/v3/util"
 )
 
 const (
-	// 	NFTIDLength = 20 is the byte length of an NFTID.
-	NFTIDLength = 20
+	// 	NFTIDLength is the byte length of an NFTID.
+	NFTIDLength = blake2b.Size256
 )
 
 var (
@@ -120,7 +121,7 @@ func NFTOutputImmutableFeatureBlocksArrayRules() serializer.ArrayRules {
 }
 
 // NFTID is the identifier for an NFT.
-// It is computed as the Blake2b-160 hash of the OutputID of the output which created the NFT.
+// It is computed as the Blake2b-256 hash of the OutputID of the output which created the NFT.
 type NFTID [NFTIDLength]byte
 
 // NFTIDs are NFTID(s).

--- a/output_test.go
+++ b/output_test.go
@@ -88,7 +88,7 @@ func TestOutputsDeSerialize(t *testing.T) {
 			source: &iotago.NFTOutput{
 				Amount:       1337,
 				NativeTokens: tpkg.RandSortNativeTokens(2),
-				NFTID:        tpkg.Rand20ByteArray(),
+				NFTID:        tpkg.Rand32ByteArray(),
 				Conditions: iotago.UnlockConditions{
 					&iotago.AddressUnlockCondition{Address: tpkg.RandEd25519Address()},
 					&iotago.StorageDepositReturnUnlockCondition{
@@ -171,7 +171,7 @@ func TestOutputsSyntacticalDepositAmount(t *testing.T) {
 			protoParas: nonZeroCostParas,
 			outputs: iotago.Outputs{
 				&iotago.BasicOutput{
-					Amount:     414, // min amount
+					Amount:     426, // min amount
 					Conditions: iotago.UnlockConditions{&iotago.AddressUnlockCondition{Address: tpkg.RandAliasAddress()}},
 				},
 			},
@@ -413,7 +413,7 @@ func TestOutputsSyntacticalAlias(t *testing.T) {
 			outputs: iotago.Outputs{
 				&iotago.AliasOutput{
 					Amount:         OneMi,
-					AliasID:        tpkg.Rand20ByteArray(),
+					AliasID:        tpkg.Rand32ByteArray(),
 					StateIndex:     10,
 					FoundryCounter: 1337,
 					Conditions: iotago.UnlockConditions{
@@ -460,7 +460,7 @@ func TestOutputsSyntacticalAlias(t *testing.T) {
 			name: "fail - cyclic state controller",
 			outputs: iotago.Outputs{
 				func() *iotago.AliasOutput {
-					aliasID := iotago.AliasID(tpkg.Rand20ByteArray())
+					aliasID := iotago.AliasID(tpkg.Rand32ByteArray())
 					return &iotago.AliasOutput{
 						Amount:         OneMi,
 						AliasID:        aliasID,
@@ -479,7 +479,7 @@ func TestOutputsSyntacticalAlias(t *testing.T) {
 			name: "fail - cyclic governance controller",
 			outputs: iotago.Outputs{
 				func() *iotago.AliasOutput {
-					aliasID := iotago.AliasID(tpkg.Rand20ByteArray())
+					aliasID := iotago.AliasID(tpkg.Rand32ByteArray())
 					return &iotago.AliasOutput{
 						Amount:         OneMi,
 						AliasID:        aliasID,
@@ -661,7 +661,7 @@ func TestOutputsSyntacticalNFT(t *testing.T) {
 			name: "fail - cyclic",
 			outputs: iotago.Outputs{
 				func() *iotago.NFTOutput {
-					nftID := iotago.NFTID(tpkg.Rand20ByteArray())
+					nftID := iotago.NFTID(tpkg.Rand32ByteArray())
 					return &iotago.NFTOutput{
 						Amount: OneMi,
 						NFTID:  nftID,

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -101,18 +101,18 @@ func Rand12ByteArray() [12]byte {
 	return h
 }
 
-// Rand20ByteArray returns an array with 20 random bytes.
-func Rand20ByteArray() [20]byte {
-	var h [20]byte
-	b := RandBytes(20)
-	copy(h[:], b)
-	return h
-}
-
 // Rand32ByteArray returns an array with 32 random bytes.
 func Rand32ByteArray() [32]byte {
 	var h [32]byte
 	b := RandBytes(32)
+	copy(h[:], b)
+	return h
+}
+
+// Rand50ByteArray returns an array with 38 random bytes.
+func Rand50ByteArray() [50]byte {
+	var h [50]byte
+	b := RandBytes(50)
 	copy(h[:], b)
 	return h
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -211,8 +211,8 @@ func TestTransactionSemanticValidation(t *testing.T) {
 			)
 
 			var (
-				nft1ID = tpkg.Rand20ByteArray()
-				nft2ID = tpkg.Rand20ByteArray()
+				nft1ID = tpkg.Rand32ByteArray()
+				nft2ID = tpkg.Rand32ByteArray()
 			)
 
 			inputIDs := tpkg.RandOutputIDs(16)


### PR DESCRIPTION
Note, this increases foundry IDs to 38 bytes and native tokens to 50.