### PR TITLE
V3 API routes

### DIFF
--- a/nodeclient/core_models.go
+++ b/nodeclient/core_models.go
@@ -8,6 +8,11 @@ import (
 )
 
 type (
+	// RoutesResponse defines the response of a GET routes REST API call.
+	RoutesResponse struct {
+		Routes []string `json:"routes"`
+	}
+
 	// InfoResponse defines the response of a GET info REST API call.
 	InfoResponse struct {
 		// The name of the node software.
@@ -24,8 +29,6 @@ type (
 		Metrics InfoResMetrics `json:"metrics"`
 		// The features this node exposes.
 		Features []string `json:"features"`
-		// The plugins this node exposes.
-		Plugins []string `json:"plugins"`
 	}
 
 	// InfoResStatus defines info res status information.

--- a/nodeclient/event_api_client.go
+++ b/nodeclient/event_api_client.go
@@ -89,7 +89,7 @@ func brokerURLFromClient(nc *Client) string {
 	baseURL := nc.BaseURL
 	baseURL = strings.Replace(baseURL, "https://", "wss://", 1)
 	baseURL = strings.Replace(baseURL, "http://", "ws://", 1)
-	return fmt.Sprintf("%s/api/plugins/%s", baseURL, MQTTPluginName)
+	return fmt.Sprintf("%s/api/%s", baseURL, MQTTPluginName)
 }
 
 func newEventAPIClient(nc *Client) *EventAPIClient {

--- a/nodeclient/event_api_client_test.go
+++ b/nodeclient/event_api_client_test.go
@@ -29,14 +29,14 @@ func TestMain(m *testing.M) {
 func Test_EventAPIEnabled(t *testing.T) {
 	defer gock.Off()
 
-	originInfo := &nodeclient.InfoResponse{
-		Plugins: []string{"mqtt/v1"},
+	originRoutes := &nodeclient.RoutesResponse{
+		Routes: []string{"mqtt/v1"},
 	}
 
 	gock.New(nodeAPIUrl).
-		Get(nodeclient.RouteInfo).
+		Get(nodeclient.RouteRoutes).
 		Reply(200).
-		JSON(originInfo)
+		JSON(originRoutes)
 
 	client := nodeclient.New(nodeAPIUrl)
 
@@ -47,14 +47,14 @@ func Test_EventAPIEnabled(t *testing.T) {
 func Test_EventAPIDisabled(t *testing.T) {
 	defer gock.Off()
 
-	originInfo := &nodeclient.InfoResponse{
-		Plugins: []string{"someplugin/v1"},
+	originRoutes := &nodeclient.RoutesResponse{
+		Routes: []string{"someplugin/v1"},
 	}
 
 	gock.New(nodeAPIUrl).
-		Get(nodeclient.RouteInfo).
+		Get(nodeclient.RouteRoutes).
 		Reply(200).
-		JSON(originInfo)
+		JSON(originRoutes)
 
 	client := nodeclient.New(nodeAPIUrl)
 

--- a/nodeclient/http_api_client.go
+++ b/nodeclient/http_api_client.go
@@ -23,92 +23,96 @@ const (
 	// RouteHealth is the route for querying a node's health status.
 	RouteHealth = "/health"
 
+	// RouteRoutes is the route for getting the routes the node supports.
+	// GET returns the nodes routes.
+	RouteRoutes = "/api/routes"
+
 	// RouteInfo is the route for getting the node info.
 	// GET returns the node info.
-	RouteInfo = "/api/v2/info"
+	RouteInfo = "/api/core/v2/info"
 
 	// RouteTips is the route for getting tips.
 	// GET returns the tips.
-	RouteTips = "/api/v2/tips"
+	RouteTips = "/api/core/v2/tips"
 
 	// RouteBlock is the route for getting a block by its ID.
 	// GET returns the block based on the given type in the request "Accept" header.
 	// MIMEApplicationJSON => json
 	// MIMEVendorIOTASerializer => bytes
-	RouteBlock = "/api/v2/blocks/%s"
+	RouteBlock = "/api/core/v2/blocks/%s"
 
 	// RouteBlockMetadata is the route for getting block metadata by its ID.
 	// GET returns block metadata (including info about "promotion/reattachment needed").
-	RouteBlockMetadata = "/api/v2/blocks/%s/metadata"
+	RouteBlockMetadata = "/api/core/v2/blocks/%s/metadata"
 
 	// RouteBlockChildren is the route for getting block IDs of the children of a block, identified by its block ID.
 	// GET returns the block IDs of all children.
-	RouteBlockChildren = "/api/v2/blocks/%s/children"
+	RouteBlockChildren = "/api/core/v2/blocks/%s/children"
 
 	// RouteBlocks is the route for creating new blocks.
 	// POST creates a single new block and returns the ID.
 	// The block is parsed based on the given type in the request "Content-Type" header.
 	// MIMEApplicationJSON => json
 	// MIMEVendorIOTASerializer => bytes
-	RouteBlocks = "/api/v2/blocks"
+	RouteBlocks = "/api/core/v2/blocks"
 
 	// RouteTransactionsIncludedBlock is the route for getting the block that was included in the ledger for a given transaction ID.
 	// GET returns the block based on the given type in the request "Accept" header.
 	// MIMEApplicationJSON => json
 	// MIMEVendorIOTASerializer => bytes
-	RouteTransactionsIncludedBlock = "/api/v2/transactions/%s/included-block"
+	RouteTransactionsIncludedBlock = "/api/core/v2/transactions/%s/included-block"
 
 	// RouteMilestoneByID is the route for getting a milestone by its ID.
 	// GET returns the milestone.
-	RouteMilestoneByID = "/api/v2/milestones/%s"
+	RouteMilestoneByID = "/api/core/v2/milestones/%s"
 
 	// RouteMilestoneByIDUTXOChanges is the route for getting all UTXO changes of a milestone by its ID.
 	// GET returns the output IDs of all UTXO changes.
-	RouteMilestoneByIDUTXOChanges = "/api/v2/milestones/%s/utxo-changes"
+	RouteMilestoneByIDUTXOChanges = "/api/core/v2/milestones/%s/utxo-changes"
 
 	// RouteMilestoneByIndex is the route for getting a milestone by its milestoneIndex.
 	// GET returns the milestone.
-	RouteMilestoneByIndex = "/api/v2/milestones/by-index/%d"
+	RouteMilestoneByIndex = "/api/core/v2/milestones/by-index/%d"
 
 	// RouteMilestoneByIndexUTXOChanges is the route for getting all UTXO changes of a milestone by its milestoneIndex.
 	// GET returns the output IDs of all UTXO changes.
-	RouteMilestoneByIndexUTXOChanges = "/api/v2/milestones/%d/utxo-changes"
+	RouteMilestoneByIndexUTXOChanges = "/api/core/v2/milestones/%d/utxo-changes"
 
 	// RouteOutput is the route for getting an output by its outputID (transactionHash + outputIndex).
 	// GET returns the output based on the given type in the request "Accept" header.
 	// MIMEApplicationJSON => json
 	// MIMEVendorIOTASerializer => bytes
-	RouteOutput = "/api/v2/outputs/%s"
+	RouteOutput = "/api/core/v2/outputs/%s"
 
 	// RouteOutputMetadata is the route for getting output metadata by its outputID (transactionHash + outputIndex) without getting the data again.
 	// GET returns the output metadata.
-	RouteOutputMetadata = "/api/v2/outputs/%s/metadata"
+	RouteOutputMetadata = "/api/core/v2/outputs/%s/metadata"
 
 	// RouteTreasury is the route for getting the current treasury output.
 	// GET returns the treasury.
-	RouteTreasury = "/api/v2/treasury"
+	RouteTreasury = "/api/core/v2/treasury"
 
 	// RouteReceipts is the route for getting all persisted receipts on a node.
 	// GET returns the receipts.
-	RouteReceipts = "/api/v2/receipts"
+	RouteReceipts = "/api/core/v2/receipts"
 
 	// RouteReceiptsMigratedAtIndex is the route for getting all persisted receipts for a given migrated at index on a node.
 	// GET returns the receipts for the given migrated at index.
-	RouteReceiptsMigratedAtIndex = "/api/v2/receipts/%d"
+	RouteReceiptsMigratedAtIndex = "/api/core/v2/receipts/%d"
 
 	// RouteComputeWhiteFlagMutations is the route to compute the white flag mutations for the cone of the given parents.
 	// POST computes the white flag mutations.
-	RouteComputeWhiteFlagMutations = "/api/v2/whiteflag"
+	RouteComputeWhiteFlagMutations = "/api/core/v2/whiteflag"
 
 	// RoutePeer is the route for getting peers by their peerID.
 	// GET returns the peer
 	// DELETE deletes the peer.
-	RoutePeer = "/api/v2/peers/%s"
+	RoutePeer = "/api/core/v2/peers/%s"
 
 	// RoutePeers is the route for getting all peers of the node.
 	// GET returns a list of all peers.
 	// POST adds a new peer.
-	RoutePeers = "/api/v2/peers"
+	RoutePeers = "/api/core/v2/peers"
 )
 
 var (
@@ -236,7 +240,7 @@ func (client *Client) DoWithRequestHeaderHook(ctx context.Context, method string
 // Indexer returns the IndexerClient.
 // Returns ErrIndexerPluginNotAvailable if the current node does not support the plugin.
 func (client *Client) Indexer(ctx context.Context) (IndexerClient, error) {
-	hasPlugin, err := client.NodeSupportsPlugin(ctx, IndexerPluginName)
+	hasPlugin, err := client.NodeSupportsRoute(ctx, IndexerPluginName)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +253,7 @@ func (client *Client) Indexer(ctx context.Context) (IndexerClient, error) {
 // EventAPI returns the EventAPIClient if supported by the node.
 // Returns ErrMQTTPluginNotAvailable if the current node does not support the plugin.
 func (client *Client) EventAPI(ctx context.Context) (*EventAPIClient, error) {
-	hasPlugin, err := client.NodeSupportsPlugin(ctx, MQTTPluginName)
+	hasPlugin, err := client.NodeSupportsRoute(ctx, MQTTPluginName)
 	if err != nil {
 		return nil, err
 	}
@@ -272,6 +276,16 @@ func (client *Client) Health(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+// Routes gets the routes the node supports.
+func (client *Client) Routes(ctx context.Context) (*RoutesResponse, error) {
+	res := &RoutesResponse{}
+	if _, err := client.Do(ctx, http.MethodGet, RouteRoutes, nil, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 // Info gets the info of the node.
 func (client *Client) Info(ctx context.Context) (*InfoResponse, error) {
 	res := &InfoResponse{}
@@ -282,14 +296,14 @@ func (client *Client) Info(ctx context.Context) (*InfoResponse, error) {
 	return res, nil
 }
 
-// NodeSupportsPlugin gets the info of the node and checks if the given plugin is enabled.
-func (client *Client) NodeSupportsPlugin(ctx context.Context, pluginName string) (bool, error) {
-	info, err := client.Info(ctx)
+// NodeSupportsRoute gets the routes of the node and checks if the given route is enabled.
+func (client *Client) NodeSupportsRoute(ctx context.Context, route string) (bool, error) {
+	routes, err := client.Routes(ctx)
 	if err != nil {
 		return false, err
 	}
-	for _, p := range info.Plugins {
-		if p == pluginName {
+	for _, p := range routes.Routes {
+		if p == route {
 			return true, nil
 		}
 	}

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -87,7 +87,6 @@ func TestClient_Info(t *testing.T) {
 			ReferencedRate:            50.0,
 		},
 		Features: []string{"Lazers"},
-		Plugins:  []string{"indexer/v1"},
 	}
 
 	gock.New(nodeAPIUrl).

--- a/nodeclient/indexer_client.go
+++ b/nodeclient/indexer_client.go
@@ -11,13 +11,13 @@ import (
 
 // Indexer plugin routes
 var (
-	IndexerAPIRouteBasicOutputs = "/api/plugins/" + IndexerPluginName + "/outputs/basic"
-	IndexerAPIRouteAliases      = "/api/plugins/" + IndexerPluginName + "/outputs/alias"
-	IndexerAPIRouteAlias        = "/api/plugins/" + IndexerPluginName + "/outputs/alias/%s"
-	IndexerAPIRouteFoundries    = "/api/plugins/" + IndexerPluginName + "/outputs/foundry"
-	IndexerAPIRouteFoundry      = "/api/plugins/" + IndexerPluginName + "/outputs/foundry/%s"
-	IndexerAPIRouteNFTs         = "/api/plugins/" + IndexerPluginName + "/outputs/nft"
-	IndexerAPIRouteNFT          = "/api/plugins/" + IndexerPluginName + "/outputs/nft/%s"
+	IndexerAPIRouteBasicOutputs = "/api/" + IndexerPluginName + "/outputs/basic"
+	IndexerAPIRouteAliases      = "/api/" + IndexerPluginName + "/outputs/alias"
+	IndexerAPIRouteAlias        = "/api/" + IndexerPluginName + "/outputs/alias/%s"
+	IndexerAPIRouteFoundries    = "/api/" + IndexerPluginName + "/outputs/foundry"
+	IndexerAPIRouteFoundry      = "/api/" + IndexerPluginName + "/outputs/foundry/%s"
+	IndexerAPIRouteNFTs         = "/api/" + IndexerPluginName + "/outputs/nft"
+	IndexerAPIRouteNFT          = "/api/" + IndexerPluginName + "/outputs/nft/%s"
 )
 
 var (

--- a/nodeclient/indexer_client_test.go
+++ b/nodeclient/indexer_client_test.go
@@ -56,14 +56,14 @@ func TestOutputsQuery_Build(t *testing.T) {
 func Test_IndexerEnabled(t *testing.T) {
 	defer gock.Off()
 
-	originInfo := &nodeclient.InfoResponse{
-		Plugins: []string{"indexer/v1"},
+	originRoutes := &nodeclient.RoutesResponse{
+		Routes: []string{"indexer/v1"},
 	}
 
 	gock.New(nodeAPIUrl).
-		Get(nodeclient.RouteInfo).
+		Get(nodeclient.RouteRoutes).
 		Reply(200).
-		JSON(originInfo)
+		JSON(originRoutes)
 
 	client := nodeclient.New(nodeAPIUrl)
 
@@ -74,14 +74,14 @@ func Test_IndexerEnabled(t *testing.T) {
 func Test_IndexerDisabled(t *testing.T) {
 	defer gock.Off()
 
-	originInfo := &nodeclient.InfoResponse{
-		Plugins: []string{"someplugin/v1"},
+	originRoutes := &nodeclient.RoutesResponse{
+		Routes: []string{"someplugin/v1"},
 	}
 
 	gock.New(nodeAPIUrl).
-		Get(nodeclient.RouteInfo).
+		Get(nodeclient.RouteRoutes).
 		Reply(200).
-		JSON(originInfo)
+		JSON(originRoutes)
 
 	client := nodeclient.New(nodeAPIUrl)
 
@@ -113,14 +113,14 @@ func TestIndexerClient_BasicOutputs(t *testing.T) {
 		RawOutput: &rawMsgSigDepJson,
 	}
 
-	originInfo := &nodeclient.InfoResponse{
-		Plugins: []string{"indexer/v1"},
+	originRoutes := &nodeclient.RoutesResponse{
+		Routes: []string{"indexer/v1"},
 	}
 
 	gock.New(nodeAPIUrl).
-		Get(nodeclient.RouteInfo).
+		Get(nodeclient.RouteRoutes).
 		Reply(200).
-		JSON(originInfo)
+		JSON(originRoutes)
 
 	gock.New(nodeAPIUrl).
 		Get(nodeclient.IndexerAPIRouteBasicOutputs).


### PR DESCRIPTION
- Use the new `/api/routes` endpoint for route discovery
- Adapted the routes to match the new urls