### PR TITLE
Use safe math in mana calculations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/ethereum/go-ethereum v1.12.0
+	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230707145818-c114638b5581
 	github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/ierrors v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/lo v0.0.0-20230706083020-ef6c3248369d

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/ethereum/go-ethereum v1.12.0
-	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230707145818-c114638b5581
+	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5
 	github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/ierrors v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/lo v0.0.0-20230706083020-ef6c3248369d

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6
 github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230705073627-cfe175cea4a6 h1:ZwIJS4ePAk3ki+OuhjSkCfdy17PpydWaSzmfWP0YrkU=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230705073627-cfe175cea4a6/go.mod h1:bvXXc6quBdERMMKnirr2+iQU4WnTz4KDbdHcusW9Ats=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230707145818-c114638b5581 h1:+At3owl5Er6q8FSUS/COU1dqN5vyxp7XWulDrJb7XtQ=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230707145818-c114638b5581/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d h1:6VVi5LZGAIXYFzb+/k3G6+T6dNkLi2beD0O6CccxdLg=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d/go.mod h1:kkIoyWWDol9XTEuNy0wtUYQWx+Eb0Ak9XP8SS3g1/J8=
 github.com/iotaledger/hive.go/ierrors v0.0.0-20230706083020-ef6c3248369d h1:USj27KfaNTE4HD99HAv9heagQ6puR/iquHp/MQXXMbw=

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/iotaledger/hive.go/constraints v0.0.0-20230705073627-cfe175cea4a6 h1:
 github.com/iotaledger/hive.go/constraints v0.0.0-20230705073627-cfe175cea4a6/go.mod h1:bvXXc6quBdERMMKnirr2+iQU4WnTz4KDbdHcusW9Ats=
 github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230707145818-c114638b5581 h1:+At3owl5Er6q8FSUS/COU1dqN5vyxp7XWulDrJb7XtQ=
 github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230707145818-c114638b5581/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5 h1:K4dWLTZwURU7xVF5uePUk0oDViBDQrsdZ7ZHBCrTYOs=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d h1:6VVi5LZGAIXYFzb+/k3G6+T6dNkLi2beD0O6CccxdLg=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d/go.mod h1:kkIoyWWDol9XTEuNy0wtUYQWx+Eb0Ak9XP8SS3g1/J8=
 github.com/iotaledger/hive.go/ierrors v0.0.0-20230706083020-ef6c3248369d h1:USj27KfaNTE4HD99HAv9heagQ6puR/iquHp/MQXXMbw=

--- a/transaction.go
+++ b/transaction.go
@@ -17,6 +17,8 @@ var (
 	ErrMissingUTXO = ierrors.New("missing utxo")
 	// ErrInputOutputSumMismatch gets returned if a transaction does not spend the entirety of the inputs to the outputs.
 	ErrInputOutputSumMismatch = ierrors.New("inputs and outputs do not spend/deposit the same amount")
+	// ErrManaOverflow gets returned when there is an under- or overflow in Mana calculations.
+	ErrManaOverflow = ierrors.New("under- or overflow in Mana calculations")
 	// ErrSignatureAndAddrIncompatible gets returned if an address of an input has a companion signature unlock with the wrong signature type.
 	ErrSignatureAndAddrIncompatible = ierrors.New("address and signature type are not compatible")
 	// ErrInvalidInputUnlock gets returned when an input unlock is invalid.

--- a/vm/stardust/vm_stardust.go
+++ b/vm/stardust/vm_stardust.go
@@ -290,10 +290,13 @@ func accountBlockIssuerSTVF(input *vm.ChainOutputWithCreationTime, next *iotago.
 		return err
 	}
 
-	manaOut := vm.TotalManaOut(
+	manaOut, err := vm.TotalManaOut(
 		vmParams.WorkingSet.Tx.Essence.Outputs,
 		vmParams.WorkingSet.Tx.Essence.Allotments,
 	)
+	if err != nil {
+		return err
+	}
 
 	manaStoredAccount, err := manaDecayProvider.StoredManaWithDecay(current.Mana, input.CreationTime, vmParams.WorkingSet.Tx.Essence.CreationTime) // AccountInStored
 	if err != nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/iotaledger/hive.go/core/safemath"
 	"github.com/iotaledger/hive.go/ierrors"
 	iotago "github.com/iotaledger/iota.go/v4"
 )
@@ -129,29 +130,43 @@ func TotalManaIn(manaDecayProvider *iotago.ManaDecayProvider, txCreationTime iot
 		if err != nil {
 			return 0, ierrors.Wrapf(err, "input %s stored mana calculation failed", outputID)
 		}
-		totalIn += manaStored
+		totalIn, err = safemath.SafeAdd(totalIn, manaStored)
+		if err != nil {
+			return 0, ierrors.Wrapf(iotago.ErrManaOverflow, "%w", err)
+		}
 
 		// potential Mana
 		manaPotential, err := manaDecayProvider.PotentialManaWithDecay(input.Output.Deposit(), input.CreationTime, txCreationTime)
 		if err != nil {
 			return 0, ierrors.Wrapf(err, "input %s potential mana calculation failed", outputID)
 		}
-		totalIn += manaPotential
+		totalIn, err = safemath.SafeAdd(totalIn, manaPotential)
+		if err != nil {
+			return 0, ierrors.Wrapf(iotago.ErrManaOverflow, "%w", err)
+		}
 	}
 
 	return totalIn, nil
 }
 
-func TotalManaOut(outputs iotago.Outputs[iotago.TxEssenceOutput], allotments iotago.Allotments) iotago.Mana {
+func TotalManaOut(outputs iotago.Outputs[iotago.TxEssenceOutput], allotments iotago.Allotments) (iotago.Mana, error) {
 	var totalOut iotago.Mana
+	var err error
+
 	for _, output := range outputs {
-		totalOut += output.StoredMana()
+		totalOut, err = safemath.SafeAdd(totalOut, output.StoredMana())
+		if err != nil {
+			return 0, ierrors.Wrapf(iotago.ErrManaOverflow, "%w", err)
+		}
 	}
 	for _, allotment := range allotments {
-		totalOut += allotment.Value
+		totalOut, err = safemath.SafeAdd(totalOut, allotment.Value)
+		if err != nil {
+			return 0, ierrors.Wrapf(iotago.ErrManaOverflow, "%w", err)
+		}
 	}
 
-	return totalOut
+	return totalOut, nil
 }
 
 // RunVMFuncs runs the given ExecFunc(s) in serial order.
@@ -463,7 +478,11 @@ func ExecFuncBalancedMana() ExecFunc {
 		if err != nil {
 			return err
 		}
-		manaOut := TotalManaOut(vmParams.WorkingSet.Tx.Essence.Outputs, vmParams.WorkingSet.Tx.Essence.Allotments)
+
+		manaOut, err := TotalManaOut(vmParams.WorkingSet.Tx.Essence.Outputs, vmParams.WorkingSet.Tx.Essence.Allotments)
+		if err != nil {
+			return err
+		}
 
 		// Whether it's valid to claim rewards is checked in the delegation and staking STVFs.
 		for _, reward := range vmParams.WorkingSet.Rewards {


### PR DESCRIPTION
# Description of change

Use safe math in mana calculations to detect overflows on the input and output side.

Depends on iotaledger/hive.go#526.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added two overflow tests for mana on input and output side.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x]  I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
