### PR TITLE
Add query for native tokens to indexer client and fix alias query parameters

### DIFF
--- a/nodeclient/indexer_models.go
+++ b/nodeclient/indexer_models.go
@@ -106,6 +106,7 @@ func (query *BasicOutputsQuery) URLParas() (string, error) {
 // AliasesQuery defines parameters for an alias outputs query.
 type AliasesQuery struct {
 	IndexerCursorParas
+	IndexerCreationParas
 	IndexerNativeTokenParas
 
 	// Bech32-encoded state controller address that should be searched for.
@@ -116,8 +117,6 @@ type AliasesQuery struct {
 	SenderBech32 string `qs:"sender,omitempty"`
 	// Filters outputs based on the presence of validated issuer.
 	IssuerBech32 string `qs:"issuer,omitempty"`
-	// Filters outputs based on matching tag feature.
-	Tag string `qs:"tag,omitempty"`
 }
 
 func (query *AliasesQuery) OutputType() iotago.OutputType {

--- a/nodeclient/indexer_models.go
+++ b/nodeclient/indexer_models.go
@@ -64,6 +64,16 @@ type IndexerStorageDepositParas struct {
 	StorageDepositReturnAddressBech32 string `qs:"storageDepositReturnAddress,omitempty"`
 }
 
+// IndexerNativeTokenParas define native token based query parameters.
+type IndexerNativeTokenParas struct {
+	// Filters outputs based on the presence of native tokens in the output.
+	HasNativeTokens *bool `qs:"hasNativeTokens,omitempty"`
+	// Filter outputs that have at least an amount of native tokens.
+	MinNativeTokenCount *uint32 `qs:"minNativeTokenCount,omitempty"`
+	// Filter outputs that have at the most an amount of native tokens.
+	MaxNativeTokenCount *uint32 `qs:"maxNativeTokenCount,omitempty"`
+}
+
 // BasicOutputsQuery defines parameters for an basic outputs query.
 type BasicOutputsQuery struct {
 	IndexerCursorParas
@@ -71,6 +81,7 @@ type BasicOutputsQuery struct {
 	IndexerExpirationParas
 	IndexerCreationParas
 	IndexerStorageDepositParas
+	IndexerNativeTokenParas
 
 	// Bech32-encoded address that should be searched for.
 	AddressBech32 string `qs:"address,omitempty"`
@@ -95,6 +106,8 @@ func (query *BasicOutputsQuery) URLParas() (string, error) {
 // AliasesQuery defines parameters for an alias outputs query.
 type AliasesQuery struct {
 	IndexerCursorParas
+	IndexerNativeTokenParas
+
 	// Bech32-encoded state controller address that should be searched for.
 	StateControllerBech32 string `qs:"stateController,omitempty"`
 	// Bech32-encoded governor address that should be searched for.
@@ -123,6 +136,8 @@ func (query *AliasesQuery) URLParas() (string, error) {
 type FoundriesQuery struct {
 	IndexerCursorParas
 	IndexerCreationParas
+	IndexerNativeTokenParas
+
 	// Bech32-encoded address that should be searched for.
 	AliasAddressBech32 string `qs:"aliasAddress,omitempty"`
 }
@@ -145,6 +160,7 @@ type NFTsQuery struct {
 	IndexerTimelockParas
 	IndexerExpirationParas
 	IndexerStorageDepositParas
+	IndexerNativeTokenParas
 	IndexerCreationParas
 
 	// Bech32-encoded address that should be searched for.


### PR DESCRIPTION
This PR adds the missing query parameters to ask the indexer for native token based filtering on all different output types.
It also adds the missing CreationParas based query to the alias outputs.

The Tag based query for aliases was removed, because there is no tag feature in alias outputs.