### PR TITLE
initial implementation of block issuer deposit

### DIFF
--- a/commitment.go
+++ b/commitment.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	CommitmentIDLength = SlotIdentifierLength
+	MaxCommitableAge   = 60 // max age of slot to which we can commit. TODO: set this parameter.
 )
 
 type CommitmentID = SlotIdentifier

--- a/feat.go
+++ b/feat.go
@@ -42,6 +42,8 @@ const (
 	FeatureMetadata
 	// FeatureTag denotes a TagFeature.
 	FeatureTag
+	// FeatureBlockIssuer denotes a BlockIssuerFeature.
+	FeatureBlockIssuer
 )
 
 func (featType FeatureType) String() string {
@@ -168,6 +170,15 @@ func (f FeatureSet) Issuer() *IssuerFeature {
 		return nil
 	}
 	return b.(*IssuerFeature)
+}
+
+// BlockIssuer returns the BlockIssuerFeature in the set or nil.
+func (f FeatureSet) BlockIssuer() *BlockIssuerFeature {
+	b, has := f[FeatureBlockIssuer]
+	if !has {
+		return nil
+	}
+	return b.(*BlockIssuerFeature)
 }
 
 // Metadata returns the MetadataFeature in the set or nil.

--- a/feat_blockissuer.go
+++ b/feat_blockissuer.go
@@ -1,0 +1,39 @@
+package iotago
+
+import (
+	"github.com/iotaledger/hive.go/serializer/v2"
+	"github.com/iotaledger/iota.go/v4/util"
+)
+
+// BlockIssuerFeature is a feature which indicates that this account can issue blocks.
+// The feature includes a block issuer address as well as an expiry slot.
+type BlockIssuerFeature struct {
+	Address    Address `serix:"0,mapKey=address"`
+	ExpiryTime uint32  `serix:"1,mapKey=expirytime"`
+}
+
+func (s *BlockIssuerFeature) Clone() Feature {
+	return &BlockIssuerFeature{Address: s.Address.Clone(), ExpiryTime: s.ExpiryTime}
+}
+
+func (s *BlockIssuerFeature) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize+serializer.UInt32ByteSize) +
+		s.Address.VBytes(rentStruct, nil)
+}
+
+func (s *BlockIssuerFeature) Equal(other Feature) bool {
+	otherFeat, is := other.(*BlockIssuerFeature)
+	if !is {
+		return false
+	}
+
+	return s.Address.Equal(otherFeat.Address) && s.ExpiryTime == otherFeat.ExpiryTime
+}
+
+func (s *BlockIssuerFeature) Type() FeatureType {
+	return FeatureBlockIssuer
+}
+
+func (s *BlockIssuerFeature) Size() int {
+	return util.NumByteLen(byte(FeatureBlockIssuer)) + s.Address.Size() + serializer.UInt32ByteSize
+}

--- a/output.go
+++ b/output.go
@@ -676,6 +676,7 @@ type OutputsSyntacticalValidationFunc func(index int, output Output) error
 //   - the deposit fulfills the minimum storage deposit as calculated from the virtual byte cost of the output
 //   - if the output contains a StorageDepositReturnUnlockCondition, it must "return" bigger equal than the minimum storage deposit
 //     required for the sender to send back the tokens.
+//   - if the output is an alias with a block issuer feature, check that it deposits enough to be a block issuer.
 func OutputsSyntacticalDepositAmount(protoParams *ProtocolParameters) OutputsSyntacticalValidationFunc {
 	var sum uint64
 	return func(index int, output Output) error {
@@ -703,6 +704,14 @@ func OutputsSyntacticalDepositAmount(protoParams *ProtocolParameters) OutputsSyn
 				return fmt.Errorf("%w: output %d, needed %d, have %d", ErrStorageDepositLessThanMinReturnOutputStorageDeposit, index, minStorageDepositForReturnOutput, storageDep.Amount)
 			case storageDep.Amount > deposit:
 				return fmt.Errorf("%w: output %d, target output's deposit %d < storage deposit %d", ErrStorageDepositExceedsTargetOutputDeposit, index, deposit, storageDep.Amount)
+			}
+		}
+
+		// check whether the amount of an alias output with a block isser feature is sufficient to be a block issuer.
+		if blockIssuerFeat := output.FeatureSet().BlockIssuer(); blockIssuerFeat != nil {
+			minBlockIssuerDeposit := protoParams.RentStructure.BlockIssuerDeposit()
+			if deposit < minBlockIssuerDeposit {
+				return fmt.Errorf("%w: output %d, target output's deposit %d < block issuer deposit %d", ErrStorageDepositExceedsTargetOutputDeposit, index, deposit, minBlockIssuerDeposit)
 			}
 		}
 

--- a/output_alias.go
+++ b/output_alias.go
@@ -22,6 +22,8 @@ var (
 	ErrInvalidAliasStateTransition = errors.New("invalid alias state transition")
 	// ErrInvalidAliasGovernanceTransition gets returned when an alias is doing an invalid governance transition.
 	ErrInvalidAliasGovernanceTransition = errors.New("invalid alias governance transition")
+	// ErrInvalidBlockIssuerTransition gets returned when an alias tries to transition block issuer expiry too soon.
+	ErrInvalidBlockIssuerTransition = errors.New("invalid block issuer transition")
 	// ErrAliasMissing gets returned when an alias is missing.
 	ErrAliasMissing = errors.New("alias is missing")
 	emptyAliasID    = [AliasIDLength]byte{}

--- a/rent.go
+++ b/rent.go
@@ -65,6 +65,12 @@ func (r *RentStructure) MinStorageDepositForReturnOutput(sender Address) uint64 
 	return (&BasicOutput{Conditions: UnlockConditions[basicOutputUnlockCondition]{&AddressUnlockCondition{Address: sender}}, Amount: 0}).VBytes(r, nil)
 }
 
+// BlockIssuerDeposit returns the minimum rendting cost for an alias output which operates a block issuer.
+// TODO: calculate what is required for block issuer deposit.
+func (r *RentStructure) BlockIssuerDeposit() uint64 {
+	return 0
+}
+
 // NonEphemeralObject is an object which can not be pruned by nodes as it
 // makes up an integral part to execute the IOTA protocol. This kind of objects are associated
 // with costs in terms of the resources they take up.


### PR DESCRIPTION
# Description of change

Adding the block issuer deposit as a feature of the alias output, along with state transition verification rule for changing the deposit and a check that the amount of IOTA tokens on the output is sufficient to cover a block issuer.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

not tested
