### PR TITLE
Move signingprovider from inx-coordinator to iota.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,12 @@ require (
 	filippo.io/edwards25519 v1.0.0
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/ethereum/go-ethereum v1.10.19
-	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220531132324-8347a155e220
+	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220623193802-86a373581cc1
 	github.com/iotaledger/iota.go v1.0.0
 	github.com/pasztorpisti/qs v0.0.0-20171216220353-8d6c33ee906c
-	github.com/stretchr/testify v1.7.3
-	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.4
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/h2non/gock.v1 v1.1.2
@@ -25,15 +26,14 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
-	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 // indirect
+	golang.org/x/net v0.0.0-20220622184535-263ec571b305 // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
-	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
+	golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
-	google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad // indirect
+	google.golang.org/genproto v0.0.0-20220623142657-077d458a5694 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220531132324-8347a155e220 h1:s+zUBEj9ji/5en3CkPIHZo44dFUeOByMH8x/WNKpHl0=
-github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220531132324-8347a155e220/go.mod h1:7fVUqbLY+iBjCNjFwzbhOyS07OZJFIYJEDNJAItzMw8=
+github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220623193802-86a373581cc1 h1:czZvfFN0hGpbbGVZ92FA8cIUlesfKJJRV50qgWEpi+w=
+github.com/iotaledger/hive.go/serializer/v2 v2.0.0-20220623193802-86a373581cc1/go.mod h1:7fVUqbLY+iBjCNjFwzbhOyS07OZJFIYJEDNJAItzMw8=
 github.com/iotaledger/iota.go v1.0.0 h1:tqm1FxJ/zOdzbrAaQ5BQpVF8dUy2eeGlSeWlNG8GoXY=
 github.com/iotaledger/iota.go v1.0.0/go.mod h1:RiKYwDyY7aCD1L0YRzHSjOsJ5mUR9yvQpvhZncNcGQI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -123,8 +123,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.3 h1:dAm0YRdRQlWojc3CrCRgPBzG5f941d0zvAKu7qY4e+I=
-github.com/stretchr/testify v1.7.3/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
+github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -132,8 +132,8 @@ go.mongodb.org/mongo-driver v1.0.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -151,8 +151,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 h1:Yqz/iviulwKwAREEeUd3nbBFn0XuyJqkoft2IlrvOhc=
-golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220622184535-263ec571b305 h1:dAgbJ2SP4jD6XYfMNLVj0BF21jo2PjChrtGaAvF5M3I=
+golang.org/x/net v0.0.0-20220622184535-263ec571b305/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -177,8 +177,8 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
-golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 h1:wEZYwx+kK+KlZ0hpvP2Ls1Xr4+RWnlzGFwPP0aiDjIU=
+golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -201,8 +201,8 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad h1:kqrS+lhvaMHCxul6sKQvKJ8nAAhlVItmZV822hYFH/U=
-google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220623142657-077d458a5694 h1:itnFmgk4Ls5nT+mYO2ZK6F0DpKsGZLhB5BB9y5ZL2HA=
+google.golang.org/genproto v0.0.0-20220623142657-077d458a5694/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/signingprovider/signing_provider.go
+++ b/signingprovider/signing_provider.go
@@ -1,0 +1,144 @@
+package signingprovider
+
+import (
+	"crypto/ed25519"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/iota.go/v3/keymanager"
+)
+
+// MilestoneSignerProvider provides milestone signers.
+type MilestoneSignerProvider interface {
+	// MilestoneIndexSigner returns a new signer for the milestone index.
+	MilestoneIndexSigner(index iotago.MilestoneIndex) MilestoneIndexSigner
+	// PublicKeysCount returns the amount of public keys in a milestone.
+	PublicKeysCount() int
+}
+
+// MilestoneIndexSigner is a signer for a particular milestone.
+type MilestoneIndexSigner interface {
+	// PublicKeys returns a slice of the used public keys.
+	PublicKeys() []iotago.MilestonePublicKey
+	// PublicKeysSet returns a map of the used public keys.
+	PublicKeysSet() iotago.MilestonePublicKeySet
+	// SigningFunc returns a function to sign the particular milestone.
+	SigningFunc() iotago.MilestoneSigningFunc
+}
+
+// InMemoryEd25519MilestoneSignerProvider provides InMemoryEd25519MilestoneIndexSigner.
+type InMemoryEd25519MilestoneSignerProvider struct {
+	privateKeys     []ed25519.PrivateKey
+	keyManger       *keymanager.KeyManager
+	publicKeysCount int
+}
+
+// NewInMemoryEd25519MilestoneSignerProvider creates a new InMemoryEd25519MilestoneSignerProvider.
+func NewInMemoryEd25519MilestoneSignerProvider(privateKeys []ed25519.PrivateKey, keyManager *keymanager.KeyManager, publicKeysCount int) *InMemoryEd25519MilestoneSignerProvider {
+
+	return &InMemoryEd25519MilestoneSignerProvider{
+		privateKeys:     privateKeys,
+		keyManger:       keyManager,
+		publicKeysCount: publicKeysCount,
+	}
+}
+
+// MilestoneIndexSigner returns a new signer for the milestone index.
+func (p *InMemoryEd25519MilestoneSignerProvider) MilestoneIndexSigner(index iotago.MilestoneIndex) MilestoneIndexSigner {
+
+	pubKeySet := p.keyManger.PublicKeysSetForMilestoneIndex(index)
+
+	keyPairs := p.keyManger.MilestonePublicKeyMappingForMilestoneIndex(index, p.privateKeys, p.PublicKeysCount())
+	pubKeys := make([]iotago.MilestonePublicKey, 0, len(keyPairs))
+	for pubKey := range keyPairs {
+		pubKeys = append(pubKeys, pubKey)
+	}
+
+	milestoneSignFunc := iotago.InMemoryEd25519MilestoneSigner(keyPairs)
+
+	return &InMemoryEd25519MilestoneIndexSigner{
+		pubKeys:     pubKeys,
+		pubKeySet:   pubKeySet,
+		signingFunc: milestoneSignFunc,
+	}
+}
+
+// PublicKeysCount returns the amount of public keys in a milestone.
+func (p *InMemoryEd25519MilestoneSignerProvider) PublicKeysCount() int {
+	return p.publicKeysCount
+}
+
+// InMemoryEd25519MilestoneIndexSigner is an in memory signer for a particular milestone.
+type InMemoryEd25519MilestoneIndexSigner struct {
+	pubKeys     []iotago.MilestonePublicKey
+	pubKeySet   iotago.MilestonePublicKeySet
+	signingFunc iotago.MilestoneSigningFunc
+}
+
+// PublicKeys returns a slice of the used public keys.
+func (s *InMemoryEd25519MilestoneIndexSigner) PublicKeys() []iotago.MilestonePublicKey {
+	return s.pubKeys
+}
+
+// PublicKeysSet returns a map of the used public keys.
+func (s *InMemoryEd25519MilestoneIndexSigner) PublicKeysSet() iotago.MilestonePublicKeySet {
+	return s.pubKeySet
+}
+
+// SigningFunc returns a function to sign the particular milestone.
+func (s *InMemoryEd25519MilestoneIndexSigner) SigningFunc() iotago.MilestoneSigningFunc {
+	return s.signingFunc
+}
+
+// InsecureRemoteEd25519MilestoneSignerProvider provides InsecureRemoteEd25519MilestoneIndexSigner.
+type InsecureRemoteEd25519MilestoneSignerProvider struct {
+	signingFunc     iotago.MilestoneSigningFunc
+	keyManger       *keymanager.KeyManager
+	publicKeysCount int
+}
+
+// NewInsecureRemoteEd25519MilestoneSignerProvider creates a new InsecureRemoteEd25519MilestoneSignerProvider.
+func NewInsecureRemoteEd25519MilestoneSignerProvider(remoteEndpoint string, keyManager *keymanager.KeyManager, publicKeysCount int) *InsecureRemoteEd25519MilestoneSignerProvider {
+
+	return &InsecureRemoteEd25519MilestoneSignerProvider{
+		signingFunc:     iotago.InsecureRemoteEd25519MilestoneSigner(remoteEndpoint),
+		keyManger:       keyManager,
+		publicKeysCount: publicKeysCount,
+	}
+}
+
+// MilestoneIndexSigner returns a new signer for the milestone index.
+func (p *InsecureRemoteEd25519MilestoneSignerProvider) MilestoneIndexSigner(index iotago.MilestoneIndex) MilestoneIndexSigner {
+
+	return &InsecureRemoteEd25519MilestoneIndexSigner{
+		pubKeys:     p.keyManger.PublicKeysForMilestoneIndex(index),
+		pubKeySet:   p.keyManger.PublicKeysSetForMilestoneIndex(index),
+		signingFunc: p.signingFunc,
+	}
+}
+
+// PublicKeysCount returns the amount of public keys in a milestone.
+func (p *InsecureRemoteEd25519MilestoneSignerProvider) PublicKeysCount() int {
+	return p.publicKeysCount
+}
+
+// InsecureRemoteEd25519MilestoneIndexSigner is an in memory signer for a particular milestone.
+type InsecureRemoteEd25519MilestoneIndexSigner struct {
+	pubKeys     []iotago.MilestonePublicKey
+	pubKeySet   iotago.MilestonePublicKeySet
+	signingFunc iotago.MilestoneSigningFunc
+}
+
+// PublicKeys returns a slice of the used public keys.
+func (s *InsecureRemoteEd25519MilestoneIndexSigner) PublicKeys() []iotago.MilestonePublicKey {
+	return s.pubKeys
+}
+
+// PublicKeysSet returns a map of the used public keys.
+func (s *InsecureRemoteEd25519MilestoneIndexSigner) PublicKeysSet() iotago.MilestonePublicKeySet {
+	return s.pubKeySet
+}
+
+// SigningFunc returns a function to sign the particular milestone.
+func (s *InsecureRemoteEd25519MilestoneIndexSigner) SigningFunc() iotago.MilestoneSigningFunc {
+	return s.signingFunc
+}

--- a/signingprovider/signing_provider_test.go
+++ b/signingprovider/signing_provider_test.go
@@ -1,0 +1,151 @@
+package signingprovider_test
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	iotago "github.com/iotaledger/iota.go/v3"
+	"github.com/iotaledger/iota.go/v3/keymanager"
+	"github.com/iotaledger/iota.go/v3/signingprovider"
+	"github.com/iotaledger/iota.go/v3/tpkg"
+)
+
+func TestInMemoryEd25519MilestoneSignerProvider(t *testing.T) {
+
+	privateKeys := make([]ed25519.PrivateKey, 0)
+
+	pubKey1, privKey1, err := ed25519.GenerateKey(nil)
+	assert.NoError(t, err)
+	privateKeys = append(privateKeys, privKey1)
+
+	pubKey2, privKey2, err := ed25519.GenerateKey(nil)
+	assert.NoError(t, err)
+	privateKeys = append(privateKeys, privKey2)
+
+	pubKey3, privKey3, err := ed25519.GenerateKey(nil)
+	assert.NoError(t, err)
+	privateKeys = append(privateKeys, privKey3)
+
+	pubKey4, privKey4, err := ed25519.GenerateKey(nil)
+	assert.NoError(t, err)
+	privateKeys = append(privateKeys, privKey4)
+
+	var msPubKey1 iotago.MilestonePublicKey
+	copy(msPubKey1[:], pubKey1)
+
+	var msPubKey2 iotago.MilestonePublicKey
+	copy(msPubKey2[:], pubKey2)
+
+	var msPubKey3 iotago.MilestonePublicKey
+	copy(msPubKey3[:], pubKey3)
+
+	var msPubKey4 iotago.MilestonePublicKey
+	copy(msPubKey4[:], pubKey4)
+
+	km := keymanager.New()
+	km.AddKeyRange(pubKey1, 0, 9)
+	km.AddKeyRange(pubKey2, 3, 10)
+	km.AddKeyRange(pubKey3, 8, 15)
+	km.AddKeyRange(pubKey4, 17, 19)
+
+	signer := signingprovider.NewInMemoryEd25519MilestoneSignerProvider(privateKeys, km, 2)
+	require.Equal(t, 2, signer.PublicKeysCount())
+
+	type test struct {
+		name            string
+		ms              *iotago.Milestone
+		signingErr      error
+		verificationErr error
+	}
+
+	tests := []test{
+		func() test {
+			msPayload := &iotago.Milestone{
+				Parents:           tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
+				Index:             4,
+				Timestamp:         uint32(time.Now().Unix()),
+				AppliedMerkleRoot: tpkg.Rand32ByteArray(),
+			}
+
+			return test{
+				name:            "ok - 2 of 2 from applicable set",
+				ms:              msPayload,
+				signingErr:      nil,
+				verificationErr: nil,
+			}
+		}(),
+		func() test {
+			msPayload := &iotago.Milestone{
+				Parents:           tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
+				Index:             8,
+				Timestamp:         uint32(time.Now().Unix()),
+				AppliedMerkleRoot: tpkg.Rand32ByteArray(),
+			}
+
+			return test{
+				name:            "ok - 2 of 3 from applicable set",
+				ms:              msPayload,
+				signingErr:      nil,
+				verificationErr: nil,
+			}
+		}(),
+		func() test {
+			msPayload := &iotago.Milestone{
+				Parents:           tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
+				Index:             20,
+				Timestamp:         uint32(time.Now().Unix()),
+				AppliedMerkleRoot: tpkg.Rand32ByteArray(),
+			}
+
+			return test{
+				name:            "err - too few signatures for signing",
+				ms:              msPayload,
+				signingErr:      iotago.ErrMilestoneTooFewSignatures,
+				verificationErr: nil,
+			}
+		}(),
+		func() test {
+			msPayload := &iotago.Milestone{
+				Parents:           tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
+				Index:             17,
+				Timestamp:         uint32(time.Now().Unix()),
+				AppliedMerkleRoot: tpkg.Rand32ByteArray(),
+			}
+
+			return test{
+				name:            "err - too few signatures for verification",
+				ms:              msPayload,
+				signingErr:      nil,
+				verificationErr: iotago.ErrMilestoneTooFewSignaturesForVerificationThreshold,
+			}
+		}(),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			indexSigner := signer.MilestoneIndexSigner(tt.ms.Index)
+
+			err := tt.ms.Sign(indexSigner.PublicKeys(), indexSigner.SigningFunc())
+			if tt.signingErr != nil {
+				assert.True(t, errors.Is(err, tt.signingErr))
+				return
+			}
+			assert.NoError(t, err)
+
+			err = tt.ms.VerifySignatures(signer.PublicKeysCount(), indexSigner.PublicKeysSet())
+			if tt.verificationErr != nil {
+				println(err.Error())
+				assert.True(t, errors.Is(err, tt.verificationErr))
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
We need the signing provider in several repositories (hornet, inx-coordinator, ...).

It uses a lot of types from iota.go, so it may make sense to directly move the code to iota.go.

What do you think? @luca-moser 

Needs to be merged after #391 