### PR TITLE
Update attestation comparison

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -42,9 +42,9 @@ func (a *Attestation) Compare(other *Attestation) int {
 		return 1
 	case a.SlotCommitmentID.Index() < other.SlotCommitmentID.Index():
 		return -1
-	case a.IssuingTime.Before(other.IssuingTime):
-		return 1
 	case a.IssuingTime.After(other.IssuingTime):
+		return 1
+	case a.IssuingTime.Before(other.IssuingTime):
 		return -1
 	default:
 		return bytes.Compare(a.BlockContentHash[:], other.BlockContentHash[:])

--- a/attestation.go
+++ b/attestation.go
@@ -38,9 +38,13 @@ func (a *Attestation) Compare(other *Attestation) int {
 		return -1
 	case other == nil:
 		return 1
-	case a.IssuingTime.After(other.IssuingTime):
+	case a.SlotCommitmentID.Index() > other.SlotCommitmentID.Index():
 		return 1
-	case other.IssuingTime.After(a.IssuingTime):
+	case a.SlotCommitmentID.Index() < other.SlotCommitmentID.Index():
+		return -1
+	case a.IssuingTime.Before(other.IssuingTime):
+		return 1
+	case a.IssuingTime.After(other.IssuingTime):
 		return -1
 	default:
 		return bytes.Compare(a.BlockContentHash[:], other.BlockContentHash[:])


### PR DESCRIPTION
# Description of change

This PR updates `Compare` of `Attestation` to take the slot index of it as the main factor for comparison. 
If equal, the lower issuing time of the carrying block is used. This is to prevent frequent switching of attestations in more recent blocks.
