### PR TITLE
Relaxes max native token count to account only for distinct tokens

### DIFF
--- a/output.go
+++ b/output.go
@@ -746,15 +746,15 @@ func OutputsSyntacticalDepositAmount(protoParas *ProtocolParameters) OutputsSynt
 //   - the sum of native tokens count across all outputs does not exceed MaxNativeTokensCount
 //   - each native token holds an amount bigger than zero
 func OutputsSyntacticalNativeTokens() OutputsSyntacticalValidationFunc {
-	var nativeTokensCount int
+	distinctNativeTokens := make(map[NativeTokenID]struct{})
 	return func(index int, output Output) error {
 		nativeTokens := output.NativeTokenList()
-		nativeTokensCount += len(nativeTokens)
-		if nativeTokensCount > MaxNativeTokensCount {
-			return ErrMaxNativeTokensCountExceeded
-		}
 
 		for i, nt := range nativeTokens {
+			distinctNativeTokens[nt.ID] = struct{}{}
+			if len(distinctNativeTokens) > MaxNativeTokensCount {
+				return ErrMaxNativeTokensCountExceeded
+			}
 			if nt.Amount.Cmp(common.Big0) == 0 {
 				return fmt.Errorf("%w: output %d, native token index %d", ErrNativeTokenAmountLessThanEqualZero, index, i)
 			}

--- a/output.go
+++ b/output.go
@@ -362,16 +362,13 @@ func (outputs Outputs) Filter(f OutputsFilterFunc) Outputs {
 }
 
 // NativeTokenSum sums up the different NativeTokens occurring within the given outputs.
-// limit defines the max amount of native tokens which are allowed.
-func (outputs Outputs) NativeTokenSum() (NativeTokenSum, int, error) {
+func (outputs Outputs) NativeTokenSum() (NativeTokenSum, error) {
 	sum := make(map[NativeTokenID]*big.Int)
-	var ntCount int
 	for _, output := range outputs {
 		nativeTokens := output.NativeTokenList()
-		ntCount += len(nativeTokens)
 		for _, nativeToken := range nativeTokens {
 			if sign := nativeToken.Amount.Sign(); sign == -1 || sign == 0 {
-				return nil, 0, ErrNativeTokenAmountLessThanEqualZero
+				return nil, ErrNativeTokenAmountLessThanEqualZero
 			}
 
 			val := sum[nativeToken.ID]
@@ -380,12 +377,12 @@ func (outputs Outputs) NativeTokenSum() (NativeTokenSum, int, error) {
 			}
 
 			if val.Add(val, nativeToken.Amount).Cmp(abi.MaxUint256) == 1 {
-				return nil, 0, ErrNativeTokenSumExceedsUint256
+				return nil, ErrNativeTokenSumExceedsUint256
 			}
 			sum[nativeToken.ID] = val
 		}
 	}
-	return sum, ntCount, nil
+	return sum, nil
 }
 
 // OutputsByType is a map of OutputType(s) to slice of Output(s).

--- a/transaction.go
+++ b/transaction.go
@@ -736,10 +736,17 @@ func TxSemanticNativeTokens() TxSemanticValidationFunc {
 		if err != nil {
 			return fmt.Errorf("invalid output native token set: %w", err)
 		}
-		outNTCount := len(svCtx.WorkingSet.OutNativeTokens)
 
-		if inNTCount+outNTCount > MaxNativeTokensCount {
-			return fmt.Errorf("%w: native token count (in %d + out %d) exceeds max of %d", ErrMaxNativeTokensCountExceeded, inNTCount, outNTCount, MaxNativeTokensCount)
+		distinctNTCount := make(map[NativeTokenID]struct{})
+		for nt := range svCtx.WorkingSet.InNativeTokens {
+			distinctNTCount[nt] = struct{}{}
+		}
+		for nt := range svCtx.WorkingSet.OutNativeTokens {
+			distinctNTCount[nt] = struct{}{}
+		}
+
+		if len(distinctNTCount) > MaxNativeTokensCount {
+			return fmt.Errorf("%w: native token count %d exceeds max of %d", ErrMaxNativeTokensCountExceeded, distinctNTCount, MaxNativeTokensCount)
 		}
 
 		// check invariants for when token foundry is absent

--- a/transaction.go
+++ b/transaction.go
@@ -722,20 +722,21 @@ func TxSemanticNativeTokens() TxSemanticValidationFunc {
 	return func(svCtx *SemanticValidationContext) error {
 		// native token set creates handle overflows
 		var err error
-		var inNTCount, outNTCount int
-		svCtx.WorkingSet.InNativeTokens, inNTCount, err = svCtx.WorkingSet.Inputs.NativeTokenSum()
+		svCtx.WorkingSet.InNativeTokens, err = svCtx.WorkingSet.Inputs.NativeTokenSum()
 		if err != nil {
 			return fmt.Errorf("invalid input native token set: %w", err)
 		}
+		inNTCount := len(svCtx.WorkingSet.InNativeTokens)
 
 		if inNTCount > MaxNativeTokensCount {
 			return fmt.Errorf("%w: inputs native token count %d exceeds max of %d", ErrMaxNativeTokensCountExceeded, inNTCount, MaxNativeTokensCount)
 		}
 
-		svCtx.WorkingSet.OutNativeTokens, outNTCount, err = svCtx.WorkingSet.Tx.Essence.Outputs.NativeTokenSum()
+		svCtx.WorkingSet.OutNativeTokens, err = svCtx.WorkingSet.Tx.Essence.Outputs.NativeTokenSum()
 		if err != nil {
 			return fmt.Errorf("invalid output native token set: %w", err)
 		}
+		outNTCount := len(svCtx.WorkingSet.OutNativeTokens)
 
 		if inNTCount+outNTCount > MaxNativeTokensCount {
 			return fmt.Errorf("%w: native token count (in %d + out %d) exceeds max of %d", ErrMaxNativeTokensCountExceeded, inNTCount, outNTCount, MaxNativeTokensCount)


### PR DESCRIPTION
According to the TIP, the max native token count should only count distinct native tokens instead of multiple occurrences of the same token.