### PR TITLE
Remove MilestoneIndex from time based UnlockConditions

### DIFF
--- a/output.go
+++ b/output.go
@@ -603,8 +603,6 @@ type Output interface {
 // ExternalUnlockParameters defines a palette of external system parameters which are used to
 // determine whether an Output can be unlocked.
 type ExternalUnlockParameters struct {
-	// The confirmed milestone index.
-	ConfMsIndex uint32
 	// The confirmed unix epoch time in seconds.
 	ConfUnix uint32
 }
@@ -769,19 +767,19 @@ func OutputsSyntacticalNativeTokens() OutputsSyntacticalValidationFunc {
 }
 
 // OutputsSyntacticalExpirationAndTimelock returns an OutputsSyntacticalValidationFunc which checks that:
-// That ExpirationUnlockCondition and TimelockUnlockCondition does not have both of its milestone and unix criteria set to zero.
+// That ExpirationUnlockCondition and TimelockUnlockCondition does not have its unix criteria set to zero.
 func OutputsSyntacticalExpirationAndTimelock() OutputsSyntacticalValidationFunc {
 	return func(index int, output Output) error {
 		unlockConditionSet := output.UnlockConditionSet()
 
 		if expiration := unlockConditionSet.Expiration(); expiration != nil {
-			if expiration.MilestoneIndex == 0 && expiration.UnixTime == 0 {
+			if expiration.UnixTime == 0 {
 				return ErrExpirationConditionsZero
 			}
 		}
 
 		if timelock := unlockConditionSet.Timelock(); timelock != nil {
-			if timelock.MilestoneIndex == 0 && timelock.UnixTime == 0 {
+			if timelock.UnixTime == 0 {
 				return ErrTimelockConditionsZero
 			}
 		}

--- a/output_test.go
+++ b/output_test.go
@@ -5,9 +5,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotaledger/hive.go/serializer/v2"
 	"github.com/iotaledger/iota.go/v3/tpkg"
-	"github.com/stretchr/testify/require"
 
 	iotago "github.com/iotaledger/iota.go/v3"
 )
@@ -25,10 +26,10 @@ func TestOutputsDeSerialize(t *testing.T) {
 						ReturnAddress: tpkg.RandEd25519Address(),
 						Amount:        1000,
 					},
-					&iotago.TimelockUnlockCondition{MilestoneIndex: 1337, UnixTime: 1000},
+					&iotago.TimelockUnlockCondition{UnixTime: 1337},
 					&iotago.ExpirationUnlockCondition{
-						ReturnAddress:  tpkg.RandEd25519Address(),
-						MilestoneIndex: 4000,
+						ReturnAddress: tpkg.RandEd25519Address(),
+						UnixTime:      4000,
 					},
 				},
 				Features: iotago.Features{
@@ -94,10 +95,10 @@ func TestOutputsDeSerialize(t *testing.T) {
 						ReturnAddress: tpkg.RandEd25519Address(),
 						Amount:        1000,
 					},
-					&iotago.TimelockUnlockCondition{MilestoneIndex: 1337, UnixTime: 1000},
+					&iotago.TimelockUnlockCondition{UnixTime: 1337},
 					&iotago.ExpirationUnlockCondition{
-						ReturnAddress:  tpkg.RandEd25519Address(),
-						MilestoneIndex: 4000,
+						ReturnAddress: tpkg.RandEd25519Address(),
+						UnixTime:      4000,
 					},
 				},
 				Features: iotago.Features{
@@ -726,26 +727,6 @@ func TestTransIndepIdentOutput_UnlockableBy(t *testing.T) {
 		func() test {
 			sourceIdent := tpkg.RandEd25519Address()
 			return test{
-				name: "can unlock - output not expired for source ident (ms index expiration)",
-				output: &iotago.BasicOutput{
-					Amount: OneMi,
-					Conditions: iotago.UnlockConditions{
-						&iotago.AddressUnlockCondition{Address: sourceIdent},
-						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  tpkg.RandEd25519Address(),
-							MilestoneIndex: 10,
-						},
-					},
-				},
-				targetIdent:           sourceIdent,
-				identCanUnlockInstead: nil,
-				extParas:              &iotago.ExternalUnlockParameters{ConfMsIndex: 5},
-				canUnlock:             true,
-			}
-		}(),
-		func() test {
-			sourceIdent := tpkg.RandEd25519Address()
-			return test{
 				name: "can unlock - output not expired for source ident (unix expiration)",
 				output: &iotago.BasicOutput{
 					Amount: OneMi,
@@ -767,27 +748,6 @@ func TestTransIndepIdentOutput_UnlockableBy(t *testing.T) {
 			sourceIdent := tpkg.RandEd25519Address()
 			senderIdent := tpkg.RandEd25519Address()
 			return test{
-				name: "can not unlock - output expired for source ident (ms index expiration)",
-				output: &iotago.BasicOutput{
-					Amount: OneMi,
-					Conditions: iotago.UnlockConditions{
-						&iotago.AddressUnlockCondition{Address: sourceIdent},
-						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  senderIdent,
-							MilestoneIndex: 5,
-						},
-					},
-				},
-				targetIdent:           sourceIdent,
-				identCanUnlockInstead: senderIdent,
-				extParas:              &iotago.ExternalUnlockParameters{ConfMsIndex: 10},
-				canUnlock:             false,
-			}
-		}(),
-		func() test {
-			sourceIdent := tpkg.RandEd25519Address()
-			senderIdent := tpkg.RandEd25519Address()
-			return test{
 				name: "can not unlock - output expired for source ident (unix expiration)",
 				output: &iotago.BasicOutput{
 					Amount: OneMi,
@@ -803,38 +763,6 @@ func TestTransIndepIdentOutput_UnlockableBy(t *testing.T) {
 				identCanUnlockInstead: senderIdent,
 				extParas:              &iotago.ExternalUnlockParameters{ConfUnix: 10},
 				canUnlock:             false,
-			}
-		}(),
-		func() test {
-			sourceIdent := tpkg.RandEd25519Address()
-			return test{
-				name: "can unlock - expired ms index timelock unlock condition",
-				output: &iotago.BasicOutput{
-					Amount: OneMi,
-					Conditions: iotago.UnlockConditions{
-						&iotago.AddressUnlockCondition{Address: sourceIdent},
-						&iotago.TimelockUnlockCondition{MilestoneIndex: 5},
-					},
-				},
-				targetIdent: sourceIdent,
-				extParas:    &iotago.ExternalUnlockParameters{ConfMsIndex: 10},
-				canUnlock:   true,
-			}
-		}(),
-		func() test {
-			sourceIdent := tpkg.RandEd25519Address()
-			return test{
-				name: "can not unlock - not expired ms index timelock unlock condition",
-				output: &iotago.BasicOutput{
-					Amount: OneMi,
-					Conditions: iotago.UnlockConditions{
-						&iotago.AddressUnlockCondition{Address: sourceIdent},
-						&iotago.TimelockUnlockCondition{MilestoneIndex: 10},
-					},
-				},
-				targetIdent: sourceIdent,
-				extParas:    &iotago.ExternalUnlockParameters{ConfMsIndex: 5},
-				canUnlock:   false,
 			}
 		}(),
 		func() test {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1763,7 +1763,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			require.NoError(t, err)
 
 			return test{
-				name: "fail - ms index timelock not expired",
+				name: "fail - timelock not expired",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
 					ConfUnix: 10,
 				}},

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -5,9 +5,10 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/iotaledger/iota.go/v3"
-	"github.com/iotaledger/iota.go/v3/tpkg"
 	"github.com/stretchr/testify/require"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/iota.go/v3/tpkg"
 )
 
 func TestTransactionDeSerialize(t *testing.T) {
@@ -191,11 +192,11 @@ func TestTransactionSemanticValidation(t *testing.T) {
 			)
 
 			var (
-				defaultAmount            uint64 = OneMi
-				confirmingMilestoneIndex uint32 = 750
-				storageDepositReturn     uint64 = OneMi / 2
-				nativeTokenTransfer1            = tpkg.RandSortNativeTokens(10)
-				nativeTokenTransfer2            = tpkg.RandSortNativeTokens(10)
+				defaultAmount        uint64 = OneMi
+				confirmingUnixTime   uint32 = 750
+				storageDepositReturn uint64 = OneMi / 2
+				nativeTokenTransfer1        = tpkg.RandSortNativeTokens(10)
+				nativeTokenTransfer2        = tpkg.RandSortNativeTokens(10)
 			)
 
 			var (
@@ -231,8 +232,8 @@ func TestTransactionSemanticValidation(t *testing.T) {
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident2},
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident1,
-							MilestoneIndex: 500,
+							ReturnAddress: ident1,
+							UnixTime:      500,
 						},
 					},
 				},
@@ -241,7 +242,7 @@ func TestTransactionSemanticValidation(t *testing.T) {
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident2},
 						&iotago.TimelockUnlockCondition{
-							MilestoneIndex: 500,
+							UnixTime: 500,
 						},
 					},
 				},
@@ -254,11 +255,11 @@ func TestTransactionSemanticValidation(t *testing.T) {
 							Amount:        storageDepositReturn,
 						},
 						&iotago.TimelockUnlockCondition{
-							MilestoneIndex: 500,
+							UnixTime: 500,
 						},
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident1,
-							MilestoneIndex: 900,
+							ReturnAddress: ident1,
+							UnixTime:      900,
 						},
 					},
 				},
@@ -627,7 +628,7 @@ func TestTransactionSemanticValidation(t *testing.T) {
 			return test{
 				name: "ok",
 				svCtx: &iotago.SemanticValidationContext{
-					ExtParas: &iotago.ExternalUnlockParameters{ConfMsIndex: confirmingMilestoneIndex},
+					ExtParas: &iotago.ExternalUnlockParameters{ConfUnix: confirmingUnixTime},
 				},
 				inputs: inputs,
 				tx: &iotago.Transaction{
@@ -728,8 +729,8 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident1},
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident2,
-							MilestoneIndex: 5,
+							ReturnAddress: ident2,
+							UnixTime:      5,
 						},
 					},
 				},
@@ -739,8 +740,8 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident1},
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident2,
-							MilestoneIndex: 20,
+							ReturnAddress: ident2,
+							UnixTime:      20,
 						},
 					},
 				},
@@ -767,8 +768,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 				name: "ok",
 				svCtx: &iotago.SemanticValidationContext{
 					ExtParas: &iotago.ExternalUnlockParameters{
-						ConfMsIndex: 10,
-						ConfUnix:    1337,
+						ConfUnix: 10,
 					},
 				},
 				inputs: inputs,
@@ -952,8 +952,8 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident1},
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident2,
-							MilestoneIndex: 10,
+							ReturnAddress: ident2,
+							UnixTime:      10,
 						},
 					},
 				},
@@ -967,7 +967,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			return test{
 				name: "fail - sender can not unlock yet",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
-					ConfMsIndex: 5,
+					ConfUnix: 5,
 				}},
 				inputs: inputs,
 				tx: &iotago.Transaction{
@@ -990,8 +990,8 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident1},
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident2,
-							MilestoneIndex: 10,
+							ReturnAddress: ident2,
+							UnixTime:      10,
 						},
 					},
 				},
@@ -1005,7 +1005,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			return test{
 				name: "fail - receiver can not unlock anymore",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
-					ConfMsIndex: 5,
+					ConfUnix: 5,
 				}},
 				inputs: inputs,
 				tx: &iotago.Transaction{
@@ -1125,8 +1125,8 @@ func TestTxSemanticDeposit(t *testing.T) {
 							Amount:        420,
 						},
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident2,
-							MilestoneIndex: 10,
+							ReturnAddress: ident2,
+							UnixTime:      10,
 						},
 					},
 				},
@@ -1140,8 +1140,8 @@ func TestTxSemanticDeposit(t *testing.T) {
 							Amount:        420,
 						},
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident2,
-							MilestoneIndex: 2,
+							ReturnAddress: ident2,
+							UnixTime:      2,
 						},
 					},
 				},
@@ -1171,7 +1171,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			return test{
 				name: "ok",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
-					ConfMsIndex: 5,
+					ConfUnix: 5,
 				}},
 				inputs: inputs,
 				tx: &iotago.Transaction{
@@ -1215,7 +1215,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			return test{
 				name: "fail - unbalanced, more on output than input",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
-					ConfMsIndex: 5,
+					ConfUnix: 5,
 				}},
 				inputs: inputs,
 				tx: &iotago.Transaction{
@@ -1257,7 +1257,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			return test{
 				name: "fail - unbalanced, more on input than output",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
-					ConfMsIndex: 5,
+					ConfUnix: 5,
 				}},
 				inputs: inputs,
 				tx: &iotago.Transaction{
@@ -1285,8 +1285,8 @@ func TestTxSemanticDeposit(t *testing.T) {
 						},
 						// not yet expired, so ident1 needs to unlock
 						&iotago.ExpirationUnlockCondition{
-							ReturnAddress:  ident2,
-							MilestoneIndex: 10,
+							ReturnAddress: ident2,
+							UnixTime:      10,
 						},
 					},
 				},
@@ -1309,7 +1309,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			return test{
 				name: "fail - return not fulfilled",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
-					ConfMsIndex: 5,
+					ConfUnix: 5,
 				}},
 				inputs: inputs,
 				tx: &iotago.Transaction{
@@ -1717,8 +1717,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident1},
 						&iotago.TimelockUnlockCondition{
-							MilestoneIndex: 5,
-							UnixTime:       1337,
+							UnixTime: 5,
 						},
 					},
 				},
@@ -1731,7 +1730,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			return test{
 				name: "ok",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
-					ConfMsIndex: 10, ConfUnix: 6666,
+					ConfUnix: 10,
 				}},
 				inputs: inputs,
 				tx: &iotago.Transaction{
@@ -1753,7 +1752,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident1},
 						&iotago.TimelockUnlockCondition{
-							MilestoneIndex: 15,
+							UnixTime: 15,
 						},
 					},
 				},
@@ -1766,7 +1765,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			return test{
 				name: "fail - ms index timelock not expired",
 				svCtx: &iotago.SemanticValidationContext{ExtParas: &iotago.ExternalUnlockParameters{
-					ConfMsIndex: 10,
+					ConfUnix: 10,
 				}},
 				inputs: inputs,
 				tx: &iotago.Transaction{

--- a/unlock_cond.go
+++ b/unlock_cond.go
@@ -191,21 +191,8 @@ func (f UnlockConditionSet) returnIdentCanUnlock(extParas *ExternalUnlockParamet
 		return false, nil
 	}
 
-	switch {
-	case expUnlockCond.MilestoneIndex != 0 && expUnlockCond.UnixTime != 0:
-		if expUnlockCond.MilestoneIndex <= extParas.ConfMsIndex && expUnlockCond.UnixTime <= extParas.ConfUnix {
-			return true, expUnlockCond.ReturnAddress
-		}
-
-	case expUnlockCond.MilestoneIndex != 0:
-		if expUnlockCond.MilestoneIndex <= extParas.ConfMsIndex {
-			return true, expUnlockCond.ReturnAddress
-		}
-
-	case expUnlockCond.UnixTime != 0:
-		if expUnlockCond.UnixTime <= extParas.ConfUnix {
-			return true, expUnlockCond.ReturnAddress
-		}
+	if expUnlockCond.UnixTime <= extParas.ConfUnix {
+		return true, expUnlockCond.ReturnAddress
 	}
 
 	return false, nil
@@ -220,10 +207,7 @@ func (f UnlockConditionSet) TimelocksExpired(extParas *ExternalUnlockParameters)
 		return nil
 	}
 
-	switch {
-	case timelock.MilestoneIndex != 0 && extParas.ConfMsIndex < timelock.MilestoneIndex:
-		return fmt.Errorf("%w: (ms index) cond %d vs. ext %d", ErrTimelockNotExpired, timelock.MilestoneIndex, extParas.ConfMsIndex)
-	case timelock.UnixTime != 0 && extParas.ConfUnix < timelock.UnixTime:
+	if extParas.ConfUnix < timelock.UnixTime {
 		return fmt.Errorf("%w: (unix) cond %d vs. ext %d", ErrTimelockNotExpired, timelock.UnixTime, extParas.ConfUnix)
 	}
 

--- a/unlock_cond_test.go
+++ b/unlock_cond_test.go
@@ -27,7 +27,7 @@ func TestUnlockConditionsDeSerialize(t *testing.T) {
 		{
 			name: "ok - TimelockUnlockCondition",
 			source: &iotago.TimelockUnlockCondition{
-				MilestoneIndex: 100,
+				UnixTime: 1000,
 			},
 			target: &iotago.TimelockUnlockCondition{},
 		},

--- a/unlock_cond_timelock.go
+++ b/unlock_cond_timelock.go
@@ -9,19 +9,16 @@ import (
 )
 
 // TimelockUnlockCondition is an unlock condition which puts a time constraint on an output depending
-// on the latest confirmed milestone's index and/or timestamp T:
+// on the latest confirmed milestone's timestamp T:
 //	- the output can only be consumed, if T is bigger than the one defined in the condition.
 type TimelockUnlockCondition struct {
-	// The milestone index until which the timelock applies (inclusive).
-	MilestoneIndex uint32
 	// The unix time in second resolution until which the timelock applies (inclusive).
 	UnixTime uint32
 }
 
 func (s *TimelockUnlockCondition) Clone() UnlockCondition {
 	return &TimelockUnlockCondition{
-		UnixTime:       s.UnixTime,
-		MilestoneIndex: s.MilestoneIndex,
+		UnixTime: s.UnixTime,
 	}
 }
 
@@ -38,8 +35,6 @@ func (s *TimelockUnlockCondition) Equal(other UnlockCondition) bool {
 	switch {
 	case s.UnixTime != otherCond.UnixTime:
 		return false
-	case s.MilestoneIndex != otherCond.MilestoneIndex:
-		return false
 	}
 
 	return true
@@ -54,9 +49,6 @@ func (s *TimelockUnlockCondition) Deserialize(data []byte, deSeriMode serializer
 		CheckTypePrefix(uint32(UnlockConditionTimelock), serializer.TypeDenotationByte, func(err error) error {
 			return fmt.Errorf("unable to deserialize timelock unlock condition: %w", err)
 		}).
-		ReadNum(&s.MilestoneIndex, func(err error) error {
-			return fmt.Errorf("unable to deserialize milestone index for timelock unlock condition: %w", err)
-		}).
 		ReadNum(&s.UnixTime, func(err error) error {
 			return fmt.Errorf("unable to deserialize unix time for timelock unlock condition: %w", err)
 		}).
@@ -68,9 +60,6 @@ func (s *TimelockUnlockCondition) Serialize(_ serializer.DeSerializationMode, de
 		WriteNum(byte(UnlockConditionTimelock), func(err error) error {
 			return fmt.Errorf("unable to serialize timelock unlock condition type ID: %w", err)
 		}).
-		WriteNum(s.MilestoneIndex, func(err error) error {
-			return fmt.Errorf("unable to serialize timelock unlock condition milestone index: %w", err)
-		}).
 		WriteNum(s.UnixTime, func(err error) error {
 			return fmt.Errorf("unable to serialize timelock unlock condition unix time: %w", err)
 		}).
@@ -79,14 +68,12 @@ func (s *TimelockUnlockCondition) Serialize(_ serializer.DeSerializationMode, de
 
 func (s *TimelockUnlockCondition) Size() int {
 	return util.NumByteLen(byte(UnlockConditionTimelock)) +
-		util.NumByteLen(s.MilestoneIndex) +
 		util.NumByteLen(s.UnixTime)
 }
 
 func (s *TimelockUnlockCondition) MarshalJSON() ([]byte, error) {
 	jTimelockUnlockCond := &jsonTimelockUnlockCondition{
-		MilestoneIndex: int(s.MilestoneIndex),
-		UnixTime:       int(s.UnixTime),
+		UnixTime: int(s.UnixTime),
 	}
 	jTimelockUnlockCond.Type = int(UnlockConditionTimelock)
 	return json.Marshal(jTimelockUnlockCond)
@@ -107,14 +94,12 @@ func (s *TimelockUnlockCondition) UnmarshalJSON(bytes []byte) error {
 
 // jsonTimelockUnlockCondition defines the json representation of a TimelockUnlockCondition.
 type jsonTimelockUnlockCondition struct {
-	Type           int `json:"type"`
-	MilestoneIndex int `json:"milestoneIndex,omitempty"`
-	UnixTime       int `json:"unixTime,omitempty"`
+	Type     int `json:"type"`
+	UnixTime int `json:"unixTime"`
 }
 
 func (j *jsonTimelockUnlockCondition) ToSerializable() (serializer.Serializable, error) {
 	return &TimelockUnlockCondition{
-		MilestoneIndex: uint32(j.MilestoneIndex),
-		UnixTime:       uint32(j.UnixTime),
+		UnixTime: uint32(j.UnixTime),
 	}, nil
 }


### PR DESCRIPTION
This PR removes the `MilestoneIndex` from `ExpirationUnlockCondition` and `TimelockUnlockCondition`.