### PR TITLE
Fix MinStorageDeposit for return output calculation

### DIFF
--- a/address_alias.go
+++ b/address_alias.go
@@ -47,7 +47,7 @@ func (aliasAddr *AliasAddress) Clone() Address {
 	return cpy
 }
 
-func (aliasAddr *AliasAddress) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (aliasAddr *AliasAddress) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(AliasAddressSerializedBytesSize)
 }
 

--- a/address_ed25519.go
+++ b/address_ed25519.go
@@ -48,7 +48,7 @@ func (edAddr *Ed25519Address) Clone() Address {
 	return cpy
 }
 
-func (edAddr *Ed25519Address) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (edAddr *Ed25519Address) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(Ed25519AddressSerializedBytesSize)
 }
 

--- a/address_nft.go
+++ b/address_nft.go
@@ -47,7 +47,7 @@ func (nftAddr *NFTAddress) Clone() Address {
 	return cpy
 }
 
-func (nftAddr *NFTAddress) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (nftAddr *NFTAddress) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(NFTAddressSerializedBytesSize)
 }
 

--- a/feat.go
+++ b/feat.go
@@ -54,8 +54,8 @@ func (f Features) Clone() Features {
 	return cpy
 }
 
-func (f Features) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
-	var sumCost uint64
+func (f Features) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
+	var sumCost VBytes
 	for _, feat := range f {
 		sumCost += feat.VBytes(rentStruct, nil)
 	}

--- a/feat_issuer.go
+++ b/feat_issuer.go
@@ -28,7 +28,7 @@ func (s *IssuerFeature) Clone() Feature {
 	return &IssuerFeature{Address: s.Address.Clone()}
 }
 
-func (s *IssuerFeature) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *IssuerFeature) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize) +
 		s.Address.VBytes(rentStruct, nil)
 }

--- a/feat_metadata.go
+++ b/feat_metadata.go
@@ -26,8 +26,8 @@ func (s *MetadataFeature) Clone() Feature {
 	return &MetadataFeature{Data: append([]byte(nil), s.Data...)}
 }
 
-func (s *MetadataFeature) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
-	return rentStruct.VBFactorData.Multiply(uint64(serializer.SmallTypeDenotationByteSize + serializer.UInt16ByteSize + len(s.Data)))
+func (s *MetadataFeature) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
+	return rentStruct.VBFactorData.Multiply(VBytes(serializer.SmallTypeDenotationByteSize + serializer.UInt16ByteSize + len(s.Data)))
 }
 
 func (s *MetadataFeature) Equal(other Feature) bool {

--- a/feat_sender.go
+++ b/feat_sender.go
@@ -26,7 +26,7 @@ func (s *SenderFeature) Clone() Feature {
 	return &SenderFeature{Address: s.Address.Clone()}
 }
 
-func (s *SenderFeature) VBytes(rentStruct *RentStructure, f VBytesFunc) uint64 {
+func (s *SenderFeature) VBytes(rentStruct *RentStructure, f VBytesFunc) VBytes {
 	if f != nil {
 		return f(rentStruct)
 	}

--- a/feat_tag.go
+++ b/feat_tag.go
@@ -25,11 +25,11 @@ func (s *TagFeature) Clone() Feature {
 	return &TagFeature{Tag: append([]byte(nil), s.Tag...)}
 }
 
-func (s *TagFeature) VBytes(rentStruct *RentStructure, f VBytesFunc) uint64 {
+func (s *TagFeature) VBytes(rentStruct *RentStructure, f VBytesFunc) VBytes {
 	if f != nil {
 		return f(rentStruct)
 	}
-	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize + serializer.OneByte + uint64(len(s.Tag)))
+	return rentStruct.VBFactorData.Multiply(VBytes(serializer.SmallTypeDenotationByteSize + serializer.OneByte + len(s.Tag)))
 }
 
 func (s *TagFeature) Equal(other Feature) bool {

--- a/native_token.go
+++ b/native_token.go
@@ -113,9 +113,9 @@ func (n NativeTokens) Clone() NativeTokens {
 	return cpy
 }
 
-func (n NativeTokens) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (n NativeTokens) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	// length prefix + (native token count * static native token cost)
-	return rentStruct.VBFactorData.Multiply(uint64(serializer.OneByte + len(n)*NativeTokenVByteCost))
+	return rentStruct.VBFactorData.Multiply(VBytes(serializer.OneByte + len(n)*NativeTokenVByteCost))
 }
 
 func (n NativeTokens) ToSerializables() serializer.Serializables {
@@ -168,7 +168,7 @@ func (n *NativeToken) Clone() *NativeToken {
 	return cpy
 }
 
-func (n *NativeToken) VBytes(_ *RentStructure, _ VBytesFunc) uint64 {
+func (n *NativeToken) VBytes(_ *RentStructure, _ VBytesFunc) VBytes {
 	return NativeTokenVByteCost
 }
 

--- a/output.go
+++ b/output.go
@@ -29,7 +29,7 @@ var (
 )
 
 // defines the default offset virtual byte costs for an output.
-func outputOffsetVByteCost(rentStruct *RentStructure) uint64 {
+func outputOffsetVByteCost(rentStruct *RentStructure) VBytes {
 	return rentStruct.VBFactorKey.Multiply(OutputIDLength) +
 		// included block id, conf ms index, conf ms ts
 		rentStruct.VBFactorData.Multiply(BlockIDLength+serializer.UInt32ByteSize+serializer.UInt32ByteSize)

--- a/output_alias.go
+++ b/output_alias.go
@@ -278,14 +278,14 @@ func (a *AliasOutput) UnlockableBy(ident Address, next TransDepIdentOutput, extP
 	return outputUnlockable(a, next, ident, extParas)
 }
 
-func (a *AliasOutput) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (a *AliasOutput) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return outputOffsetVByteCost(rentStruct) +
 		// prefix + amount
 		rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize+serializer.UInt64ByteSize) +
 		a.NativeTokens.VBytes(rentStruct, nil) +
 		rentStruct.VBFactorData.Multiply(AliasIDLength) +
 		// state index, state meta length, state meta, foundry counter
-		rentStruct.VBFactorData.Multiply(uint64(serializer.UInt32ByteSize+serializer.UInt16ByteSize+len(a.StateMetadata)+serializer.UInt32ByteSize)) +
+		rentStruct.VBFactorData.Multiply(VBytes(serializer.UInt32ByteSize+serializer.UInt16ByteSize+len(a.StateMetadata)+serializer.UInt32ByteSize)) +
 		a.Conditions.VBytes(rentStruct, nil) +
 		a.Features.VBytes(rentStruct, nil) +
 		a.ImmutableFeatures.VBytes(rentStruct, nil)

--- a/output_basic.go
+++ b/output_basic.go
@@ -118,7 +118,7 @@ func (e *BasicOutput) UnlockableBy(ident Address, extParas *ExternalUnlockParame
 	return ok
 }
 
-func (e *BasicOutput) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (e *BasicOutput) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return outputOffsetVByteCost(rentStruct) +
 		// prefix + amount
 		rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize+serializer.UInt64ByteSize) +

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -197,7 +197,7 @@ func (f *FoundryOutput) UnlockableBy(ident Address, extParas *ExternalUnlockPara
 	return ok
 }
 
-func (f *FoundryOutput) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (f *FoundryOutput) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return outputOffsetVByteCost(rentStruct) +
 		// prefix + amount
 		rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize+serializer.UInt64ByteSize) +

--- a/output_nft.go
+++ b/output_nft.go
@@ -211,7 +211,7 @@ func (n *NFTOutput) UnlockableBy(ident Address, extParas *ExternalUnlockParamete
 	return ok
 }
 
-func (n *NFTOutput) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (n *NFTOutput) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return outputOffsetVByteCost(rentStruct) +
 		// prefix + amount
 		rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize+serializer.UInt64ByteSize) +

--- a/output_test.go
+++ b/output_test.go
@@ -158,7 +158,7 @@ func copyObject(t *testing.T, source serializer.Serializable, mutations fieldMut
 func TestOutputsSyntacticalDepositAmount(t *testing.T) {
 	nonZeroCostParas := &iotago.ProtocolParameters{
 		RentStructure: iotago.RentStructure{
-			VByteCost:    1,
+			VByteCost:    100,
 			VBFactorData: iotago.VByteCostFactorData,
 			VBFactorKey:  iotago.VByteCostFactorKey,
 		},
@@ -187,7 +187,7 @@ func TestOutputsSyntacticalDepositAmount(t *testing.T) {
 			protoParas: nonZeroCostParas,
 			outputs: iotago.Outputs{
 				&iotago.BasicOutput{
-					Amount:     426, // min amount
+					Amount:     42600, // min amount
 					Conditions: iotago.UnlockConditions{&iotago.AddressUnlockCondition{Address: tpkg.RandAliasAddress()}},
 				},
 			},
@@ -197,14 +197,14 @@ func TestOutputsSyntacticalDepositAmount(t *testing.T) {
 			name:       "ok - storage deposit return",
 			protoParas: nonZeroCostParas,
 			outputs: iotago.Outputs{
-				// min 444
+				// min 46800
 				&iotago.BasicOutput{
-					Amount: 1000,
+					Amount: 100000,
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: tpkg.RandAliasAddress()},
 						&iotago.StorageDepositReturnUnlockCondition{
 							ReturnAddress: tpkg.RandAliasAddress(),
-							Amount:        566, // 1000 - 444
+							Amount:        42600,
 						},
 					},
 				},
@@ -216,12 +216,12 @@ func TestOutputsSyntacticalDepositAmount(t *testing.T) {
 			protoParas: nonZeroCostParas,
 			outputs: iotago.Outputs{
 				&iotago.BasicOutput{
-					Amount: 1000,
+					Amount: 100000,
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: tpkg.RandAliasAddress()},
 						&iotago.StorageDepositReturnUnlockCondition{
 							ReturnAddress: tpkg.RandAliasAddress(),
-							Amount:        413, // off by 1
+							Amount:        42600 - 1, // off by 1
 						},
 					},
 				},
@@ -251,7 +251,7 @@ func TestOutputsSyntacticalDepositAmount(t *testing.T) {
 			protoParas: nonZeroCostParas,
 			outputs: iotago.Outputs{
 				&iotago.BasicOutput{
-					Amount: 100,
+					Amount: 42600 - 1,
 					Conditions: iotago.UnlockConditions{
 						&iotago.AddressUnlockCondition{Address: tpkg.RandAliasAddress()},
 					},
@@ -315,7 +315,7 @@ func TestOutputsSyntacticalDepositAmount(t *testing.T) {
 					runErr = err
 				}
 			}
-			require.ErrorIs(t, runErr, tt.wantErr)
+			require.ErrorIs(t, runErr, tt.wantErr, tt.name)
 		})
 	}
 }

--- a/output_treasury.go
+++ b/output_treasury.go
@@ -30,7 +30,7 @@ func (t *TreasuryOutput) Clone() Output {
 	return &TreasuryOutput{Amount: t.Amount}
 }
 
-func (t *TreasuryOutput) VBytes(_ *RentStructure, _ VBytesFunc) uint64 {
+func (t *TreasuryOutput) VBytes(_ *RentStructure, _ VBytesFunc) VBytes {
 	return 0
 }
 

--- a/rent.go
+++ b/rent.go
@@ -8,6 +8,9 @@ import (
 	"github.com/iotaledger/hive.go/serializer/v2"
 )
 
+// VBytes defines the type of the virtual byte costs.
+type VBytes uint64
+
 // VByteCostFactor defines the type of the virtual byte cost factor.
 type VByteCostFactor byte
 
@@ -27,8 +30,8 @@ var (
 )
 
 // Multiply multiplies in with this factor.
-func (factor VByteCostFactor) Multiply(in uint64) uint64 {
-	return uint64(factor) * in
+func (factor VByteCostFactor) Multiply(in VBytes) VBytes {
+	return VBytes(factor) * in
 }
 
 // With joins two factors with each other.
@@ -133,7 +136,7 @@ func (r *RentStructure) CoversStateRent(object NonEphemeralObject, rent uint64) 
 
 // MinRent returns the minimum rent to cover a given object.
 func (r *RentStructure) MinRent(object NonEphemeralObject) uint64 {
-	return uint64(r.VByteCost) * object.VBytes(r, nil)
+	return uint64(r.VByteCost) * uint64(object.VBytes(r, nil))
 }
 
 // MinStorageDepositForReturnOutput returns the minimum renting costs for an BasicOutput which returns
@@ -150,8 +153,8 @@ type NonEphemeralObject interface {
 	// virtual and physical space within the data set needed to implement the IOTA protocol.
 	// The override parameter acts as an escape hatch in case the cost needs to be adjusted
 	// according to some external properties outside the NonEphemeralObject.
-	VBytes(rentStruct *RentStructure, override VBytesFunc) uint64
+	VBytes(rentStruct *RentStructure, override VBytesFunc) VBytes
 }
 
 // VBytesFunc is a function which computes the virtual byte cost of a NonEphemeralObject.
-type VBytesFunc func(rentStruct *RentStructure) uint64
+type VBytesFunc func(rentStruct *RentStructure) VBytes

--- a/rent.go
+++ b/rent.go
@@ -139,7 +139,7 @@ func (r *RentStructure) MinRent(object NonEphemeralObject) uint64 {
 // MinStorageDepositForReturnOutput returns the minimum renting costs for an BasicOutput which returns
 // a StorageDepositReturnUnlockCondition amount back to the origin sender.
 func (r *RentStructure) MinStorageDepositForReturnOutput(sender Address) uint64 {
-	return (&BasicOutput{Conditions: UnlockConditions{&AddressUnlockCondition{Address: sender}}, Amount: 0}).VBytes(r, nil)
+	return uint64(r.VByteCost) * uint64((&BasicOutput{Conditions: UnlockConditions{&AddressUnlockCondition{Address: sender}}, Amount: 0}).VBytes(r, nil))
 }
 
 // NonEphemeralObject is an object which can not be pruned by nodes as it

--- a/token_scheme_simple.go
+++ b/token_scheme_simple.go
@@ -39,7 +39,7 @@ func (s *SimpleTokenScheme) Clone() TokenScheme {
 	}
 }
 
-func (s *SimpleTokenScheme) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *SimpleTokenScheme) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.OneByte) +
 		// minted/melted supply, max. supply
 		rentStruct.VBFactorData.Multiply(Uint256ByteSize+Uint256ByteSize+Uint256ByteSize)

--- a/unlock_cond.go
+++ b/unlock_cond.go
@@ -76,8 +76,8 @@ type UnlockCondition interface {
 // UnlockConditions is a slice of UnlockCondition(s).
 type UnlockConditions []UnlockCondition
 
-func (f UnlockConditions) VBytes(rentStruct *RentStructure, override VBytesFunc) uint64 {
-	var sumCost uint64
+func (f UnlockConditions) VBytes(rentStruct *RentStructure, override VBytesFunc) VBytes {
+	var sumCost VBytes
 	for _, unlockCond := range f {
 		sumCost += unlockCond.VBytes(rentStruct, nil)
 	}

--- a/unlock_cond_address.go
+++ b/unlock_cond_address.go
@@ -24,7 +24,7 @@ func (s *AddressUnlockCondition) Clone() UnlockCondition {
 	return &AddressUnlockCondition{Address: s.Address.Clone()}
 }
 
-func (s *AddressUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *AddressUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize) +
 		s.Address.VBytes(rentStruct, nil)
 }

--- a/unlock_cond_expiration.go
+++ b/unlock_cond_expiration.go
@@ -33,7 +33,7 @@ func (s *ExpirationUnlockCondition) Clone() UnlockCondition {
 	}
 }
 
-func (s *ExpirationUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *ExpirationUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize+serializer.UInt32ByteSize) +
 		s.ReturnAddress.VBytes(rentStruct, nil)
 }

--- a/unlock_cond_governor.go
+++ b/unlock_cond_governor.go
@@ -24,7 +24,7 @@ func (s *GovernorAddressUnlockCondition) Clone() UnlockCondition {
 	return &GovernorAddressUnlockCondition{Address: s.Address.Clone()}
 }
 
-func (s *GovernorAddressUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *GovernorAddressUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize) +
 		s.Address.VBytes(rentStruct, nil)
 }

--- a/unlock_cond_imm_alias.go
+++ b/unlock_cond_imm_alias.go
@@ -26,7 +26,7 @@ func (s *ImmutableAliasUnlockCondition) Clone() UnlockCondition {
 	return &ImmutableAliasUnlockCondition{Address: s.Address.Clone().(*AliasAddress)}
 }
 
-func (s *ImmutableAliasUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *ImmutableAliasUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize) +
 		s.Address.VBytes(rentStruct, nil)
 }

--- a/unlock_cond_state_ctrl.go
+++ b/unlock_cond_state_ctrl.go
@@ -24,7 +24,7 @@ func (s *StateControllerAddressUnlockCondition) Clone() UnlockCondition {
 	return &StateControllerAddressUnlockCondition{Address: s.Address.Clone()}
 }
 
-func (s *StateControllerAddressUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *StateControllerAddressUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize) +
 		s.Address.VBytes(rentStruct, nil)
 }

--- a/unlock_cond_storage_return.go
+++ b/unlock_cond_storage_return.go
@@ -31,7 +31,7 @@ func (s *StorageDepositReturnUnlockCondition) Clone() UnlockCondition {
 	}
 }
 
-func (s *StorageDepositReturnUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *StorageDepositReturnUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize+serializer.UInt64ByteSize) +
 		s.ReturnAddress.VBytes(rentStruct, nil)
 }

--- a/unlock_cond_timelock.go
+++ b/unlock_cond_timelock.go
@@ -22,7 +22,7 @@ func (s *TimelockUnlockCondition) Clone() UnlockCondition {
 	}
 }
 
-func (s *TimelockUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) uint64 {
+func (s *TimelockUnlockCondition) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.SmallTypeDenotationByteSize + serializer.UInt32ByteSize)
 }
 


### PR DESCRIPTION
This PR fixes a non-critical bug in the minimum balance calculation for the needed balance for the storage deposit return unlock condition.

There was no attack vector to bloat the ledger, because the rules for minimum storage deposit of the output itself still applied.