### PR TITLE
Change `MaxCommittableAge` field type

### DIFF
--- a/api.go
+++ b/api.go
@@ -107,8 +107,9 @@ type ProtocolParameters struct {
 	StoredManaDecayFactors []float64 //`serix:"9,mapKey=storedManaDecayFactors"`
 	// PotentialManaDecayFactors is a map of slot index to decay factor.
 	PotentialManaDecayFactors []float64 //`serix:"10,mapKey=potentialManaDecayFactors"`
-	// MaxCommitableAge defines the maximum age of a slot to which a block can commit relative to the block timestamp.
-	MaxCommitableAge uint32 `serix:"11,mapKey=maxCommitableAge"`
+	// MaxCommittableAge defines the maximum age of a slot to which a block can commit relative to the block timestamp,
+	// expressed in number of slots.
+	MaxCommittableAge SlotIndex `serix:"11,mapKey=maxCommittableAge"`
 }
 
 func (p ProtocolParameters) AsSerixContext() context.Context {

--- a/api_test.go
+++ b/api_test.go
@@ -86,9 +86,9 @@ func TestProtocolParametersJSONMarshalling(t *testing.T) {
 		TokenSupply:           1234567890987654321,
 		GenesisUnixTimestamp:  1681373293,
 		SlotDurationInSeconds: 10,
-		MaxCommitableAge:      10,
+		MaxCommittableAge:     10,
 	}
-	protoParamsJSON := `{"version":6,"networkName":"xxxNetwork","bech32Hrp":"xxx","minPowScore":666,"rentStructure":{"vByteCost":6,"vByteFactorData":8,"vByteFactorKey":7},"tokenSupply":"1234567890987654321","genesisUnixTimestamp":1681373293,"slotDurationInSeconds":10,"maxCommitableAge":10}`
+	protoParamsJSON := `{"version":6,"networkName":"xxxNetwork","bech32Hrp":"xxx","minPowScore":666,"rentStructure":{"vByteCost":6,"vByteFactorData":8,"vByteFactorKey":7},"tokenSupply":"1234567890987654321","genesisUnixTimestamp":1681373293,"slotDurationInSeconds":10,"maxCommittableAge":"10"}`
 
 	jsonProtoParams, err := v3API.JSONEncode(protoParams)
 	require.NoError(t, err)

--- a/nodeclient/event_api_client_test.go
+++ b/nodeclient/event_api_client_test.go
@@ -25,7 +25,7 @@ var emptyAPI = iotago.LatestAPI(&iotago.ProtocolParameters{
 	TokenSupply:           0,
 	GenesisUnixTimestamp:  0,
 	SlotDurationInSeconds: 0,
-	MaxCommitableAge:      0,
+	MaxCommittableAge:     0,
 })
 
 func TestMain(m *testing.M) { // call the tests

--- a/vm/stardust/stvf_test.go
+++ b/vm/stardust/stvf_test.go
@@ -117,7 +117,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			transType: iotago.ChainTransitionTypeGenesis,
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -155,7 +155,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			transType: iotago.ChainTransitionTypeGenesis,
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -193,7 +193,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			transType: iotago.ChainTransitionTypeGenesis,
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -410,7 +410,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{},
@@ -464,7 +464,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{},
@@ -636,7 +636,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -698,7 +698,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -748,7 +748,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -811,7 +811,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -874,7 +874,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -937,7 +937,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{
@@ -993,7 +993,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			svCtx: &vm.Params{
 				External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(0, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				},
 				WorkingSet: &vm.WorkingSet{
 					UnlockedIdents: vm.UnlockedIdentities{

--- a/vm/stardust/vm_stardust.go
+++ b/vm/stardust/vm_stardust.go
@@ -117,7 +117,7 @@ func accountGenesisValid(current *iotago.AccountOutput, vmParams *vm.Params) err
 		return fmt.Errorf("%w: AccountOutput's ID is not zeroed even though it is new", iotago.ErrInvalidAccountStateTransition)
 	}
 
-	if nextBIFeat := current.FeatureSet().BlockIssuer(); nextBIFeat != nil && nextBIFeat.ExpirySlot != 0 && nextBIFeat.ExpirySlot < vmParams.WorkingSet.Tx.Essence.CreationTime+iotago.SlotIndex(vmParams.External.ProtocolParameters.MaxCommitableAge) {
+	if nextBIFeat := current.FeatureSet().BlockIssuer(); nextBIFeat != nil && nextBIFeat.ExpirySlot != 0 && nextBIFeat.ExpirySlot < vmParams.WorkingSet.Tx.Essence.CreationTime+vmParams.External.ProtocolParameters.MaxCommittableAge {
 		return fmt.Errorf("%w: block issuer feature expiry set too soon", iotago.ErrInvalidBlockIssuerTransition)
 	}
 
@@ -229,13 +229,13 @@ func accountBlockIssuerSTVF(input *vm.ChainOutputWithCreationTime, next *iotago.
 		if nextBIFeat == nil {
 			return fmt.Errorf("%w: cannot remove block issuer feature until it expires", iotago.ErrInvalidBlockIssuerTransition)
 		}
-		if nextBIFeat.ExpirySlot != 0 && nextBIFeat.ExpirySlot != currentBIFeat.ExpirySlot && nextBIFeat.ExpirySlot < txSlotIndex+iotago.SlotIndex(vmParams.External.ProtocolParameters.MaxCommitableAge) {
+		if nextBIFeat.ExpirySlot != 0 && nextBIFeat.ExpirySlot != currentBIFeat.ExpirySlot && nextBIFeat.ExpirySlot < txSlotIndex+vmParams.External.ProtocolParameters.MaxCommittableAge {
 			return fmt.Errorf("%w: block issuer feature expiry set too soon", iotago.ErrInvalidBlockIssuerTransition)
 		}
 
 	} else if nextBIFeat != nil {
 		// if the block issuer feature has expired, it must either be removed or expiry extended.
-		if nextBIFeat.ExpirySlot != 0 && nextBIFeat.ExpirySlot < txSlotIndex+iotago.SlotIndex(vmParams.External.ProtocolParameters.MaxCommitableAge) {
+		if nextBIFeat.ExpirySlot != 0 && nextBIFeat.ExpirySlot < txSlotIndex+vmParams.External.ProtocolParameters.MaxCommittableAge {
 			return fmt.Errorf("%w: block issuer feature expiry set too soon", iotago.ErrInvalidBlockIssuerTransition)
 		}
 	}
@@ -263,7 +263,7 @@ func accountBlockIssuerSTVF(input *vm.ChainOutputWithCreationTime, next *iotago.
 		if !is {
 			continue
 		}
-		if basicOutput.UnlockConditionSet().HasManalockCondition(current.AccountID, txSlotIndex+iotago.SlotIndex(vmParams.External.ProtocolParameters.MaxCommitableAge)) {
+		if basicOutput.UnlockConditionSet().HasManalockCondition(current.AccountID, txSlotIndex+vmParams.External.ProtocolParameters.MaxCommittableAge) {
 			manaOut -= basicOutput.StoredMana()
 		}
 	}
@@ -272,7 +272,7 @@ func accountBlockIssuerSTVF(input *vm.ChainOutputWithCreationTime, next *iotago.
 		if !is {
 			continue
 		}
-		if nftOutput.UnlockConditionSet().HasManalockCondition(current.AccountID, txSlotIndex+iotago.SlotIndex(vmParams.External.ProtocolParameters.MaxCommitableAge)) {
+		if nftOutput.UnlockConditionSet().HasManalockCondition(current.AccountID, txSlotIndex+vmParams.External.ProtocolParameters.MaxCommittableAge) {
 			manaOut -= nftOutput.StoredMana()
 		}
 	}

--- a/vm/stardust/vm_stardust_test.go
+++ b/vm/stardust/vm_stardust_test.go
@@ -850,7 +850,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 				name: "ok - modify block issuer account",
 				vmParams: &vm.Params{External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(1, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				}},
 				resolvedInputs: vm.ResolvedInputs{InputSet: inputs, BICInputSet: bicInputs},
 				tx: &iotago.Transaction{
@@ -936,7 +936,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 				name: "ok - set block issuer expiry to 0",
 				vmParams: &vm.Params{External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(1, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				}},
 				resolvedInputs: vm.ResolvedInputs{InputSet: inputs, BICInputSet: bicInputs},
 				tx: &iotago.Transaction{
@@ -1011,7 +1011,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 				name: "fail - destroy block issuer account with expiry at slot 0",
 				vmParams: &vm.Params{External: &iotago.ExternalUnlockParameters{
 					DecayProvider:      iotago.NewDecayProvider(1, []float64{}, []float64{}),
-					ProtocolParameters: &iotago.ProtocolParameters{MaxCommitableAge: 10},
+					ProtocolParameters: &iotago.ProtocolParameters{MaxCommittableAge: 10},
 				}},
 				resolvedInputs: vm.ResolvedInputs{InputSet: inputs, BICInputSet: bicInputs},
 				tx: &iotago.Transaction{


### PR DESCRIPTION
# Description of change

Changes the type of the `MaxCommittableAge` protocol parameter to `SlotIndex` and fixes the typo in its name.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`go test`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
