### PR TITLE
Align Mana field in Outputs

### DIFF
--- a/output_account.go
+++ b/output_account.go
@@ -141,24 +141,24 @@ type (
 type AccountOutput struct {
 	// The amount of IOTA tokens held by the output.
 	Amount BaseToken `serix:"0,mapKey=amount"`
-	// The native tokens held by the output.
-	NativeTokens NativeTokens `serix:"1,mapKey=nativeTokens,omitempty"`
-	// The identifier for this account.
-	AccountID AccountID `serix:"2,mapKey=accountId"`
-	// The index of the state.
-	StateIndex uint32 `serix:"3,mapKey=stateIndex"`
-	// The state of the account which can only be mutated by the state controller.
-	StateMetadata []byte `serix:"4,lengthPrefixType=uint16,mapKey=stateMetadata,omitempty,maxLen=8192"`
-	// The counter that denotes the number of foundries created by this account.
-	FoundryCounter uint32 `serix:"5,mapKey=foundryCounter"`
-	// The unlock conditions on this output.
-	Conditions AccountOutputUnlockConditions `serix:"6,mapKey=unlockConditions,omitempty"`
-	// The features on the output.
-	Features AccountOutputFeatures `serix:"7,mapKey=features,omitempty"`
-	// The immutable feature on the output.
-	ImmutableFeatures AccountOutputImmFeatures `serix:"8,mapKey=immutableFeatures,omitempty"`
 	// The stored mana held by the output.
-	Mana Mana `serix:"9,mapKey=mana"`
+	Mana Mana `serix:"1,mapKey=mana"`
+	// The native tokens held by the output.
+	NativeTokens NativeTokens `serix:"2,mapKey=nativeTokens,omitempty"`
+	// The identifier for this account.
+	AccountID AccountID `serix:"3,mapKey=accountId"`
+	// The index of the state.
+	StateIndex uint32 `serix:"4,mapKey=stateIndex"`
+	// The state of the account which can only be mutated by the state controller.
+	StateMetadata []byte `serix:"5,lengthPrefixType=uint16,mapKey=stateMetadata,omitempty,maxLen=8192"`
+	// The counter that denotes the number of foundries created by this account.
+	FoundryCounter uint32 `serix:"6,mapKey=foundryCounter"`
+	// The unlock conditions on this output.
+	Conditions AccountOutputUnlockConditions `serix:"7,mapKey=unlockConditions,omitempty"`
+	// The features on the output.
+	Features AccountOutputFeatures `serix:"8,mapKey=features,omitempty"`
+	// The immutable feature on the output.
+	ImmutableFeatures AccountOutputImmFeatures `serix:"9,mapKey=immutableFeatures,omitempty"`
 }
 
 func (a *AccountOutput) GovernorAddress() Address {
@@ -172,15 +172,15 @@ func (a *AccountOutput) StateController() Address {
 func (a *AccountOutput) Clone() Output {
 	return &AccountOutput{
 		Amount:            a.Amount,
-		AccountID:         a.AccountID,
+		Mana:              a.Mana,
 		NativeTokens:      a.NativeTokens.Clone(),
+		AccountID:         a.AccountID,
 		StateIndex:        a.StateIndex,
 		StateMetadata:     append([]byte(nil), a.StateMetadata...),
 		FoundryCounter:    a.FoundryCounter,
 		Conditions:        a.Conditions.Clone(),
 		Features:          a.Features.Clone(),
 		ImmutableFeatures: a.ImmutableFeatures.Clone(),
-		Mana:              a.Mana,
 	}
 }
 
@@ -265,6 +265,7 @@ func (a *AccountOutput) Type() OutputType {
 func (a *AccountOutput) Size() int {
 	return util.NumByteLen(byte(OutputAccount)) +
 		BaseTokenSize +
+		ManaSize +
 		a.NativeTokens.Size() +
 		AccountIDLength +
 		util.NumByteLen(a.StateIndex) +
@@ -273,6 +274,5 @@ func (a *AccountOutput) Size() int {
 		util.NumByteLen(a.FoundryCounter) +
 		a.Conditions.Size() +
 		a.Features.Size() +
-		a.ImmutableFeatures.Size() +
-		ManaSize
+		a.ImmutableFeatures.Size()
 }

--- a/output_basic.go
+++ b/output_basic.go
@@ -19,14 +19,14 @@ type BasicOutputs []*BasicOutput
 type BasicOutput struct {
 	// The amount of IOTA tokens held by the output.
 	Amount BaseToken `serix:"0,mapKey=amount"`
-	// The native tokens held by the output.
-	NativeTokens NativeTokens `serix:"1,mapKey=nativeTokens,omitempty"`
-	// The unlock conditions on this output.
-	Conditions BasicOutputUnlockConditions `serix:"2,mapKey=unlockConditions,omitempty"`
-	// The features on the output.
-	Features BasicOutputFeatures `serix:"3,mapKey=features,omitempty"`
 	// The stored mana held by the output.
-	Mana Mana `serix:"4,mapKey=mana"`
+	Mana Mana `serix:"1,mapKey=mana"`
+	// The native tokens held by the output.
+	NativeTokens NativeTokens `serix:"2,mapKey=nativeTokens,omitempty"`
+	// The unlock conditions on this output.
+	Conditions BasicOutputUnlockConditions `serix:"3,mapKey=unlockConditions,omitempty"`
+	// The features on the output.
+	Features BasicOutputFeatures `serix:"4,mapKey=features,omitempty"`
 }
 
 // IsSimpleTransfer tells whether this BasicOutput fulfills the criteria of being a simple transfer.
@@ -37,10 +37,10 @@ func (e *BasicOutput) IsSimpleTransfer() bool {
 func (e *BasicOutput) Clone() Output {
 	return &BasicOutput{
 		Amount:       e.Amount,
+		Mana:         e.Mana,
 		NativeTokens: e.NativeTokens.Clone(),
 		Conditions:   e.Conditions.Clone(),
 		Features:     e.Features.Clone(),
-		Mana:         e.Mana,
 	}
 }
 
@@ -88,8 +88,8 @@ func (e *BasicOutput) Type() OutputType {
 func (e *BasicOutput) Size() int {
 	return util.NumByteLen(byte(OutputBasic)) +
 		BaseTokenSize +
+		ManaSize +
 		e.NativeTokens.Size() +
 		e.Conditions.Size() +
-		e.Features.Size() +
-		ManaSize
+		e.Features.Size()
 }

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -95,8 +95,6 @@ type FoundryOutput struct {
 	Features FoundryOutputFeatures `serix:"5,mapKey=features,omitempty"`
 	// The immutable feature on the output.
 	ImmutableFeatures FoundryOutputImmFeatures `serix:"6,mapKey=immutableFeatures,omitempty"`
-	// The stored mana held by the output.
-	Mana Mana `serix:"7,mapKey=mana"`
 }
 
 func (f *FoundryOutput) Clone() Output {
@@ -108,7 +106,6 @@ func (f *FoundryOutput) Clone() Output {
 		Conditions:        f.Conditions.Clone(),
 		Features:          f.Features.Clone(),
 		ImmutableFeatures: f.ImmutableFeatures.Clone(),
-		Mana:              f.Mana,
 	}
 }
 
@@ -200,7 +197,7 @@ func (f *FoundryOutput) Deposit() BaseToken {
 }
 
 func (f *FoundryOutput) StoredMana() Mana {
-	return f.Mana
+	return 0
 }
 
 func (f *FoundryOutput) Type() OutputType {
@@ -215,6 +212,5 @@ func (f *FoundryOutput) Size() int {
 		f.TokenScheme.Size() +
 		f.Conditions.Size() +
 		f.Features.Size() +
-		f.ImmutableFeatures.Size() +
-		ManaSize
+		f.ImmutableFeatures.Size()
 }

--- a/output_nft.go
+++ b/output_nft.go
@@ -83,29 +83,29 @@ type (
 type NFTOutput struct {
 	// The amount of IOTA tokens held by the output.
 	Amount BaseToken `serix:"0,mapKey=amount"`
-	// The native tokens held by the output.
-	NativeTokens NativeTokens `serix:"1,mapKey=nativeTokens,omitempty"`
-	// The identifier of this NFT.
-	NFTID NFTID `serix:"2,mapKey=nftId"`
-	// The unlock conditions on this output.
-	Conditions NFTOutputUnlockConditions `serix:"3,mapKey=unlockConditions,omitempty"`
-	// The feature on the output.
-	Features NFTOutputFeatures `serix:"4,mapKey=features,omitempty"`
-	// The immutable feature on the output.
-	ImmutableFeatures NFTOutputImmFeatures `serix:"5,mapKey=immutableFeatures,omitempty"`
 	// The stored mana held by the output.
-	Mana Mana `serix:"6,mapKey=mana"`
+	Mana Mana `serix:"1,mapKey=mana"`
+	// The native tokens held by the output.
+	NativeTokens NativeTokens `serix:"2,mapKey=nativeTokens,omitempty"`
+	// The identifier of this NFT.
+	NFTID NFTID `serix:"3,mapKey=nftId"`
+	// The unlock conditions on this output.
+	Conditions NFTOutputUnlockConditions `serix:"4,mapKey=unlockConditions,omitempty"`
+	// The feature on the output.
+	Features NFTOutputFeatures `serix:"5,mapKey=features,omitempty"`
+	// The immutable feature on the output.
+	ImmutableFeatures NFTOutputImmFeatures `serix:"6,mapKey=immutableFeatures,omitempty"`
 }
 
 func (n *NFTOutput) Clone() Output {
 	return &NFTOutput{
 		Amount:            n.Amount,
+		Mana:              n.Mana,
 		NativeTokens:      n.NativeTokens.Clone(),
 		NFTID:             n.NFTID,
 		Conditions:        n.Conditions.Clone(),
 		Features:          n.Features.Clone(),
 		ImmutableFeatures: n.ImmutableFeatures.Clone(),
-		Mana:              n.Mana,
 	}
 }
 
@@ -164,10 +164,10 @@ func (n *NFTOutput) Type() OutputType {
 func (n *NFTOutput) Size() int {
 	return util.NumByteLen(byte(OutputNFT)) +
 		BaseTokenSize +
+		ManaSize +
 		n.NativeTokens.Size() +
 		NFTIDLength +
 		n.Conditions.Size() +
 		n.Features.Size() +
-		n.ImmutableFeatures.Size() +
-		ManaSize
+		n.ImmutableFeatures.Size()
 }

--- a/output_test.go
+++ b/output_test.go
@@ -142,7 +142,6 @@ func TestOutputsDeSerialize(t *testing.T) {
 				Features: iotago.FoundryOutputFeatures{
 					&iotago.MetadataFeature{Data: tpkg.RandBytes(100)},
 				},
-				Mana: 500,
 			},
 			target: &iotago.FoundryOutput{},
 		},


### PR DESCRIPTION
# Description of change

Align Mana field with TIPs.

- Change the field's position in Basic, Account and NFT Outputs.
- Remove Mana field from Foundry.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`go test`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
