### PR TITLE
Use IOTASerializerV1 accept header in OutputByID

### DIFF
--- a/nodeclient/event_api_client.go
+++ b/nodeclient/event_api_client.go
@@ -219,15 +219,15 @@ func subscribeToTopic[T any](eac *EventAPIClient, topic string, deseriFunc func(
 }
 
 func (eac *EventAPIClient) subscribeToOutputsTopic(topic string) (<-chan *OutputResponse, *EventAPIClientSubscription) {
-	return subscribeToTopic[OutputResponse](eac, topic, jsonDeserializer[OutputResponse])
+	return subscribeToTopic(eac, topic, jsonDeserializer[OutputResponse])
 }
 
 func (eac *EventAPIClient) subscribeToBlockMetadataTopic(topic string) (<-chan *BlockMetadataResponse, *EventAPIClientSubscription) {
-	return subscribeToTopic[BlockMetadataResponse](eac, topic, jsonDeserializer[BlockMetadataResponse])
+	return subscribeToTopic(eac, topic, jsonDeserializer[BlockMetadataResponse])
 }
 
 func (eac *EventAPIClient) subscribeToBlockMetadataBlockTopic(topic string, protoParas *iotago.ProtocolParameters) (<-chan *iotago.Block, *EventAPIClientSubscription) {
-	return subscribeToTopic[iotago.Block](eac, topic, func(payload []byte) (*iotago.Block, error) {
+	return subscribeToTopic(eac, topic, func(payload []byte) (*iotago.Block, error) {
 		metadataRes := &BlockMetadataResponse{}
 		if err := json.Unmarshal(payload, metadataRes); err != nil {
 			sendErrOrDrop(eac.Errors, err)
@@ -239,7 +239,7 @@ func (eac *EventAPIClient) subscribeToBlockMetadataBlockTopic(topic string, prot
 }
 
 func (eac *EventAPIClient) subscribeToBlocksTopic(topic string, protoParas *iotago.ProtocolParameters) (<-chan *iotago.Block, *EventAPIClientSubscription) {
-	return subscribeToTopic[iotago.Block](eac, topic, func(payload []byte) (*iotago.Block, error) {
+	return subscribeToTopic(eac, topic, func(payload []byte) (*iotago.Block, error) {
 		block := &iotago.Block{}
 		if _, err := block.Deserialize(payload, serializer.DeSeriModeNoValidation, protoParas); err != nil {
 			return nil, err
@@ -249,15 +249,15 @@ func (eac *EventAPIClient) subscribeToBlocksTopic(topic string, protoParas *iota
 }
 
 func (eac *EventAPIClient) subscribeToMilestoneInfoTopic(topic string) (<-chan *MilestoneInfo, *EventAPIClientSubscription) {
-	return subscribeToTopic[MilestoneInfo](eac, topic, jsonDeserializer[MilestoneInfo])
+	return subscribeToTopic(eac, topic, jsonDeserializer[MilestoneInfo])
 }
 
 func (eac *EventAPIClient) subscribeToMilestoneTopic(topic string) (<-chan *iotago.Milestone, *EventAPIClientSubscription) {
-	return subscribeToTopic[iotago.Milestone](eac, topic, jsonDeserializer[iotago.Milestone])
+	return subscribeToTopic(eac, topic, jsonDeserializer[iotago.Milestone])
 }
 
 func (eac *EventAPIClient) subscribeToReceiptsTopic(topic string) (<-chan *iotago.ReceiptMilestoneOpt, *EventAPIClientSubscription) {
-	return subscribeToTopic[iotago.ReceiptMilestoneOpt](eac, topic, jsonDeserializer[iotago.ReceiptMilestoneOpt])
+	return subscribeToTopic(eac, topic, jsonDeserializer[iotago.ReceiptMilestoneOpt])
 }
 
 // Blocks returns a channel of newly received blocks.

--- a/nodeclient/indexer_client.go
+++ b/nodeclient/indexer_client.go
@@ -99,13 +99,9 @@ func (resultSet *IndexerResultSet) Outputs() (iotago.Outputs, error) {
 	outputIDs := resultSet.Response.Items.MustOutputIDs()
 	outputs := make(iotago.Outputs, len(outputIDs))
 	for i, outputID := range outputIDs {
-		res, err := resultSet.client.OutputByID(resultSet.ctx, outputID)
+		output, err := resultSet.client.OutputByID(resultSet.ctx, outputID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch output %s: %w", outputID.ToHex(), err)
-		}
-		output, err := res.Output()
-		if err != nil {
-			return nil, fmt.Errorf("unable to build output %s: %w", outputID.ToHex(), err)
 		}
 		outputs[i] = output
 	}
@@ -162,12 +158,11 @@ func (client *indexerClient) singleOutputQuery(ctx context.Context, route string
 	}
 
 	outputID := res.Items.MustOutputIDs()[0]
-	outputRes, err := client.core.OutputByID(ctx, outputID)
+	output, err := client.core.OutputByID(ctx, outputID)
 	if err != nil {
 		return nil, nil, err
 	}
-	out, err := outputRes.Output()
-	return &outputID, out, err
+	return &outputID, output, err
 }
 
 func (client *indexerClient) Alias(ctx context.Context, aliasID iotago.AliasID) (*iotago.OutputID, *iotago.AliasOutput, error) {


### PR DESCRIPTION
The node supports fetching outputs without an intermediate JSON serialization step by sending `RequestHeaderHookAcceptIOTASerializerV1`.
This is now used in `OutputByID`, for example to fetch outputs in the indexer client.

If `RequestHeaderHookAcceptJSON` is used, also metadata about the output is returned in the same request.
In case that is needed by the client, `OutputWithMetadataByID` can now be used instead.