### PR TITLE
Move keymanager from hornet to iota.go

### DIFF
--- a/keymanager/keymanager.go
+++ b/keymanager/keymanager.go
@@ -1,0 +1,112 @@
+package keymanager
+
+import (
+	"crypto/ed25519"
+	"sort"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+)
+
+// KeyRange defines a public key of a milestone including the range it is valid.
+type KeyRange struct {
+	PublicKey  iotago.MilestonePublicKey
+	StartIndex uint32
+	EndIndex   uint32
+}
+
+// KeyManager provides public and private keys for ranges of milestone indexes.
+type KeyManager struct {
+	keyRanges []*KeyRange
+}
+
+// New returns a new KeyManager.
+func New() *KeyManager {
+	return &KeyManager{}
+}
+
+// AddKeyRange adds a new public key to the MilestoneKeyManager including its valid range.
+func (k *KeyManager) AddKeyRange(publicKey ed25519.PublicKey, startIndex uint32, endIndex uint32) {
+
+	var msPubKey iotago.MilestonePublicKey
+	copy(msPubKey[:], publicKey)
+
+	k.keyRanges = append(k.keyRanges, &KeyRange{PublicKey: msPubKey, StartIndex: startIndex, EndIndex: endIndex})
+
+	// sort by start index
+	sort.Slice(k.keyRanges, func(i int, j int) bool {
+		return k.keyRanges[i].StartIndex < k.keyRanges[j].StartIndex
+	})
+}
+
+func (k *KeyManager) KeyRanges() []*KeyRange {
+	keyRanges := []*KeyRange{}
+	for _, r := range k.keyRanges {
+		keyRanges = append(keyRanges, &KeyRange{
+			PublicKey:  r.PublicKey,
+			StartIndex: r.StartIndex,
+			EndIndex:   r.EndIndex,
+		})
+	}
+	return keyRanges
+}
+
+// PublicKeysForMilestoneIndex returns the valid public keys for a certain milestone index.
+func (k *KeyManager) PublicKeysForMilestoneIndex(msIndex uint32) []iotago.MilestonePublicKey {
+	var pubKeys []iotago.MilestonePublicKey
+
+	for _, pubKeyRange := range k.keyRanges {
+		if pubKeyRange.StartIndex <= msIndex {
+			if pubKeyRange.EndIndex >= msIndex || pubKeyRange.EndIndex == 0 {
+				// EndIndex == 0 means the key is valid forever
+				pubKeys = append(pubKeys, pubKeyRange.PublicKey)
+			}
+			continue
+		}
+
+		// no need to search further because the keys are sorted by StartIndex
+		break
+	}
+
+	return pubKeys
+}
+
+// PublicKeysSetForMilestoneIndex returns a set of valid public keys for a certain milestone index.
+func (k *KeyManager) PublicKeysSetForMilestoneIndex(msIndex uint32) iotago.MilestonePublicKeySet {
+	pubKeys := k.PublicKeysForMilestoneIndex(msIndex)
+
+	result := iotago.MilestonePublicKeySet{}
+
+	for _, pubKey := range pubKeys {
+		result[pubKey] = struct{}{}
+	}
+
+	return result
+}
+
+// MilestonePublicKeyMappingForMilestoneIndex returns a MilestonePublicKeyMapping for a certain milestone index.
+func (k *KeyManager) MilestonePublicKeyMappingForMilestoneIndex(msIndex uint32, privateKeys []ed25519.PrivateKey, milestonePublicKeysCount int) iotago.MilestonePublicKeyMapping {
+	pubKeySet := k.PublicKeysSetForMilestoneIndex(msIndex)
+
+	result := iotago.MilestonePublicKeyMapping{}
+
+	for _, privKey := range privateKeys {
+		pubKey := privKey.Public().(ed25519.PublicKey)
+
+		var msPubKey iotago.MilestonePublicKey
+		copy(msPubKey[:], pubKey)
+
+		if _, exists := pubKeySet[msPubKey]; exists {
+			result[msPubKey] = privKey
+
+			if len(result) == len(pubKeySet) {
+				break
+			}
+
+			if len(result) == milestonePublicKeysCount {
+				break
+			}
+		}
+	}
+
+	return result
+}

--- a/keymanager/keymanager.go
+++ b/keymanager/keymanager.go
@@ -10,8 +10,8 @@ import (
 // KeyRange defines a public key of a milestone including the range it is valid.
 type KeyRange struct {
 	PublicKey  iotago.MilestonePublicKey
-	StartIndex uint32
-	EndIndex   uint32
+	StartIndex iotago.MilestoneIndex
+	EndIndex   iotago.MilestoneIndex
 }
 
 // KeyManager provides public and private keys for ranges of milestone indexes.
@@ -25,7 +25,7 @@ func New() *KeyManager {
 }
 
 // AddKeyRange adds a new public key to the MilestoneKeyManager including its valid range.
-func (k *KeyManager) AddKeyRange(publicKey ed25519.PublicKey, startIndex uint32, endIndex uint32) {
+func (k *KeyManager) AddKeyRange(publicKey ed25519.PublicKey, startIndex iotago.MilestoneIndex, endIndex iotago.MilestoneIndex) {
 
 	var msPubKey iotago.MilestonePublicKey
 	copy(msPubKey[:], publicKey)
@@ -51,7 +51,7 @@ func (k *KeyManager) KeyRanges() []*KeyRange {
 }
 
 // PublicKeysForMilestoneIndex returns the valid public keys for a certain milestone index.
-func (k *KeyManager) PublicKeysForMilestoneIndex(msIndex uint32) []iotago.MilestonePublicKey {
+func (k *KeyManager) PublicKeysForMilestoneIndex(msIndex iotago.MilestoneIndex) []iotago.MilestonePublicKey {
 	var pubKeys []iotago.MilestonePublicKey
 
 	for _, pubKeyRange := range k.keyRanges {
@@ -71,7 +71,7 @@ func (k *KeyManager) PublicKeysForMilestoneIndex(msIndex uint32) []iotago.Milest
 }
 
 // PublicKeysSetForMilestoneIndex returns a set of valid public keys for a certain milestone index.
-func (k *KeyManager) PublicKeysSetForMilestoneIndex(msIndex uint32) iotago.MilestonePublicKeySet {
+func (k *KeyManager) PublicKeysSetForMilestoneIndex(msIndex iotago.MilestoneIndex) iotago.MilestonePublicKeySet {
 	pubKeys := k.PublicKeysForMilestoneIndex(msIndex)
 
 	result := iotago.MilestonePublicKeySet{}
@@ -84,7 +84,7 @@ func (k *KeyManager) PublicKeysSetForMilestoneIndex(msIndex uint32) iotago.Miles
 }
 
 // MilestonePublicKeyMappingForMilestoneIndex returns a MilestonePublicKeyMapping for a certain milestone index.
-func (k *KeyManager) MilestonePublicKeyMappingForMilestoneIndex(msIndex uint32, privateKeys []ed25519.PrivateKey, milestonePublicKeysCount int) iotago.MilestonePublicKeyMapping {
+func (k *KeyManager) MilestonePublicKeyMappingForMilestoneIndex(msIndex iotago.MilestoneIndex, privateKeys []ed25519.PrivateKey, milestonePublicKeysCount int) iotago.MilestonePublicKeyMapping {
 	pubKeySet := k.PublicKeysSetForMilestoneIndex(msIndex)
 
 	result := iotago.MilestonePublicKeyMapping{}

--- a/keymanager/keymanager_test.go
+++ b/keymanager/keymanager_test.go
@@ -1,0 +1,96 @@
+package keymanager_test
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/iota.go/v3/keymanager"
+)
+
+func TestMilestoneKeyManager(t *testing.T) {
+
+	pubKey1, privKey1, err := ed25519.GenerateKey(nil)
+	assert.NoError(t, err)
+
+	pubKey2, privKey2, err := ed25519.GenerateKey(nil)
+	assert.NoError(t, err)
+
+	pubKey3, privKey3, err := ed25519.GenerateKey(nil)
+	assert.NoError(t, err)
+
+	pubKey4, privKey4, err := ed25519.GenerateKey(nil)
+	assert.NoError(t, err)
+
+	var msPubKey1 iotago.MilestonePublicKey
+	copy(msPubKey1[:], pubKey1)
+
+	var msPubKey2 iotago.MilestonePublicKey
+	copy(msPubKey2[:], pubKey2)
+
+	var msPubKey3 iotago.MilestonePublicKey
+	copy(msPubKey3[:], pubKey3)
+
+	var msPubKey4 iotago.MilestonePublicKey
+	copy(msPubKey4[:], pubKey4)
+
+	km := keymanager.New()
+	km.AddKeyRange(pubKey1, 0, 0)
+	km.AddKeyRange(pubKey2, 3, 10)
+	km.AddKeyRange(pubKey3, 8, 15)
+	km.AddKeyRange(pubKey4, 17, 0)
+
+	keysIndex0 := km.PublicKeysForMilestoneIndex(0)
+	assert.Len(t, keysIndex0, 1)
+
+	keysIndex3 := km.PublicKeysForMilestoneIndex(3)
+	assert.Len(t, keysIndex3, 2)
+
+	keysIndex7 := km.PublicKeysForMilestoneIndex(7)
+	assert.Len(t, keysIndex7, 2)
+
+	keysIndex8 := km.PublicKeysForMilestoneIndex(8)
+	assert.Len(t, keysIndex8, 3)
+
+	keysIndex10 := km.PublicKeysForMilestoneIndex(10)
+	assert.Len(t, keysIndex10, 3)
+
+	keysIndex11 := km.PublicKeysForMilestoneIndex(11)
+	assert.Len(t, keysIndex11, 2)
+
+	keysIndex15 := km.PublicKeysForMilestoneIndex(15)
+	assert.Len(t, keysIndex15, 2)
+
+	keysIndex16 := km.PublicKeysForMilestoneIndex(16)
+	assert.Len(t, keysIndex16, 1)
+
+	keysIndex17 := km.PublicKeysForMilestoneIndex(17)
+	assert.Len(t, keysIndex17, 2)
+
+	keysIndex1000 := km.PublicKeysForMilestoneIndex(1000)
+	assert.Len(t, keysIndex1000, 2)
+
+	keysSet8 := km.PublicKeysSetForMilestoneIndex(8)
+	assert.Len(t, keysSet8, 3)
+
+	assert.Contains(t, keysSet8, msPubKey1)
+	assert.Contains(t, keysSet8, msPubKey2)
+	assert.Contains(t, keysSet8, msPubKey3)
+
+	keyMapping8 := km.MilestonePublicKeyMappingForMilestoneIndex(8, []ed25519.PrivateKey{privKey1, privKey2, privKey3}, 2)
+	assert.Len(t, keyMapping8, 2)
+
+	assert.Equal(t, keyMapping8[msPubKey1], privKey1)
+	assert.Equal(t, keyMapping8[msPubKey2], privKey2)
+
+	keyMapping17 := km.MilestonePublicKeyMappingForMilestoneIndex(17, []ed25519.PrivateKey{privKey1, privKey4}, 2)
+	assert.Len(t, keyMapping17, 2)
+
+	assert.Equal(t, keyMapping17[msPubKey1], privKey1)
+	assert.Equal(t, keyMapping17[msPubKey4], privKey4)
+
+	keysSet17 := km.PublicKeysSetForMilestoneIndex(17)
+	assert.Len(t, keysSet17, 2)
+}

--- a/milestone.go
+++ b/milestone.go
@@ -111,6 +111,9 @@ type (
 	MilestoneMerkleProof = [MilestoneMerkleProofLength]byte
 )
 
+// MilestoneIndex is the index of a Milestone.
+type MilestoneIndex = uint32
+
 // MilestoneID is the ID of a Milestone.
 type MilestoneID [MilestoneIDLength]byte
 
@@ -140,7 +143,7 @@ func (id *MilestoneID) String() string {
 }
 
 // NewMilestone creates a new unsigned Milestone.
-func NewMilestone(index uint32, timestamp uint32, protocolVersion byte, prevMsID MilestoneID, parents BlockIDs, inclMerkleProof MilestoneMerkleProof, appliedMerkleRoot MilestoneMerkleProof) *Milestone {
+func NewMilestone(index MilestoneIndex, timestamp uint32, protocolVersion byte, prevMsID MilestoneID, parents BlockIDs, inclMerkleProof MilestoneMerkleProof, appliedMerkleRoot MilestoneMerkleProof) *Milestone {
 	return &Milestone{
 		Index:               index,
 		Timestamp:           timestamp,
@@ -155,7 +158,7 @@ func NewMilestone(index uint32, timestamp uint32, protocolVersion byte, prevMsID
 // Milestone represents a special payload which defines the inclusion set of other blocks in the Tangle.
 type Milestone struct {
 	// The index of this milestone.
-	Index uint32
+	Index MilestoneIndex
 	// The time at which this milestone was issued.
 	Timestamp uint32
 	// The protocol version under which this milestone operates.
@@ -546,7 +549,7 @@ func (j *jsonMilestone) ToSerializable() (serializer.Serializable, error) {
 	var err error
 
 	payload := &Milestone{}
-	payload.Index = uint32(j.Index)
+	payload.Index = MilestoneIndex(j.Index)
 	payload.Timestamp = uint32(j.Timestamp)
 	payload.ProtocolVersion = byte(j.ProtocolVersion)
 	prevMsID, err := DecodeHex(j.PreviousMilestoneID)

--- a/ms_opt_proto_params.go
+++ b/ms_opt_proto_params.go
@@ -20,7 +20,7 @@ const (
 // ProtocolParamsMilestoneOpt is a MilestoneOpt defining changing protocol parameters.
 type ProtocolParamsMilestoneOpt struct {
 	// The milestone index at which these protocol parameters become active.
-	TargetMilestoneIndex uint32
+	TargetMilestoneIndex MilestoneIndex
 	// The protocol version.
 	ProtocolVersion byte
 	// The protocol parameters in binary form.
@@ -123,7 +123,7 @@ func (j *jsonProtocolParamsMilestoneOpt) ToSerializable() (serializer.Serializab
 		return nil, fmt.Errorf("unable to decode json milestone protocol params option: %w", err)
 	}
 	return &ProtocolParamsMilestoneOpt{
-		TargetMilestoneIndex: uint32(j.TargetMilestoneIndex),
+		TargetMilestoneIndex: MilestoneIndex(j.TargetMilestoneIndex),
 		ProtocolVersion:      byte(j.ProtocolVersion),
 		Params:               params,
 	}, nil

--- a/ms_opt_receipt.go
+++ b/ms_opt_receipt.go
@@ -62,7 +62,7 @@ func MigratedFundEntriesArrayRules() serializer.ArrayRules {
 // ReceiptMilestoneOpt is a listing of migrated funds.
 type ReceiptMilestoneOpt struct {
 	// The milestone index at which the funds were migrated in the legacy network.
-	MigratedAt uint32
+	MigratedAt MilestoneIndex
 	// Whether this ReceiptMilestoneOpt is the final one for a given migrated at index.
 	Final bool
 	// The funds which were migrated with this ReceiptMilestoneOpt.
@@ -219,7 +219,7 @@ type jsonReceiptMilestoneOpt struct {
 
 func (j *jsonReceiptMilestoneOpt) ToSerializable() (serializer.Serializable, error) {
 	payload := &ReceiptMilestoneOpt{}
-	payload.MigratedAt = uint32(j.MigratedAt)
+	payload.MigratedAt = MilestoneIndex(j.MigratedAt)
 
 	migratedFundsEntries := make(MigratedFundsEntries, len(j.Funds))
 	for i, ele := range j.Funds {

--- a/nodeclient/core_models.go
+++ b/nodeclient/core_models.go
@@ -40,13 +40,13 @@ type (
 		// The current confirmed milestone's index.
 		ConfirmedMilestone InfoResMilestone `json:"confirmedMilestone"`
 		// The milestone index at which the last pruning commenced.
-		PruningIndex uint32 `json:"pruningIndex"`
+		PruningIndex iotago.MilestoneIndex `json:"pruningIndex"`
 	}
 
 	// InfoResMilestone defines the info res milestone information.
 	InfoResMilestone struct {
 		// The index of the milestone.
-		Index uint32 `json:"index"`
+		Index iotago.MilestoneIndex `json:"index"`
 		// The unix time of the milestone payload.
 		Timestamp uint32 `json:"timestamp"`
 		// The IO of the milestone.
@@ -94,9 +94,9 @@ type (
 		// Whether the block is solid.
 		Solid bool `json:"isSolid"`
 		// The milestone index that references this block.
-		ReferencedByMilestoneIndex *uint32 `json:"referencedByMilestoneIndex,omitempty"`
+		ReferencedByMilestoneIndex *iotago.MilestoneIndex `json:"referencedByMilestoneIndex,omitempty"`
 		// If this block represents a milestone this is the milestone index
-		MilestoneIndex *uint32 `json:"milestoneIndex,omitempty"`
+		MilestoneIndex *iotago.MilestoneIndex `json:"milestoneIndex,omitempty"`
 		// The ledger inclusion state of the transaction payload.
 		LedgerInclusionState *string `json:"ledgerInclusionState,omitempty"`
 		// Whether the block should be promoted.
@@ -130,17 +130,17 @@ type (
 		// Whether this output is spent.
 		Spent bool `json:"isSpent"`
 		// The milestone index at which this output was spent.
-		MilestoneIndexSpent uint32 `json:"milestoneIndexSpent,omitempty"`
+		MilestoneIndexSpent iotago.MilestoneIndex `json:"milestoneIndexSpent,omitempty"`
 		// The milestone timestamp this output was spent.
 		MilestoneTimestampSpent uint32 `json:"milestoneTimestampSpent,omitempty"`
 		// The transaction this output was spent with.
 		TransactionIDSpent string `json:"transactionIdSpent,omitempty"`
 		// The milestone index at which this output was booked into the ledger.
-		MilestoneIndexBooked uint32 `json:"milestoneIndexBooked"`
+		MilestoneIndexBooked iotago.MilestoneIndex `json:"milestoneIndexBooked"`
 		// The milestone timestamp this output was booked in the ledger.
 		MilestoneTimestampBooked uint32 `json:"milestoneTimestampBooked"`
 		// The ledger index at which this output was available at.
-		LedgerIndex uint32 `json:"ledgerIndex"`
+		LedgerIndex iotago.MilestoneIndex `json:"ledgerIndex"`
 	}
 
 	// OutputResponse defines the response of a GET outputs REST API call.
@@ -164,13 +164,13 @@ type (
 	// ReceiptTuple represents a receipt and the milestone index in which it was contained.
 	ReceiptTuple struct {
 		Receipt        *iotago.ReceiptMilestoneOpt `json:"receipt"`
-		MilestoneIndex uint32                      `json:"milestoneIndex"`
+		MilestoneIndex iotago.MilestoneIndex       `json:"milestoneIndex"`
 	}
 
 	// MilestoneUTXOChangesResponse defines the response of a GET milestone UTXO changes REST API call.
 	MilestoneUTXOChangesResponse struct {
 		// The index of the milestone.
-		Index uint32 `json:"index"`
+		Index iotago.MilestoneIndex `json:"index"`
 		// The output IDs (transaction hash + output index) of the newly created outputs.
 		CreatedOutputs []string `json:"createdOutputs"`
 		// The output IDs (transaction hash + output index) of the consumed (spent) outputs.
@@ -180,7 +180,7 @@ type (
 	// ComputeWhiteFlagMutationsRequest defines the request for a POST ComputeWhiteFlagMutations REST API call.
 	ComputeWhiteFlagMutationsRequest struct {
 		// The index of the milestone.
-		Index uint32 `json:"index"`
+		Index iotago.MilestoneIndex `json:"index"`
 		// The timestamp of the milestone.
 		Timestamp uint32 `json:"timestamp"`
 		// The hex encoded IDs of the parent blocks the milestone references.
@@ -245,11 +245,11 @@ type (
 	//	- the node performed pruning of data
 	GossipHeartbeat struct {
 		// The solid milestone of the node.
-		SolidMilestoneIndex uint32 `json:"solidMilestoneIndex"`
+		SolidMilestoneIndex iotago.MilestoneIndex `json:"solidMilestoneIndex"`
 		// The milestone index at which the node pruned its data.
-		PrunedMilestoneIndex uint32 `json:"prunedMilestoneIndex"`
+		PrunedMilestoneIndex iotago.MilestoneIndex `json:"prunedMilestoneIndex"`
 		// The latest known milestone index by the node.
-		LatestMilestoneIndex uint32 `json:"latestMilestoneIndex"`
+		LatestMilestoneIndex iotago.MilestoneIndex `json:"latestMilestoneIndex"`
 		// The amount of currently connected peers.
 		ConnectedPeers int `json:"connectedPeers"`
 		// The amount of currently connected peers who also

--- a/nodeclient/event_api_client.go
+++ b/nodeclient/event_api_client.go
@@ -359,9 +359,9 @@ func (eac *EventAPIClient) Receipts() (<-chan *iotago.ReceiptMilestoneOpt, *Even
 
 // MilestoneInfo is an informative struct holding a milestone index, milestone ID and timestamp.
 type MilestoneInfo struct {
-	Index       uint32 `json:"index"`
-	Timestamp   uint32 `json:"timestamp"`
-	MilestoneID string `json:"milestoneId"`
+	Index       iotago.MilestoneIndex `json:"index"`
+	Timestamp   uint32                `json:"timestamp"`
+	MilestoneID string                `json:"milestoneId"`
 }
 
 // LatestMilestones returns a channel of infos about newly seen latest milestones.

--- a/nodeclient/http_api_client.go
+++ b/nodeclient/http_api_client.go
@@ -467,7 +467,7 @@ func (client *Client) Receipts(ctx context.Context) ([]*ReceiptTuple, error) {
 }
 
 // ReceiptsByMigratedAtIndex gets all receipts for the given migrated at index persisted on the node.
-func (client *Client) ReceiptsByMigratedAtIndex(ctx context.Context, index uint32) ([]*ReceiptTuple, error) {
+func (client *Client) ReceiptsByMigratedAtIndex(ctx context.Context, index iotago.MilestoneIndex) ([]*ReceiptTuple, error) {
 	query := fmt.Sprintf(RouteReceiptsMigratedAtIndex, index)
 
 	res := &ReceiptsResponse{}
@@ -508,7 +508,7 @@ func (client *Client) MilestoneUTXOChangesByID(ctx context.Context, id iotago.Mi
 }
 
 // MilestoneByIndex gets a milestone by its index.
-func (client *Client) MilestoneByIndex(ctx context.Context, index uint32) (*iotago.Milestone, error) {
+func (client *Client) MilestoneByIndex(ctx context.Context, index iotago.MilestoneIndex) (*iotago.Milestone, error) {
 	query := fmt.Sprintf(RouteMilestoneByIndex, index)
 
 	res := &RawDataEnvelope{}
@@ -525,7 +525,7 @@ func (client *Client) MilestoneByIndex(ctx context.Context, index uint32) (*iota
 }
 
 // MilestoneUTXOChangesByIndex returns all UTXO changes of a milestone by its milestoneIndex.
-func (client *Client) MilestoneUTXOChangesByIndex(ctx context.Context, index uint32) (*MilestoneUTXOChangesResponse, error) {
+func (client *Client) MilestoneUTXOChangesByIndex(ctx context.Context, index iotago.MilestoneIndex) (*MilestoneUTXOChangesResponse, error) {
 	query := fmt.Sprintf(RouteMilestoneByIndexUTXOChanges, index)
 
 	res := &MilestoneUTXOChangesResponse{}
@@ -538,7 +538,7 @@ func (client *Client) MilestoneUTXOChangesByIndex(ctx context.Context, index uin
 
 // ComputeWhiteFlagMutations is the route to compute the white flag mutations for the cone of the given parents.
 // This function returns the merkle tree roots calculated by the node.
-func (client *Client) ComputeWhiteFlagMutations(ctx context.Context, index uint32, timestamp uint32, parents iotago.BlockIDs, previousMilestoneID iotago.MilestoneID) (*ComputeWhiteFlagMutationsResponse, error) {
+func (client *Client) ComputeWhiteFlagMutations(ctx context.Context, index iotago.MilestoneIndex, timestamp uint32, parents iotago.BlockIDs, previousMilestoneID iotago.MilestoneID) (*ComputeWhiteFlagMutationsResponse, error) {
 
 	parentsHex := make([]string, len(parents))
 	for i, parent := range parents {

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -420,7 +420,7 @@ func TestNodeHTTPAPIClient_Receipts(t *testing.T) {
 func TestNodeHTTPAPIClient_ReceiptsByMigratedAtIndex(t *testing.T) {
 	defer gock.Off()
 
-	var index uint32 = 1000
+	var index iotago.MilestoneIndex = 1000
 
 	originRes := &nodeclient.ReceiptsResponse{
 		Receipts: []*nodeclient.ReceiptTuple{
@@ -526,7 +526,7 @@ func TestClient_MilestoneUTXOChangesByID(t *testing.T) {
 func TestClient_MilestoneByIndex(t *testing.T) {
 	defer gock.Off()
 
-	var milestoneIndex uint32 = 1337
+	var milestoneIndex iotago.MilestoneIndex = 1337
 
 	milestone := &iotago.Milestone{
 		Index:               milestoneIndex,
@@ -568,7 +568,7 @@ func TestClient_MilestoneByIndex(t *testing.T) {
 func TestClient_MilestoneUTXOChangesByIndex(t *testing.T) {
 	defer gock.Off()
 
-	var milestoneIndex uint32 = 1337
+	var milestoneIndex iotago.MilestoneIndex = 1337
 
 	randCreatedOutput := tpkg.RandUTXOInput()
 	randConsumedOutput := tpkg.RandUTXOInput()
@@ -593,7 +593,7 @@ func TestClient_MilestoneUTXOChangesByIndex(t *testing.T) {
 func TestClient_ComputeWhiteFlagMutations(t *testing.T) {
 	defer gock.Off()
 
-	var milestoneIndex uint32 = 1337
+	var milestoneIndex iotago.MilestoneIndex = 1337
 	var milestoneTimestamp uint32 = 1333337
 
 	parents := tpkg.SortedRandBlockIDs(1 + rand.Intn(7))

--- a/nodeclient/indexer_client_test.go
+++ b/nodeclient/indexer_client_test.go
@@ -17,18 +17,14 @@ import (
 func TestOutputsQuery_Build(t *testing.T) {
 	query := &nodeclient.BasicOutputsQuery{
 		IndexerTimelockParas: nodeclient.IndexerTimelockParas{
-			HasTimelockCondition:      true,
-			TimelockedBefore:          1,
-			TimelockedAfter:           2,
-			TimelockedBeforeMilestone: 3,
-			TimelockedAfterMilestone:  4,
+			HasTimelockCondition: true,
+			TimelockedBefore:     1,
+			TimelockedAfter:      2,
 		},
 		IndexerExpirationParas: nodeclient.IndexerExpirationParas{
 			HasExpirationCondition: true,
 			ExpiresBefore:          5,
 			ExpiresAfter:           6,
-			ExpiresBeforeMilestone: 7,
-			ExpiresAfterMilestone:  8,
 		},
 		IndexerCreationParas: nodeclient.IndexerCreationParas{
 			CreatedBefore: 9,

--- a/nodeclient/indexer_models.go
+++ b/nodeclient/indexer_models.go
@@ -34,10 +34,6 @@ type IndexerTimelockParas struct {
 	TimelockedBefore uint32 `qs:"timelockedBefore,omitempty"`
 	// Return outputs that are timelocked after a certain Unix timestamp.
 	TimelockedAfter uint32 `qs:"timelockedAfter,omitempty"`
-	// Return outputs that are timelocked before a certain milestone index.
-	TimelockedBeforeMilestone uint32 `qs:"timelockedBeforeMilestone,omitempty"`
-	// Return outputs that are timelocked after a certain milestone index.
-	TimelockedAfterMilestone uint32 `qs:"timelockedAfterMilestone,omitempty"`
 }
 
 // IndexerExpirationParas define expiration query parameters.
@@ -48,10 +44,6 @@ type IndexerExpirationParas struct {
 	ExpiresBefore uint32 `qs:"expiresBefore,omitempty"`
 	// Return outputs that expire after a certain Unix timestamp.
 	ExpiresAfter uint32 `qs:"expiresAfter,omitempty"`
-	// Return outputs that expire before a certain milestone index.
-	ExpiresBeforeMilestone uint32 `qs:"expiresBeforeMilestone,omitempty"`
-	// Return outputs that expire after a certain milestone index.
-	ExpiresAfterMilestone uint32 `qs:"expiresAfterMilestone,omitempty"`
 	// Filter outputs based on the presence of a specific return address in the expiration unlock condition.
 	ExpirationReturnAddressBech32 string `qs:"expirationReturnAddress,omitempty"`
 }

--- a/nodeclient/indexer_models.go
+++ b/nodeclient/indexer_models.go
@@ -9,7 +9,7 @@ import (
 // IndexerResponse is the standard successful response by the indexer.
 type IndexerResponse struct {
 	// The ledger index at which these outputs where available at.
-	LedgerIndex uint32 `json:"ledgerIndex"`
+	LedgerIndex iotago.MilestoneIndex `json:"ledgerIndex"`
 	// The maximum count of results that are returned by the node.
 	PageSize int `json:"pageSize"`
 	// The output IDs (transaction hash + output index) of the found outputs.

--- a/receipt_builder.go
+++ b/receipt_builder.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewReceiptBuilder creates a new ReceiptBuilder.
-func NewReceiptBuilder(migratedAt uint32) *ReceiptBuilder {
+func NewReceiptBuilder(migratedAt MilestoneIndex) *ReceiptBuilder {
 	return &ReceiptBuilder{
 		r: &ReceiptMilestoneOpt{
 			MigratedAt:  migratedAt,

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -305,7 +305,7 @@ func RandMilestone(parents iotago.BlockIDs) *iotago.Milestone {
 	}
 
 	msPayload := &iotago.Milestone{
-		Index:               uint32(rand.Intn(1000)),
+		Index:               iotago.MilestoneIndex(rand.Intn(1000)),
 		Timestamp:           uint32(time.Now().Unix()),
 		PreviousMilestoneID: Rand32ByteArray(),
 		Parents:             parents,


### PR DESCRIPTION
We need the keymanager in several repositories (hornet, inx-coordinator, ...).

It uses a type from iota.go, so it may make sense to directly move the code to iota.go.

What do you think? @luca-moser 