### PR TITLE
Replace `time.Time` with `uint64` as block timestamp

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -25,7 +25,7 @@ type Attestation struct {
 func NewAttestation(block *Block) *Attestation {
 	return &Attestation{
 		IssuerID:         block.IssuerID,
-		IssuingTime:      block.IssuingTime,
+		IssuingTime:      block.IssuingTime(),
 		SlotCommitmentID: block.SlotCommitment.MustID(),
 		BlockContentHash: lo.PanicOnErr(block.ContentHash()),
 		Signature:        block.Signature,

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -20,10 +20,10 @@ const (
 func NewBlockBuilder() *BlockBuilder {
 	return &BlockBuilder{
 		block: &iotago.Block{
-			ProtocolVersion: defaultProtocolVersion,
-			SlotCommitment:  iotago.NewEmptyCommitment(),
-			IssuingTime:     time.Now(),
-			Signature:       &iotago.Ed25519Signature{},
+			ProtocolVersion:  defaultProtocolVersion,
+			SlotCommitment:   iotago.NewEmptyCommitment(),
+			IssuingTimestamp: uint64(time.Now().UnixNano()),
+			Signature:        &iotago.Ed25519Signature{},
 		},
 	}
 }
@@ -70,7 +70,7 @@ func (mb *BlockBuilder) IssuingTime(time time.Time) *BlockBuilder {
 		return mb
 	}
 
-	mb.block.IssuingTime = time
+	mb.block.SetIssuingTime(time)
 
 	return mb
 }


### PR DESCRIPTION
# Description of change

Replace `time.Time` with `uint64` on the `Block` type. The timestamp is supposed to be encoded as `uint64` but `time.Time` is serialized as an `int64`. Out of the two options of 1) changing how `Time` is serialized and 2) replacing the type of the timestamp on the block, the latter was chosen. This option is both easier to implement and the convenience of working with `Time` can still be added via getters and setters.
The approach for converting between a Unix timestamp in `int64` and `uint64` and vice versa, is to truncate to the common value range both types can represent, which still allows for any dates to be represented between `1970` and `2262`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tests were added to ensure the correct conversion between the `uint64` we need and the expected `int64` nanosecond timestamp used by `time.Time`.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
