### PR TITLE
Fix formatting of error messages

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -12,7 +12,7 @@ type ChainConstrainedOutputsSet map[ChainID]ChainConstrainedOutput
 func (set ChainConstrainedOutputsSet) Includes(other ChainConstrainedOutputsSet) error {
 	for chainID := range other {
 		if _, has := set[chainID]; !has {
-			return fmt.Errorf("%w: %s missing in source", ErrChainMissing, chainID)
+			return fmt.Errorf("%w: %s missing in source", ErrChainMissing, chainID.ToHex())
 		}
 	}
 	return nil
@@ -41,7 +41,7 @@ func (set ChainConstrainedOutputsSet) Merge(other ChainConstrainedOutputsSet) (C
 	}
 	for k, v := range other {
 		if _, has := newSet[k]; has {
-			return nil, fmt.Errorf("%w: chain %s exists in both sets", ErrNonUniqueChainConstrainedOutputs, k)
+			return nil, fmt.Errorf("%w: chain %s exists in both sets", ErrNonUniqueChainConstrainedOutputs, k.ToHex())
 		}
 		newSet[k] = v
 	}

--- a/milestone.go
+++ b/milestone.go
@@ -46,15 +46,15 @@ var (
 	// ErrMilestoneTooManySignatures gets returned when a Milestone holds more than 255 signatures.
 	ErrMilestoneTooManySignatures = fmt.Errorf("a milestone can hold max %d signatures", MaxSignaturesInAMilestone)
 	// ErrMilestoneInvalidMinSignatureThreshold gets returned when an invalid min signatures threshold is given to the verification function.
-	ErrMilestoneInvalidMinSignatureThreshold = fmt.Errorf("min threshold must be at least 1")
+	ErrMilestoneInvalidMinSignatureThreshold = errors.New("min threshold must be at least 1")
 	// ErrMilestoneNonApplicablePublicKey gets returned when a Milestone contains a public key which isn't in the applicable public key set.
-	ErrMilestoneNonApplicablePublicKey = fmt.Errorf("non applicable public key found")
+	ErrMilestoneNonApplicablePublicKey = errors.New("non applicable public key found")
 	// ErrMilestoneSignatureThresholdGreaterThanApplicablePublicKeySet gets returned when a min. signature threshold is greater than a given applicable public key set.
-	ErrMilestoneSignatureThresholdGreaterThanApplicablePublicKeySet = fmt.Errorf("the min. signature threshold must be less or equal the applicable public key set")
+	ErrMilestoneSignatureThresholdGreaterThanApplicablePublicKeySet = errors.New("the min. signature threshold must be less or equal the applicable public key set")
 	// ErrMilestoneInvalidSignature gets returned when a Milestone's signature is invalid.
-	ErrMilestoneInvalidSignature = fmt.Errorf("invalid milestone signature")
+	ErrMilestoneInvalidSignature = errors.New("invalid milestone signature")
 	// ErrMilestoneInMemorySignerPrivateKeyMissing gets returned when an InMemoryEd25519MilestoneSigner is missing a private key.
-	ErrMilestoneInMemorySignerPrivateKeyMissing = fmt.Errorf("private key missing")
+	ErrMilestoneInMemorySignerPrivateKeyMissing = errors.New("private key missing")
 
 	milestoneSupportedMsOptTypes = MilestoneOptTypeSet{MilestoneOptReceipt: struct{}{}, MilestoneOptProtocolParams: struct{}{}}
 	milestoneOptsArrayRules      = serializer.ArrayRules{

--- a/ms_opt_proto_params.go
+++ b/ms_opt_proto_params.go
@@ -2,6 +2,7 @@ package iotago
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/iotaledger/hive.go/serializer/v2"
@@ -10,7 +11,7 @@ import (
 
 var (
 	// ErrProtocolParamsMilestoneOptInvalid gets returned when a ProtocolParamsMilestoneOpt is invalid.
-	ErrProtocolParamsMilestoneOptInvalid = fmt.Errorf("invalid protocol params milestone option")
+	ErrProtocolParamsMilestoneOptInvalid = errors.New("invalid protocol params milestone option")
 )
 
 const (

--- a/nodeclient/indexer_client.go
+++ b/nodeclient/indexer_client.go
@@ -101,11 +101,11 @@ func (resultSet *IndexerResultSet) Outputs() (iotago.Outputs, error) {
 	for i, outputID := range outputIDs {
 		res, err := resultSet.client.OutputByID(resultSet.ctx, outputID)
 		if err != nil {
-			return nil, fmt.Errorf("unable to fetch output %s: %w", outputID, err)
+			return nil, fmt.Errorf("unable to fetch output %s: %w", outputID.ToHex(), err)
 		}
 		output, err := res.Output()
 		if err != nil {
-			return nil, fmt.Errorf("unable to build output %s: %w", outputID, err)
+			return nil, fmt.Errorf("unable to build output %s: %w", outputID.ToHex(), err)
 		}
 		outputs[i] = output
 	}

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -250,12 +250,12 @@ func (f *FoundryOutput) genesisValid(semValCtx *SemanticValidationContext, thisF
 	aliasID := f.Ident().(*AliasAddress).AliasID()
 	inAlias, ok := semValCtx.WorkingSet.InChains[aliasID]
 	if !ok {
-		return fmt.Errorf("missing input transitioning alias output %s for new foundry output %s", aliasID, thisFoundryID)
+		return fmt.Errorf("missing input transitioning alias output %s for new foundry output %s", aliasID.ToHex(), thisFoundryID)
 	}
 
 	outAlias, ok := semValCtx.WorkingSet.OutChains[aliasID]
 	if !ok {
-		return fmt.Errorf("missing output transitioning alias output %s for new foundry output %s", aliasID, thisFoundryID)
+		return fmt.Errorf("missing output transitioning alias output %s for new foundry output %s", aliasID.ToHex(), thisFoundryID)
 	}
 
 	if err := f.validSerialNumber(semValCtx, inAlias.(*AliasOutput), outAlias.(*AliasOutput), thisFoundryID); err != nil {
@@ -270,7 +270,7 @@ func (f *FoundryOutput) validSerialNumber(semValCtx *SemanticValidationContext, 
 	startSerial := inAlias.FoundryCounter
 	endIncSerial := outAlias.FoundryCounter
 	if startSerial >= f.SerialNumber || f.SerialNumber > endIncSerial {
-		return fmt.Errorf("new foundry output %s's serial number is not between the foundry counter interval of [%d,%d)", thisFoundryID, startSerial, endIncSerial)
+		return fmt.Errorf("new foundry output %s's serial number is not between the foundry counter interval of [%d,%d)", thisFoundryID.ToHex(), startSerial, endIncSerial)
 	}
 
 	// OPTIMIZE: this loop happens on every STVF of every new foundry output
@@ -300,7 +300,7 @@ func (f *FoundryOutput) validSerialNumber(semValCtx *SemanticValidationContext, 
 		}
 
 		if otherFoundryOutput.SerialNumber >= f.SerialNumber {
-			return fmt.Errorf("new foundry output %s at index %d has bigger equal serial number than this foundry %s", otherFoundryID, outputIndex, thisFoundryID)
+			return fmt.Errorf("new foundry output %s at index %d has bigger equal serial number than this foundry %s", otherFoundryID.ToHex(), outputIndex, thisFoundryID.ToHex())
 		}
 	}
 	return nil
@@ -309,7 +309,7 @@ func (f *FoundryOutput) validSerialNumber(semValCtx *SemanticValidationContext, 
 func (f *FoundryOutput) stateChangeValid(next ChainConstrainedOutput, inSums NativeTokenSum, outSums NativeTokenSum) error {
 	nextState, is := next.(*FoundryOutput)
 	if !is {
-		return fmt.Errorf("foundry output can only state transition to another foundry output")
+		return errors.New("foundry output can only state transition to another foundry output")
 	}
 
 	if !f.ImmutableFeatures.Equal(nextState.ImmutableFeatures) {

--- a/output_nft.go
+++ b/output_nft.go
@@ -2,6 +2,7 @@ package iotago
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"golang.org/x/crypto/blake2b"
@@ -241,7 +242,7 @@ func (n *NFTOutput) ValidateStateTransition(transType ChainTransitionType, next 
 
 func (n *NFTOutput) genesisValid(semValCtx *SemanticValidationContext) error {
 	if !n.NFTID.Empty() {
-		return fmt.Errorf("NFTOutput's ID is not zeroed even though it is new")
+		return errors.New("NFTOutput's ID is not zeroed even though it is new")
 	}
 	return IsIssuerOnOutputUnlocked(n, semValCtx.WorkingSet.UnlockedIdents)
 }
@@ -249,7 +250,7 @@ func (n *NFTOutput) genesisValid(semValCtx *SemanticValidationContext) error {
 func (n *NFTOutput) stateChangeValid(next ChainConstrainedOutput) error {
 	nextState, is := next.(*NFTOutput)
 	if !is {
-		return fmt.Errorf("NFTOutput can only state transition to another NFTOutput")
+		return errors.New("NFTOutput can only state transition to another NFTOutput")
 	}
 	if !n.ImmutableFeatures.Equal(nextState.ImmutableFeatures) {
 		return fmt.Errorf("old state %s, next state %s", n.ImmutableFeatures, nextState.ImmutableFeatures)

--- a/signature_ed25519.go
+++ b/signature_ed25519.go
@@ -36,7 +36,7 @@ func (e *Ed25519Signature) Type() SignatureType {
 }
 
 func (e *Ed25519Signature) String() string {
-	return fmt.Sprintf("publick key: %s, signature: %s", EncodeHex(e.PublicKey[:]), EncodeHex(e.Signature[:]))
+	return fmt.Sprintf("public key: %s, signature: %s", EncodeHex(e.PublicKey[:]), EncodeHex(e.Signature[:]))
 }
 
 // Valid verifies whether given the message and Ed25519 address, the signature is valid.
@@ -44,10 +44,10 @@ func (e *Ed25519Signature) Valid(msg []byte, addr *Ed25519Address) error {
 	// an address is the Blake2b 256 hash of the public key
 	addrFromPubKey := Ed25519AddressFromPubKey(e.PublicKey[:])
 	if !bytes.Equal(addr[:], addrFromPubKey[:]) {
-		return fmt.Errorf("%w: address %s, public key %v", ErrEd25519PubKeyAndAddrMismatch, addr[:], addrFromPubKey)
+		return fmt.Errorf("%w: address %s, address from public key %v", ErrEd25519PubKeyAndAddrMismatch, EncodeHex(addr[:]), addrFromPubKey)
 	}
 	if valid := iotagoEd25519.Verify(e.PublicKey[:], msg, e.Signature[:]); !valid {
-		return fmt.Errorf("%w: address %s, public key %v, signature %v", ErrEd25519SignatureInvalid, addr[:], e.PublicKey, e.Signature)
+		return fmt.Errorf("%w: address %s, public key %v, signature %v", ErrEd25519SignatureInvalid, EncodeHex(addr[:]), EncodeHex(e.PublicKey[:]), EncodeHex(e.Signature[:]))
 	}
 	return nil
 }

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -486,7 +486,7 @@ func RandBasicOutput(addrType iotago.AddressType) *iotago.BasicOutput {
 		panic(fmt.Sprintf("invalid addr type: %d", addrType))
 	}
 
-	amount := uint64(rand.Intn(10000))
+	amount := uint64(rand.Intn(10000) + 1)
 	dep.Amount = amount
 	return dep
 }

--- a/transaction.go
+++ b/transaction.go
@@ -678,12 +678,12 @@ func TxSemanticSTVFOnChains() TxSemanticValidationFunc {
 			nextState := svCtx.WorkingSet.OutChains[chainID]
 			if nextState == nil {
 				if err := inputChain.ValidateStateTransition(ChainTransitionTypeDestroy, nil, svCtx); err != nil {
-					return fmt.Errorf("input chain %s (%T) destruction transition failed: %w", chainID, inputChain, err)
+					return fmt.Errorf("input chain %s (%T) destruction transition failed: %w", chainID.ToHex(), inputChain, err)
 				}
 				continue
 			}
 			if err := inputChain.ValidateStateTransition(ChainTransitionTypeStateChange, nextState, svCtx); err != nil {
-				return fmt.Errorf("chain %s (%T) state transition failed: %w", chainID, inputChain, err)
+				return fmt.Errorf("chain %s (%T) state transition failed: %w", chainID.ToHex(), inputChain, err)
 			}
 		}
 
@@ -691,7 +691,7 @@ func TxSemanticSTVFOnChains() TxSemanticValidationFunc {
 			previousState := svCtx.WorkingSet.InChains[chainID]
 			if previousState == nil {
 				if err := outputChain.ValidateStateTransition(ChainTransitionTypeGenesis, nil, svCtx); err != nil {
-					return fmt.Errorf("new chain %s (%T) state transition failed: %w", chainID, outputChain, err)
+					return fmt.Errorf("new chain %s (%T) state transition failed: %w", chainID.ToHex(), outputChain, err)
 				}
 			}
 		}


### PR DESCRIPTION
I saw some garbage log messages in the indexer client, because a `.ToHex()` was missing.

Then I went through all `fmt.Errorf` and checked for the same problem.
Hopefully I didn't change too much :) 