### PR TITLE
Fix block issuer keys validation rules.

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -70,8 +70,7 @@ var (
 		Min: MinBlockIssuerKeysCount,
 		Max: MaxBlockIssuerKeysCount,
 		ValidationMode: serializer.ArrayValidationModeNoDuplicates |
-			serializer.ArrayValidationModeLexicalOrdering |
-			serializer.ArrayValidationModeAtMostOneOfEachTypeByte,
+			serializer.ArrayValidationModeLexicalOrdering,
 	}
 
 	accountOutputV3ImmFeatBlocksArrRules = &serix.ArrayRules{


### PR DESCRIPTION
# Description of change

Remove incorrect `ArrayValidationModeAtMostOneOfEachTypeByte` rule.
