### PR TITLE
Use distinct types for ID types

### DIFF
--- a/address.go
+++ b/address.go
@@ -104,6 +104,8 @@ type ChainID interface {
 	Empty() bool
 	// Key returns a key to use to index this ChainID.
 	Key() interface{}
+	// ToHex returns the hex representation of the ChainID.
+	ToHex() string
 }
 
 // UTXOIDChainID is a ChainID which gets produced by taking an OutputID.

--- a/benches_test.go
+++ b/benches_test.go
@@ -158,7 +158,7 @@ func BenchmarkSerializeAndHashBlockWithTransactionPayload(b *testing.B) {
 
 	m := &iotago.Block{
 		ProtocolVersion: tpkg.TestProtocolVersion,
-		Parents:         tpkg.SortedRand32BytArray(2),
+		Parents:         tpkg.SortedRandBlockIDs(2),
 		Payload:         txPayload,
 		Nonce:           0,
 	}

--- a/block_test.go
+++ b/block_test.go
@@ -56,7 +56,7 @@ func TestBlock_MinSize(t *testing.T) {
 
 	block := &iotago.Block{
 		ProtocolVersion: tpkg.TestProtocolVersion,
-		Parents:         tpkg.SortedRand32BytArray(1),
+		Parents:         tpkg.SortedRandBlockIDs(1),
 		Payload:         nil,
 	}
 

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -76,7 +76,7 @@ func (mb *BlockBuilder) Parents(parents [][]byte) *BlockBuilder {
 		copy(parent[:], parentBytes)
 		pars[i] = parent
 	}
-	mb.block.Parents = serializer.RemoveDupsAndSortByLexicalOrderArrayOf32Bytes(pars)
+	mb.block.Parents = pars.RemoveDupsAndSort()
 	return mb
 }
 
@@ -86,7 +86,7 @@ func (mb *BlockBuilder) ParentsBlockIDs(parents iotago.BlockIDs) *BlockBuilder {
 		return mb
 	}
 
-	mb.block.Parents = serializer.RemoveDupsAndSortByLexicalOrderArrayOf32Bytes(parents)
+	mb.block.Parents = parents.RemoveDupsAndSort()
 	return mb
 }
 

--- a/builder/block_builder_test.go
+++ b/builder/block_builder_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 func TestBlockBuilder(t *testing.T) {
 	const targetPoWScore float64 = 500
 
-	parents := tpkg.SortedRand32BytArray(4)
+	parents := tpkg.SortedRandBlockIDs(4)
 
 	taggedDataPayload := &iotago.TaggedData{
 		Tag:  []byte("hello world"),

--- a/milestone.go
+++ b/milestone.go
@@ -162,14 +162,14 @@ func (m *Milestone) PayloadType() PayloadType {
 }
 
 // ID computes the ID of the Milestone.
-func (m *Milestone) ID() (*MilestoneID, error) {
+func (m *Milestone) ID() (MilestoneID, error) {
 	var msID MilestoneID
 	data, err := m.Essence()
 	if err != nil {
-		return nil, err
+		return MilestoneID{}, err
 	}
 	copy(msID[:], data)
-	return &msID, nil
+	return msID, nil
 }
 
 // Essence returns the essence bytes (the bytes to be signed) of the Milestone.

--- a/milestone_test.go
+++ b/milestone_test.go
@@ -44,7 +44,7 @@ func TestMilestone_MarshalUnmarshalJSON(t *testing.T) {
 	ms := &iotago.Milestone{
 		Index:             1337,
 		Timestamp:         13371337,
-		Parents:           tpkg.SortedRand32BytArray(2),
+		Parents:           tpkg.SortedRandBlockIDs(2),
 		AppliedMerkleRoot: tpkg.Rand32ByteArray(),
 		Metadata:          tpkg.RandBytes(10),
 		Opts:              iotago.MilestoneOpts{},
@@ -90,7 +90,7 @@ func TestMilestoneSigning(t *testing.T) {
 			pubKeys := []iotago.MilestonePublicKey{pubKey1}
 
 			msPayload := &iotago.Milestone{
-				Parents:           tpkg.SortedRand32BytArray(1 + rand.Intn(7)),
+				Parents:           tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 				Index:             1000,
 				Timestamp:         uint32(time.Now().Unix()),
 				AppliedMerkleRoot: tpkg.Rand32ByteArray(),
@@ -123,7 +123,7 @@ func TestMilestoneSigning(t *testing.T) {
 			sort.Sort(pubKeys)
 
 			msPayload := &iotago.Milestone{
-				Parents:           tpkg.SortedRand32BytArray(1 + rand.Intn(7)),
+				Parents:           tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 				Index:             1000,
 				Timestamp:         uint32(time.Now().Unix()),
 				AppliedMerkleRoot: tpkg.Rand32ByteArray(),
@@ -151,7 +151,7 @@ func TestMilestoneSigning(t *testing.T) {
 			pubKeys := []iotago.MilestonePublicKey{pubKey1}
 
 			msPayload := &iotago.Milestone{
-				Parents:             tpkg.SortedRand32BytArray(1 + rand.Intn(7)),
+				Parents:             tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 				Index:               1000,
 				Timestamp:           uint32(time.Now().Unix()),
 				InclusionMerkleRoot: tpkg.Rand32ByteArray(),
@@ -194,7 +194,7 @@ func TestMilestoneSigning(t *testing.T) {
 }
 
 func TestNewMilestone(t *testing.T) {
-	parents := tpkg.SortedRand32BytArray(1 + rand.Intn(7))
+	parents := tpkg.SortedRandBlockIDs(1 + rand.Intn(7))
 	prevMs := tpkg.Rand32ByteArray()
 	pastConeMerkleProof := tpkg.Rand32ByteArray()
 	inclusionMerkleProof := tpkg.Rand32ByteArray()

--- a/nodeclient/event_api_client.go
+++ b/nodeclient/event_api_client.go
@@ -304,7 +304,7 @@ func (eac *EventAPIClient) TaggedDataWithTagBlocks(tag []byte, protoParas *iotag
 
 // BlockMetadataChange returns a channel of BlockMetadataResponse each time the given block's state changes.
 func (eac *EventAPIClient) BlockMetadataChange(blockID iotago.BlockID) (<-chan *BlockMetadataResponse, *EventAPIClientSubscription) {
-	topic := strings.Replace(EventAPIBlockMetadata, "{blockId}", iotago.BlockIDToHexString(blockID), 1)
+	topic := strings.Replace(EventAPIBlockMetadata, "{blockId}", blockID.ToHex(), 1)
 	return eac.subscribeToBlockMetadataTopic(topic)
 }
 
@@ -342,7 +342,7 @@ func (eac *EventAPIClient) SpentOutputsByUnlockConditionAndAddress(addr iotago.A
 
 // TransactionIncludedBlock returns a channel of the included block which carries the transaction with the given ID.
 func (eac *EventAPIClient) TransactionIncludedBlock(txID iotago.TransactionID, protoParas *iotago.ProtocolParameters) (<-chan *iotago.Block, *EventAPIClientSubscription) {
-	topic := strings.Replace(EventAPITransactionsIncludedBlock, "{transactionId}", iotago.BlockIDToHexString(txID), 1)
+	topic := strings.Replace(EventAPITransactionsIncludedBlock, "{transactionId}", txID.ToHex(), 1)
 	return eac.subscribeToBlocksTopic(topic, protoParas)
 }
 

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -130,12 +130,12 @@ func TestClient_SubmitBlock(t *testing.T) {
 
 	incompleteBlock := &iotago.Block{
 		ProtocolVersion: tpkg.TestProtocolVersion,
-		Parents:         tpkg.SortedRand32BytArray(1),
+		Parents:         tpkg.SortedRandBlockIDs(1),
 	}
 
 	completeBlock := &iotago.Block{
 		ProtocolVersion: tpkg.TestProtocolVersion,
-		Parents:         tpkg.SortedRand32BytArray(1),
+		Parents:         tpkg.SortedRandBlockIDs(1),
 		Payload:         nil,
 		Nonce:           3495721389537486,
 	}
@@ -173,7 +173,7 @@ func TestClient_BlockMetadataByMessageID(t *testing.T) {
 	defer gock.Off()
 
 	identifier := tpkg.Rand32ByteArray()
-	parents := tpkg.SortedRand32BytArray(1 + rand.Intn(7))
+	parents := tpkg.SortedRandBlockIDs(1 + rand.Intn(7))
 
 	queryHash := iotago.EncodeHex(identifier[:])
 
@@ -213,7 +213,7 @@ func TestClient_BlockByBlockID(t *testing.T) {
 
 	originBlock := &iotago.Block{
 		ProtocolVersion: tpkg.TestProtocolVersion,
-		Parents:         tpkg.SortedRand32BytArray(1 + rand.Intn(7)),
+		Parents:         tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 		Payload:         nil,
 		Nonce:           16345984576234,
 	}
@@ -273,7 +273,7 @@ func TestClient_TransactionIncludedBlock(t *testing.T) {
 
 	originBlock := &iotago.Block{
 		ProtocolVersion: tpkg.TestProtocolVersion,
-		Parents:         tpkg.SortedRand32BytArray(1 + rand.Intn(7)),
+		Parents:         tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 		Payload:         nil,
 		Nonce:           16345984576234,
 	}
@@ -466,7 +466,7 @@ func TestClient_MilestoneByID(t *testing.T) {
 		Index:               1337,
 		Timestamp:           1337,
 		PreviousMilestoneID: tpkg.RandMilestoneID(),
-		Parents: iotago.MilestoneParentBlockIDs{
+		Parents: iotago.BlockIDs{
 			tpkg.Rand32ByteArray(),
 		},
 		InclusionMerkleRoot: tpkg.Rand32ByteArray(),
@@ -533,7 +533,7 @@ func TestClient_MilestoneByIndex(t *testing.T) {
 		Index:               milestoneIndex,
 		Timestamp:           1337,
 		PreviousMilestoneID: tpkg.RandMilestoneID(),
-		Parents: iotago.MilestoneParentBlockIDs{
+		Parents: iotago.BlockIDs{
 			tpkg.Rand32ByteArray(),
 		},
 		InclusionMerkleRoot: tpkg.Rand32ByteArray(),
@@ -597,7 +597,7 @@ func TestClient_ComputeWhiteFlagMutations(t *testing.T) {
 	var milestoneIndex uint32 = 1337
 	var milestoneTimestamp uint32 = 1333337
 
-	parents := tpkg.SortedRand32BytArray(1 + rand.Intn(7))
+	parents := tpkg.SortedRandBlockIDs(1 + rand.Intn(7))
 	parentBlockIDs := make([]string, len(parents))
 	for i, p := range parents {
 		parentBlockIDs[i] = iotago.EncodeHex(p[:])

--- a/output_alias.go
+++ b/output_alias.go
@@ -134,6 +134,10 @@ func (id AliasID) Addressable() bool {
 	return true
 }
 
+func (id AliasID) ToHex() string {
+	return EncodeHex(id[:])
+}
+
 func (id AliasID) Key() interface{} {
 	return id.String()
 }

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -114,6 +114,10 @@ func FoundryOutputImmutableFeaturesArrayRules() serializer.ArrayRules {
 // FoundryID defines the identifier for a foundry consisting out of the address, serial number and TokenScheme.
 type FoundryID [FoundryIDLength]byte
 
+func (fID FoundryID) ToHex() string {
+	return EncodeHex(fID[:])
+}
+
 func (fID FoundryID) Addressable() bool {
 	return false
 }

--- a/output_nft.go
+++ b/output_nft.go
@@ -124,6 +124,10 @@ func NFTOutputImmutableFeaturesArrayRules() serializer.ArrayRules {
 // It is computed as the Blake2b-256 hash of the OutputID of the output which created the NFT.
 type NFTID [NFTIDLength]byte
 
+func (nftID NFTID) ToHex() string {
+	return EncodeHex(nftID[:])
+}
+
 // NFTIDs are NFTID(s).
 type NFTIDs []NFTID
 

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -141,14 +141,23 @@ func Rand64ByteArray() [64]byte {
 	return h
 }
 
-// SortedRand32BytArray returns a count length slice of sorted 32 byte arrays.
-func SortedRand32BytArray(count int) [][32]byte {
+// SortedRand32ByteArray returns a count length slice of sorted 32 byte arrays.
+func SortedRand32ByteArray(count int) [][32]byte {
 	hashes := make(serializer.LexicalOrdered32ByteArrays, count)
 	for i := 0; i < count; i++ {
 		hashes[i] = Rand32ByteArray()
 	}
 	sort.Sort(hashes)
 	return hashes
+}
+
+// SortedRandBlockIDs returns random block IDs.
+func SortedRandBlockIDs(count int) iotago.BlockIDs {
+	slice := make(iotago.BlockIDs, count)
+	for i, ele := range SortedRand32ByteArray(count) {
+		slice[i] = ele
+	}
+	return slice
 }
 
 // RandEd25519Address returns a random Ed25519 address.
@@ -257,7 +266,7 @@ func RandMilestone(parents iotago.BlockIDs) *iotago.Milestone {
 	const sigsCount = 3
 
 	if parents == nil {
-		parents = SortedRand32BytArray(1 + rand.Intn(7))
+		parents = SortedRandBlockIDs(1 + rand.Intn(7))
 	}
 
 	msPayload := &iotago.Milestone{
@@ -314,7 +323,7 @@ func RandTaggedData(tag []byte, dataLength ...int) *iotago.TaggedData {
 func RandBlock(withPayloadType iotago.PayloadType) *iotago.Block {
 	var payload iotago.Payload
 
-	parents := SortedRand32BytArray(1 + rand.Intn(7))
+	parents := SortedRandBlockIDs(1 + rand.Intn(7))
 
 	switch withPayloadType {
 	case iotago.PayloadTransaction:

--- a/transaction.go
+++ b/transaction.go
@@ -66,6 +66,11 @@ func TransactionUnlocksArrayRules() serializer.ArrayRules {
 // TransactionID is the ID of a Transaction.
 type TransactionID [TransactionIDLength]byte
 
+// ToHex converts the TransactionID to its hex representation.
+func (transactionID TransactionID) ToHex() string {
+	return EncodeHex(transactionID[:])
+}
+
 // TransactionIDs are IDs of transactions.
 type TransactionIDs []TransactionID
 
@@ -75,11 +80,6 @@ type Transaction struct {
 	Essence *TransactionEssence
 	// The unlocks defining the unlocking data for the inputs within the Essence.
 	Unlocks Unlocks
-}
-
-// ToHex converts the TransactionID to its hex representation.
-func (transactionID TransactionID) ToHex() string {
-	return EncodeHex(transactionID[:])
 }
 
 func (t *Transaction) PayloadType() PayloadType {


### PR DESCRIPTION
Makes `BlockID` and `BlockIDs` actual types instead of aliases. This allows us to add methods to these types for hex conversion etc.

Due to the serializer's shortcoming, I've added some variable declarations as to make it work with the current serializer API. Given that we will be getting rid of it anyway, this seems like an ok solution for now.

Also added ToHex() to `ChainID` thus to `AliasID`/`FoundryID`/`NFTID`.