### PR TITLE
Check network id during tx essence syntactical checks

### DIFF
--- a/benches_test.go
+++ b/benches_test.go
@@ -31,6 +31,7 @@ func BenchmarkDeserializeWithValidationOneIOTxPayload(b *testing.B) {
 func BenchmarkDeserializeWithValidationLargeTxPayload(b *testing.B) {
 	origin := &iotago.Transaction{
 		Essence: &iotago.TransactionEssence{
+			NetworkID: tpkg.TestNetworkID,
 			Inputs: func() iotago.Inputs {
 				var inputs iotago.Inputs
 				for i := 0; i < iotago.MaxInputsCount; i++ {

--- a/builder/transaction_builder_test.go
+++ b/builder/transaction_builder_test.go
@@ -3,7 +3,6 @@ package builder_test
 import (
 	"crypto/ed25519"
 	"errors"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,7 +29,7 @@ func TestTransactionBuilder(t *testing.T) {
 		func() test {
 			inputUTXO1 := &iotago.UTXOInput{TransactionID: tpkg.Rand32ByteArray(), TransactionOutputIndex: 0}
 
-			bdl := builder.NewTransactionBuilder(rand.Uint64()).
+			bdl := builder.NewTransactionBuilder(tpkg.TestNetworkID).
 				AddInput(&builder.ToBeSignedUTXOInput{Address: &inputAddr, OutputID: inputUTXO1.ID(), Output: tpkg.RandBasicOutput(iotago.AddressEd25519)}).
 				AddOutput(&iotago.BasicOutput{
 					Amount: 50,
@@ -48,7 +47,7 @@ func TestTransactionBuilder(t *testing.T) {
 		func() test {
 			inputUTXO1 := &iotago.UTXOInput{TransactionID: tpkg.Rand32ByteArray(), TransactionOutputIndex: 0}
 
-			bdl := builder.NewTransactionBuilder(rand.Uint64()).
+			bdl := builder.NewTransactionBuilder(tpkg.TestNetworkID).
 				AddInput(&builder.ToBeSignedUTXOInput{Address: &inputAddr, OutputID: inputUTXO1.ID(), Output: tpkg.RandBasicOutput(iotago.AddressEd25519)}).
 				AddOutput(&iotago.BasicOutput{
 					Amount: 50,
@@ -65,7 +64,7 @@ func TestTransactionBuilder(t *testing.T) {
 			}
 		}(),
 		func() test {
-			bdl := builder.NewTransactionBuilder(rand.Uint64())
+			bdl := builder.NewTransactionBuilder(tpkg.TestNetworkID)
 			return test{
 				name:       "err - no inputs",
 				addrSigner: iotago.NewInMemoryAddressSigner(),
@@ -75,7 +74,7 @@ func TestTransactionBuilder(t *testing.T) {
 		}(),
 		func() test {
 			inputUTXO1 := &iotago.UTXOInput{TransactionID: tpkg.Rand32ByteArray(), TransactionOutputIndex: 0}
-			bdl := builder.NewTransactionBuilder(rand.Uint64()).
+			bdl := builder.NewTransactionBuilder(tpkg.TestNetworkID).
 				AddInput(&builder.ToBeSignedUTXOInput{Address: &inputAddr, OutputID: inputUTXO1.ID(), Output: tpkg.RandBasicOutput(iotago.AddressEd25519)})
 			return test{
 				name:       "err - no outputs",
@@ -87,7 +86,7 @@ func TestTransactionBuilder(t *testing.T) {
 		func() test {
 			inputUTXO1 := &iotago.UTXOInput{TransactionID: tpkg.Rand32ByteArray(), TransactionOutputIndex: 0}
 
-			bdl := builder.NewTransactionBuilder(rand.Uint64()).
+			bdl := builder.NewTransactionBuilder(tpkg.TestNetworkID).
 				AddInput(&builder.ToBeSignedUTXOInput{Address: &inputAddr, OutputID: inputUTXO1.ID(), Output: tpkg.RandBasicOutput(iotago.AddressEd25519)}).
 				AddOutput(&iotago.BasicOutput{
 					Amount: 50,
@@ -111,7 +110,7 @@ func TestTransactionBuilder(t *testing.T) {
 		func() test {
 			inputUTXO1 := &iotago.UTXOInput{TransactionID: tpkg.Rand32ByteArray(), TransactionOutputIndex: 0}
 
-			bdl := builder.NewTransactionBuilder(rand.Uint64()).
+			bdl := builder.NewTransactionBuilder(tpkg.TestNetworkID).
 				AddInput(&builder.ToBeSignedUTXOInput{Address: &inputAddr, OutputID: inputUTXO1.ID(), Output: tpkg.RandBasicOutput(iotago.AddressEd25519)}).
 				AddOutput(&iotago.BasicOutput{
 					Amount: 50,

--- a/tpkg/test_consts.go
+++ b/tpkg/test_consts.go
@@ -5,13 +5,20 @@ import "github.com/iotaledger/iota.go/v3"
 // TestProtoParas is an instance of iotago.ProtocolParameters for testing purposes. It contains a zero vbyte rent cost.
 // Only use this var in testing. Do not modify or use outside unit tests.
 var TestProtoParas = &iotago.ProtocolParameters{
-	TokenSupply: TestTokenSupply,
+	Version:     2,
+	NetworkName: "TestJungle",
+	Bech32HRP:   "tgl",
+	MinPoWScore: 0,
 	RentStructure: iotago.RentStructure{
 		VByteCost:    0,
 		VBFactorData: 0,
 		VBFactorKey:  0,
 	},
+	TokenSupply: TestTokenSupply,
 }
+
+// TestNetworkID is a test network ID.
+var TestNetworkID = TestProtoParas.NetworkID()
 
 const (
 	// TestTokenSupply is a test token supply constant.

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -212,7 +212,9 @@ func ReferenceUnlockBlock(index uint16) *iotago.ReferenceUnlockBlock {
 
 // RandTransactionEssence returns a random transaction essence.
 func RandTransactionEssence() *iotago.TransactionEssence {
-	tx := &iotago.TransactionEssence{}
+	tx := &iotago.TransactionEssence{
+		NetworkID: TestNetworkID,
+	}
 
 	inputCount := rand.Intn(10) + 1
 	for i := inputCount; i > 0; i-- {

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -33,6 +33,8 @@ const (
 var (
 	// ErrInvalidInputsCommitment gets returned when the inputs commitment is invalid.
 	ErrInvalidInputsCommitment = errors.New("invalid inputs commitment")
+	// ErrTxEssenceNetworkIDInvalid gets returned when a network ID within a TransactionEssence is invalid.
+	ErrTxEssenceNetworkIDInvalid = errors.New("invalid network ID")
 	// ErrInputUTXORefsNotUnique gets returned if multiple inputs reference the same UTXO.
 	ErrInputUTXORefsNotUnique = errors.New("inputs must each reference a unique UTXO")
 	// ErrAliasOutputNonEmptyState gets returned if an AliasOutput with zeroed AliasID contains state (counters non-zero etc.).
@@ -324,6 +326,12 @@ func (u *TransactionEssence) UnmarshalJSON(bytes []byte) error {
 // syntacticallyValidate checks whether the transaction essence is syntactically valid.
 // The function does not syntactically validate the input or outputs themselves.
 func (u *TransactionEssence) syntacticallyValidate(protoParas *ProtocolParameters) error {
+
+	expectedNetworkID := protoParas.NetworkID()
+	if u.NetworkID != expectedNetworkID {
+		return fmt.Errorf("%w: got %v, want %v (%s)", ErrTxEssenceNetworkIDInvalid, u.NetworkID, expectedNetworkID, protoParas.NetworkName)
+	}
+
 	if err := SyntacticallyValidateInputs(u.Inputs,
 		InputsSyntacticalUnique(),
 		InputsSyntacticalIndicesWithinBounds(),


### PR DESCRIPTION
Because now we can given `ProtocolParameters`.