### PR TITLE
Do not return the finalized block in SubmitBlock

### DIFF
--- a/nodeclient/http_api_client.go
+++ b/nodeclient/http_api_client.go
@@ -335,33 +335,29 @@ func (client *Client) Tips(ctx context.Context) (*TipsResponse, error) {
 
 // SubmitBlock submits the given Block to the node.
 // The node will take care of filling missing information.
-// This function returns the finalized block created by the node.
-func (client *Client) SubmitBlock(ctx context.Context, m *iotago.Block, protoParas *iotago.ProtocolParameters) (*iotago.Block, error) {
+// This function returns the blockID of the finalized block.
+// To get the finalized block you need to call "BlockByBlockID".
+func (client *Client) SubmitBlock(ctx context.Context, m *iotago.Block, protoParas *iotago.ProtocolParameters) (iotago.BlockID, error) {
 	// do not check the block because the validation would fail if
 	// no parents were given. The node will first add this missing information and
 	// validate the block afterwards.
 	data, err := m.Serialize(serializer.DeSeriModePerformLexicalOrdering, protoParas)
 	if err != nil {
-		return nil, err
+		return iotago.EmptyBlockID(), err
 	}
 
 	req := &RawDataEnvelope{Data: data}
 	res, err := client.Do(ctx, http.MethodPost, RouteBlocks, req, nil)
 	if err != nil {
-		return nil, err
+		return iotago.EmptyBlockID(), err
 	}
 
 	blockID, err := iotago.BlockIDFromHexString(res.Header.Get(locationHeader))
 	if err != nil {
-		return nil, err
+		return iotago.EmptyBlockID(), err
 	}
 
-	block, err := client.BlockByBlockID(ctx, blockID, protoParas)
-	if err != nil {
-		return nil, err
-	}
-
-	return block, nil
+	return blockID, nil
 }
 
 // BlockMetadataByBlockID gets the metadata of a block by its ID from the node.

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -137,20 +137,6 @@ func TestClient_SubmitBlock(t *testing.T) {
 		Parents:         tpkg.SortedRandBlockIDs(1),
 	}
 
-	completeBlock := &iotago.Block{
-		ProtocolVersion: tpkg.TestProtocolVersion,
-		Parents:         tpkg.SortedRandBlockIDs(1),
-		Payload:         nil,
-		Nonce:           3495721389537486,
-	}
-
-	serializedCompleteBlock, err := completeBlock.Serialize(serializer.DeSeriModeNoValidation, tpkg.TestProtoParas)
-	require.NoError(t, err)
-
-	block2 := iotago.Block{}
-	_, err = block2.Deserialize(serializedCompleteBlock, serializer.DeSeriModePerformValidation, tpkg.TestProtoParas)
-	require.NoError(t, err)
-
 	serializedIncompleteBlock, err := incompleteBlock.Serialize(serializer.DeSeriModePerformValidation, tpkg.TestProtoParas)
 	require.NoError(t, err)
 
@@ -161,16 +147,10 @@ func TestClient_SubmitBlock(t *testing.T) {
 		Reply(200).
 		AddHeader("Location", blockHashStr)
 
-	gock.New(nodeAPIUrl).
-		Get(fmt.Sprintf(nodeclient.RouteBlock, blockHashStr)).
-		MatchHeader("Accept", nodeclient.MIMEApplicationVendorIOTASerializerV1).
-		Reply(200).
-		Body(bytes.NewReader(serializedCompleteBlock))
-
 	nodeAPI := nodeclient.New(nodeAPIUrl)
 	resp, err := nodeAPI.SubmitBlock(context.Background(), incompleteBlock, tpkg.TestProtoParas)
 	require.NoError(t, err)
-	require.EqualValues(t, completeBlock, resp)
+	require.EqualValues(t, blockHash, resp)
 }
 
 func TestClient_BlockMetadataByMessageID(t *testing.T) {


### PR DESCRIPTION
In `SubmitBlock` two http requests are executed.

The first one posts the block to the node and the second one returns the finalized block by calling `BlockByBlockID`.
The problem with this approach is, that this might fail in case the target endpoint lives behind a loadbalancer.
The posted block might not exist on the second node yet, and the call will fail. If the caller repeats this function call, another error is returned because the block already exists.

Its better to only submit the block and let the caller handle the `BlockByBlockID` call.