### PR TITLE
Rename `CreationTime` to `CreationSlot`

### DIFF
--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -74,8 +74,8 @@ func (b *TransactionBuilder) AddOutput(output iotago.Output) *TransactionBuilder
 	return b
 }
 
-func (b *TransactionBuilder) SetCreationTime(creationTime iotago.SlotIndex) *TransactionBuilder {
-	b.essence.CreationTime = creationTime
+func (b *TransactionBuilder) SetCreationSlot(creationSlot iotago.SlotIndex) *TransactionBuilder {
+	b.essence.CreationSlot = creationSlot
 
 	return b
 }

--- a/transaction.go
+++ b/transaction.go
@@ -31,8 +31,8 @@ var (
 	ErrReturnAmountNotFulFilled = ierrors.New("return amount not fulfilled")
 	// ErrInputOutputManaMismatch gets returned if Mana is not balanced across inputs and outputs/allotments.
 	ErrInputOutputManaMismatch = ierrors.New("inputs and outputs do not contain the same amount of Mana")
-	// ErrInputCreationAfterTxCreation gets returned if an input has creation time after the transaction creation time.
-	ErrInputCreationAfterTxCreation = ierrors.New("input creation time after tx creation time")
+	// ErrInputCreationAfterTxCreation gets returned if an input has creation slot after the transaction creation slot.
+	ErrInputCreationAfterTxCreation = ierrors.New("input creation slot after tx creation slot")
 	// ErrUnknownTransactionEssenceType gets returned for unknown transaction essence types.
 	ErrUnknownTransactionEssenceType = ierrors.New("unknown transaction essence type")
 )

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -102,8 +102,8 @@ type (
 type TransactionEssence struct {
 	// The network ID for which this essence is valid for.
 	NetworkID NetworkID `serix:"0,mapKey=networkId"`
-	// The time at which this transaction was created by the client.
-	CreationTime SlotIndex `serix:"1,mapKey=creationTime"`
+	// The slot index in which the transaction was created by the client.
+	CreationSlot SlotIndex `serix:"1,mapKey=creationSlot"`
 	// The commitment references of this transaction.
 	ContextInputs TxEssenceContextInputs `serix:"2,mapKey=contextInputs"`
 	// The inputs of this transaction.
@@ -166,7 +166,7 @@ func (u *TransactionEssence) Size() int {
 	return serializer.OneByte +
 		// NetworkID
 		serializer.UInt64ByteSize +
-		// CreationTime
+		// CreationSlot
 		SlotIndexLength +
 		u.ContextInputs.Size() +
 		u.Inputs.Size() +
@@ -217,7 +217,7 @@ func (u *TransactionEssence) syntacticallyValidate(protoParams ProtocolParameter
 }
 
 func (u *TransactionEssence) WorkScore(workScoreStructure *WorkScoreStructure) (WorkScore, error) {
-	// TransactionEssenceType + NetworkID + CreationTime + InputsCommitment
+	// TransactionEssenceType + NetworkID + CreationSlot + InputsCommitment
 	workScoreBytes, err := workScoreStructure.DataByte.Multiply(serializer.OneByte + serializer.UInt64ByteSize + serializer.UInt64ByteSize + InputsCommitmentLength)
 	if err != nil {
 		return 0, err

--- a/vm/stardust/stvf_test.go
+++ b/vm/stardust/stvf_test.go
@@ -71,7 +71,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 
 	type test struct {
 		name      string
-		input     *vm.ChainOutputWithCreationTime
+		input     *vm.ChainOutputWithCreationSlot
 		next      *iotago.AccountOutput
 		nextMut   map[string]fieldMutations
 		transType iotago.ChainTransitionType
@@ -137,7 +137,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: 900,
+							CreationSlot: 900,
 						},
 					},
 				},
@@ -176,7 +176,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: 10001,
+							CreationSlot: 10001,
 						},
 					},
 				},
@@ -215,7 +215,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: 991,
+							CreationSlot: 991,
 						},
 					},
 				},
@@ -254,7 +254,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -294,7 +294,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -334,7 +334,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -374,7 +374,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -413,7 +413,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -423,7 +423,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - valid staking transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:     100,
 					AccountID:  exampleAccountID,
@@ -473,7 +473,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -482,7 +482,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - removing staking feature before end epoch",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:     100,
 					AccountID:  exampleAccountID,
@@ -526,7 +526,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -536,7 +536,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - changing staking feature's staked amount",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:     100,
 					AccountID:  exampleAccountID,
@@ -586,7 +586,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -596,7 +596,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - reducing staking feature's end epoch by more than the unbonding period",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:     100,
 					AccountID:  exampleAccountID,
@@ -646,7 +646,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -656,7 +656,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - account removes block issuer feature while having a staking feature",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:     100,
 					AccountID:  exampleAccountID,
@@ -678,7 +678,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: 1000,
+				CreationSlot: 1000,
 			},
 			next: &iotago.AccountOutput{
 				Amount:     100,
@@ -709,7 +709,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -719,7 +719,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - expired staking feature removed without specifying reward input",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:     100,
 					AccountID:  exampleAccountID,
@@ -738,7 +738,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 						exampleBlockIssuerFeature,
 					},
 				},
-				CreationTime: 1000,
+				CreationSlot: 1000,
 			},
 			next: &iotago.AccountOutput{
 				Amount:     100,
@@ -764,7 +764,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -774,7 +774,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - changing an expired staking feature without claiming",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:     100,
 					AccountID:  exampleAccountID,
@@ -793,7 +793,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 						exampleBlockIssuerFeature,
 					},
 				},
-				CreationTime: 1000,
+				CreationSlot: 1000,
 			},
 			next: &iotago.AccountOutput{
 				Amount:     100,
@@ -825,7 +825,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -835,7 +835,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - claiming rewards of an expired staking feature without resetting start epoch",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				ChainID: exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:     100,
@@ -855,7 +855,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 						exampleBlockIssuerFeature,
 					},
 				},
-				CreationTime: 1000,
+				CreationSlot: 1000,
 			},
 			next: &iotago.AccountOutput{
 				Amount:     100,
@@ -887,7 +887,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: currentSlot,
+							CreationSlot: currentSlot,
 						},
 					},
 					BIC: exampleBIC,
@@ -900,7 +900,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - destroy transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: tpkg.RandAccountAddress().AccountID(),
@@ -922,7 +922,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - destroy block issuer account with negative BIC",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -949,7 +949,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					UnlockedIdents: vm.UnlockedIdentities{},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: 1001,
+							CreationSlot: 1001,
 						},
 					},
 					BIC: map[iotago.AccountID]iotago.BlockIssuanceCredits{
@@ -961,7 +961,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - destroy block issuer account no BIC provided",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -988,7 +988,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					UnlockedIdents: vm.UnlockedIdentities{},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: 1001,
+							CreationSlot: 1001,
 						},
 					},
 				},
@@ -998,7 +998,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 
 		{
 			name: "fail - non-expired block issuer destroy transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: tpkg.RandAccountAddress().AccountID(),
@@ -1025,7 +1025,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					UnlockedIdents: vm.UnlockedIdentities{},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: 1000,
+							CreationSlot: 1000,
 						},
 					},
 				},
@@ -1034,7 +1034,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - expired block issuer destroy transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1065,7 +1065,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
 							Inputs:       nil,
-							CreationTime: 1001,
+							CreationSlot: 1001,
 						},
 					},
 				},
@@ -1074,7 +1074,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "failed - remove non-expired block issuer feature transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1115,7 +1115,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
 							Inputs:       nil,
-							CreationTime: 999,
+							CreationSlot: 999,
 						},
 					},
 				},
@@ -1124,7 +1124,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - remove expired block issuer feature transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1165,7 +1165,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
 							Inputs:       nil,
-							CreationTime: 1001,
+							CreationSlot: 1001,
 						},
 					},
 				},
@@ -1174,7 +1174,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - gov transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1216,7 +1216,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - state transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1250,7 +1250,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					UnlockedIdents: vm.UnlockedIdentities{
 						exampleStateCtrl.Key(): {UnlockedAt: 0},
 					},
-					InChains: map[iotago.ChainID]*vm.ChainOutputWithCreationTime{
+					InChains: map[iotago.ChainID]*vm.ChainOutputWithCreationSlot{
 						// serial number 5
 						exampleExistingFoundryOutputID: {
 							Output: exampleExistingFoundryOutput,
@@ -1285,7 +1285,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - update expired account without extending expiration after MCA",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1335,7 +1335,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
 							Inputs:       nil,
-							CreationTime: 990,
+							CreationSlot: 990,
 						},
 					},
 				},
@@ -1344,7 +1344,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - update account immutable features",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1390,7 +1390,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - update expired account with extending expiration before MCA",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1440,7 +1440,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
 							Inputs:       nil,
-							CreationTime: 990,
+							CreationSlot: 990,
 						},
 					},
 				},
@@ -1449,7 +1449,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - update expired account with extending expiration to the past before MCA",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1499,7 +1499,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
 							Inputs:       nil,
-							CreationTime: 990,
+							CreationSlot: 990,
 						},
 					},
 				},
@@ -1508,7 +1508,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - update block issuer account with negative BIC",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1558,7 +1558,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
 							Inputs:       nil,
-							CreationTime: 900,
+							CreationSlot: 900,
 						},
 					},
 				},
@@ -1567,7 +1567,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - update block issuer account without BIC provided",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1614,7 +1614,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: 900,
+							CreationSlot: 900,
 						},
 					},
 				},
@@ -1623,7 +1623,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - update expiration to earlier slot",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1672,7 +1672,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					},
 					Tx: &iotago.Transaction{
 						Essence: &iotago.TransactionEssence{
-							CreationTime: 900,
+							CreationSlot: 900,
 						},
 					},
 				},
@@ -1681,7 +1681,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - non-expired block issuer replace key",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1728,7 +1728,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 					UnlockedIdents: vm.UnlockedIdentities{
 						exampleStateCtrl.Key(): {UnlockedAt: 0},
 					},
-					InChains: map[iotago.ChainID]*vm.ChainOutputWithCreationTime{
+					InChains: map[iotago.ChainID]*vm.ChainOutputWithCreationSlot{
 						// serial number 5
 						exampleExistingFoundryOutputID: {
 							Output: exampleExistingFoundryOutput,
@@ -1766,7 +1766,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - gov transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:     100,
 					AccountID:  exampleAccountID,
@@ -1802,7 +1802,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - state transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.AccountOutput{
 					Amount:         100,
 					AccountID:      exampleAccountID,
@@ -1877,13 +1877,13 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 
 					if tt.input != nil {
 						// create the working set for the test
-						if tt.svCtx.WorkingSet.UTXOInputsWithCreationTime == nil {
-							tt.svCtx.WorkingSet.UTXOInputsWithCreationTime = make(vm.InputSet)
+						if tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot == nil {
+							tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot = make(vm.InputSet)
 						}
 
-						tt.svCtx.WorkingSet.UTXOInputsWithCreationTime[tpkg.RandOutputID(0)] = vm.OutputWithCreationTime{
+						tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot[tpkg.RandOutputID(0)] = vm.OutputWithCreationSlot{
 							Output:       tt.input.Output,
-							CreationTime: tt.input.CreationTime,
+							CreationSlot: tt.input.CreationSlot,
 						}
 					}
 
@@ -1901,13 +1901,13 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.input != nil {
 				// create the working set for the test
-				if tt.svCtx.WorkingSet.UTXOInputsWithCreationTime == nil {
-					tt.svCtx.WorkingSet.UTXOInputsWithCreationTime = make(vm.InputSet)
+				if tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot == nil {
+					tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot = make(vm.InputSet)
 				}
 
-				tt.svCtx.WorkingSet.UTXOInputsWithCreationTime[tpkg.RandOutputID(0)] = vm.OutputWithCreationTime{
+				tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot[tpkg.RandOutputID(0)] = vm.OutputWithCreationSlot{
 					Output:       tt.input.Output,
-					CreationTime: tt.input.CreationTime,
+					CreationSlot: tt.input.CreationSlot,
 				}
 			}
 
@@ -1953,7 +1953,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 
 	type test struct {
 		name      string
-		input     *vm.ChainOutputWithCreationTime
+		input     *vm.ChainOutputWithCreationSlot
 		next      *iotago.FoundryOutput
 		nextMut   map[string]fieldMutations
 		transType iotago.ChainTransitionType
@@ -1977,7 +1977,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 						Unlocks: nil,
 					},
 					InChains: vm.ChainInputSet{
-						exampleAccountIdent.AccountID(): &vm.ChainOutputWithCreationTime{
+						exampleAccountIdent.AccountID(): &vm.ChainOutputWithCreationSlot{
 							Output: &iotago.AccountOutput{FoundryCounter: 5},
 						},
 					},
@@ -2006,7 +2006,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 						Unlocks: nil,
 					},
 					InChains: vm.ChainInputSet{
-						exampleAccountIdent.AccountID(): &vm.ChainOutputWithCreationTime{
+						exampleAccountIdent.AccountID(): &vm.ChainOutputWithCreationSlot{
 							Output: &iotago.AccountOutput{FoundryCounter: 5},
 						},
 					},
@@ -2035,7 +2035,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 						Unlocks: nil,
 					},
 					InChains: vm.ChainInputSet{
-						exampleAccountIdent.AccountID(): &vm.ChainOutputWithCreationTime{
+						exampleAccountIdent.AccountID(): &vm.ChainOutputWithCreationSlot{
 							Output: &iotago.AccountOutput{FoundryCounter: 6},
 						},
 					},
@@ -2077,7 +2077,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 						Unlocks: nil,
 					},
 					InChains: vm.ChainInputSet{
-						exampleAccountIdent.AccountID(): &vm.ChainOutputWithCreationTime{
+						exampleAccountIdent.AccountID(): &vm.ChainOutputWithCreationSlot{
 							Output: &iotago.AccountOutput{FoundryCounter: 5},
 						},
 					},
@@ -2093,7 +2093,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - state transition - metadata feature",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2113,7 +2113,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - state transition - mint",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2137,7 +2137,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - state transition - melt",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2164,7 +2164,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - state transition - burn",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut:   map[string]fieldMutations{},
@@ -2183,7 +2183,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - state transition - melt complete supply",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2208,7 +2208,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - state transition - mint (out: excess)",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2233,7 +2233,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - state transition - mint (out: deficit)",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2258,7 +2258,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - state transition - melt (out: excess)",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2286,7 +2286,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - state transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2306,7 +2306,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - destroy transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: toBeDestoyedFoundry,
 			},
 			transType: iotago.ChainTransitionTypeDestroy,
@@ -2320,7 +2320,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - destroy transition - foundry token unbalanced",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleFoundry,
 			},
 			transType: iotago.ChainTransitionTypeDestroy,
@@ -2383,7 +2383,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 
 	type test struct {
 		name      string
-		input     *vm.ChainOutputWithCreationTime
+		input     *vm.ChainOutputWithCreationSlot
 		next      *iotago.NFTOutput
 		nextMut   map[string]fieldMutations
 		transType iotago.ChainTransitionType
@@ -2409,7 +2409,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - destroy transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleCurrentNFTOutput,
 			},
 			next:      nil,
@@ -2424,7 +2424,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - state transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleCurrentNFTOutput,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2451,7 +2451,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - state transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: exampleCurrentNFTOutput,
 			},
 			nextMut: map[string]fieldMutations{
@@ -2521,7 +2521,7 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 
 	type test struct {
 		name      string
-		input     *vm.ChainOutputWithCreationTime
+		input     *vm.ChainOutputWithCreationSlot
 		next      *iotago.DelegationOutput
 		nextMut   map[string]fieldMutations
 		transType iotago.ChainTransitionType
@@ -2661,7 +2661,7 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - invalid transition - non-zero delegation id on input",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				Output: &iotago.DelegationOutput{
 					Amount:          100,
 					DelegatedAmount: 100,
@@ -2689,7 +2689,7 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - invalid transition - modified delegated amount, start epoch and validator id",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				ChainID: exampleDelegationID,
 				Output: &iotago.DelegationOutput{
 					Amount:          100,
@@ -2735,7 +2735,7 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - invalid pre-registration slot transition - end epoch not set to expected epoch",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				ChainID: exampleDelegationID,
 				Output: &iotago.DelegationOutput{
 					Amount:          100,
@@ -2773,7 +2773,7 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - invalid post-registration slot transition - end epoch not set to expected epoch",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				ChainID: exampleDelegationID,
 				Output: &iotago.DelegationOutput{
 					Amount:          100,
@@ -2811,7 +2811,7 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - invalid transition - cannot claim rewards during transition",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				ChainID: exampleDelegationID,
 				Output: &iotago.DelegationOutput{
 					Amount:          100,
@@ -2843,7 +2843,7 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "ok - valid destruction",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				ChainID: exampleDelegationID,
 				Output: &iotago.DelegationOutput{
 					Amount:          100,
@@ -2875,7 +2875,7 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 		},
 		{
 			name: "fail - invalid destruction - missing reward input",
-			input: &vm.ChainOutputWithCreationTime{
+			input: &vm.ChainOutputWithCreationSlot{
 				ChainID: exampleDelegationID,
 				Output: &iotago.DelegationOutput{
 					Amount:          100,
@@ -2937,13 +2937,13 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 
 					if tt.input != nil {
 						// create the working set for the test
-						if tt.svCtx.WorkingSet.UTXOInputsWithCreationTime == nil {
-							tt.svCtx.WorkingSet.UTXOInputsWithCreationTime = make(vm.InputSet)
+						if tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot == nil {
+							tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot = make(vm.InputSet)
 						}
 
-						tt.svCtx.WorkingSet.UTXOInputsWithCreationTime[tpkg.RandOutputID(0)] = vm.OutputWithCreationTime{
+						tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot[tpkg.RandOutputID(0)] = vm.OutputWithCreationSlot{
 							Output:       tt.input.Output,
-							CreationTime: tt.input.CreationTime,
+							CreationSlot: tt.input.CreationSlot,
 						}
 					}
 
@@ -2961,13 +2961,13 @@ func TestDelegationOutput_ValidateStateTransition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.input != nil {
 				// create the working set for the test
-				if tt.svCtx.WorkingSet.UTXOInputsWithCreationTime == nil {
-					tt.svCtx.WorkingSet.UTXOInputsWithCreationTime = make(vm.InputSet)
+				if tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot == nil {
+					tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot = make(vm.InputSet)
 				}
 
-				tt.svCtx.WorkingSet.UTXOInputsWithCreationTime[tpkg.RandOutputID(0)] = vm.OutputWithCreationTime{
+				tt.svCtx.WorkingSet.UTXOInputsWithCreationSlot[tpkg.RandOutputID(0)] = vm.OutputWithCreationSlot{
 					Output:       tt.input.Output,
-					CreationTime: tt.input.CreationTime,
+					CreationSlot: tt.input.CreationSlot,
 				}
 			}
 

--- a/vm/stardust/vm_stardust_test.go
+++ b/vm/stardust/vm_stardust_test.go
@@ -56,7 +56,7 @@ func TestNFTTransition(t *testing.T) {
 
 	inputIDs := tpkg.RandOutputIDs(1)
 	inputs := vm.InputSet{
-		inputIDs[0]: vm.OutputWithCreationTime{
+		inputIDs[0]: vm.OutputWithCreationSlot{
 			Output: &iotago.NFTOutput{
 				Amount: OneMi,
 				NFTID:  iotago.NFTID{},
@@ -65,7 +65,7 @@ func TestNFTTransition(t *testing.T) {
 				},
 				Features: nil,
 			},
-			CreationTime: iotago.SlotIndex(0),
+			CreationSlot: iotago.SlotIndex(0),
 		},
 	}
 
@@ -107,7 +107,7 @@ func TestCirculatingSupplyMelting(t *testing.T) {
 
 	inputIDs := tpkg.RandOutputIDs(3)
 	inputs := vm.InputSet{
-		inputIDs[0]: vm.OutputWithCreationTime{
+		inputIDs[0]: vm.OutputWithCreationSlot{
 			Output: &iotago.BasicOutput{
 				Amount: OneMi,
 				Conditions: iotago.BasicOutputUnlockConditions{
@@ -115,7 +115,7 @@ func TestCirculatingSupplyMelting(t *testing.T) {
 				},
 			},
 		},
-		inputIDs[1]: vm.OutputWithCreationTime{
+		inputIDs[1]: vm.OutputWithCreationSlot{
 			Output: &iotago.AccountOutput{
 				Amount:         OneMi,
 				NativeTokens:   nil,
@@ -130,7 +130,7 @@ func TestCirculatingSupplyMelting(t *testing.T) {
 				Features: nil,
 			},
 		},
-		inputIDs[2]: vm.OutputWithCreationTime{
+		inputIDs[2]: vm.OutputWithCreationSlot{
 			Output: &iotago.FoundryOutput{
 				Amount:       OneMi,
 				NativeTokens: nil,
@@ -241,7 +241,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(16)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: defaultAmount,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -249,7 +249,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       defaultAmount,
 						NativeTokens: nativeTokenTransfer1,
@@ -258,7 +258,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[2]: vm.OutputWithCreationTime{
+				inputIDs[2]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       defaultAmount,
 						NativeTokens: nativeTokenTransfer2,
@@ -267,7 +267,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[3]: vm.OutputWithCreationTime{
+				inputIDs[3]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: defaultAmount,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -279,7 +279,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[4]: vm.OutputWithCreationTime{
+				inputIDs[4]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: defaultAmount,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -290,7 +290,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[5]: vm.OutputWithCreationTime{
+				inputIDs[5]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: defaultAmount + storageDepositReturn,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -309,7 +309,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[6]: vm.OutputWithCreationTime{
+				inputIDs[6]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:         defaultAmount,
 						NativeTokens:   nil,
@@ -324,7 +324,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						Features: nil,
 					},
 				},
-				inputIDs[7]: vm.OutputWithCreationTime{
+				inputIDs[7]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:         defaultAmount + defaultAmount, // to fund also the new account output
 						NativeTokens:   nil,
@@ -339,7 +339,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						Features: nil,
 					},
 				},
-				inputIDs[8]: vm.OutputWithCreationTime{
+				inputIDs[8]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:         defaultAmount,
 						NativeTokens:   nil,
@@ -354,7 +354,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						Features: nil,
 					},
 				},
-				inputIDs[9]: vm.OutputWithCreationTime{
+				inputIDs[9]: vm.OutputWithCreationSlot{
 					Output: &iotago.FoundryOutput{
 						Amount:       defaultAmount,
 						NativeTokens: nil,
@@ -370,7 +370,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						Features: nil,
 					},
 				},
-				inputIDs[10]: vm.OutputWithCreationTime{
+				inputIDs[10]: vm.OutputWithCreationSlot{
 					Output: &iotago.FoundryOutput{
 						Amount:       defaultAmount,
 						NativeTokens: nil, // filled out later
@@ -386,7 +386,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						Features: nil,
 					},
 				},
-				inputIDs[11]: vm.OutputWithCreationTime{
+				inputIDs[11]: vm.OutputWithCreationSlot{
 					Output: &iotago.FoundryOutput{
 						Amount:       defaultAmount,
 						NativeTokens: nil,
@@ -402,7 +402,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						Features: nil,
 					},
 				},
-				inputIDs[12]: vm.OutputWithCreationTime{
+				inputIDs[12]: vm.OutputWithCreationSlot{
 					Output: &iotago.FoundryOutput{
 						Amount:       defaultAmount,
 						NativeTokens: nil,
@@ -418,7 +418,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						Features: nil,
 					},
 				},
-				inputIDs[13]: vm.OutputWithCreationTime{
+				inputIDs[13]: vm.OutputWithCreationSlot{
 					Output: &iotago.NFTOutput{
 						Amount:       defaultAmount,
 						NativeTokens: nil,
@@ -434,7 +434,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[14]: vm.OutputWithCreationTime{
+				inputIDs[14]: vm.OutputWithCreationSlot{
 					Output: &iotago.NFTOutput{
 						Amount:       defaultAmount,
 						NativeTokens: nil,
@@ -450,7 +450,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[15]: vm.OutputWithCreationTime{
+				inputIDs[15]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: defaultAmount,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -503,7 +503,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			creationSlot := iotago.SlotIndex(750)
 			essence := &iotago.TransactionEssence{
 				Inputs:       inputIDs.UTXOInputs(),
-				CreationTime: creationSlot,
+				CreationSlot: creationSlot,
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.BasicOutput{
 						Amount: defaultAmount,
@@ -756,7 +756,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			}
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						StateIndex: 0,
@@ -767,7 +767,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: inFoundry,
 				},
 			}
@@ -820,7 +820,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						StateIndex: 0,
@@ -840,7 +840,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			}
 
 			essence := &iotago.TransactionEssence{
-				CreationTime: 110,
+				CreationSlot: 110,
 				ContextInputs: iotago.TxEssenceContextInputs{
 					&iotago.BlockIssuanceCreditInput{
 						AccountID: accountAddr1.AccountID(),
@@ -902,7 +902,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						StateIndex: 0,
@@ -922,7 +922,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			}
 
 			essence := &iotago.TransactionEssence{
-				CreationTime: 110,
+				CreationSlot: 110,
 				ContextInputs: iotago.TxEssenceContextInputs{
 					&iotago.BlockIssuanceCreditInput{
 						AccountID: accountAddr1.AccountID(),
@@ -983,7 +983,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						StateIndex: 0,
@@ -1003,7 +1003,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			}
 
 			essence := &iotago.TransactionEssence{
-				CreationTime: 110,
+				CreationSlot: 110,
 				ContextInputs: iotago.TxEssenceContextInputs{
 					&iotago.BlockIssuanceCreditInput{
 						AccountID: accountAddr1.AccountID(),
@@ -1056,7 +1056,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						StateIndex: 0,
@@ -1076,7 +1076,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			}
 
 			essence := &iotago.TransactionEssence{
-				CreationTime: 110,
+				CreationSlot: 110,
 				ContextInputs: iotago.TxEssenceContextInputs{
 					&iotago.BlockIssuanceCreditInput{
 						AccountID: accountAddr1.AccountID(),
@@ -1128,7 +1128,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						StateIndex: 0,
@@ -1148,7 +1148,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			}
 
 			essence := &iotago.TransactionEssence{
-				CreationTime: 110,
+				CreationSlot: 110,
 				Inputs:       inputIDs.UTXOInputs(),
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.BasicOutput{
@@ -1190,7 +1190,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						StateIndex: 0,
@@ -1210,7 +1210,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 			}
 
 			essence := &iotago.TransactionEssence{
-				CreationTime: 110,
+				CreationSlot: 110,
 				Inputs:       inputIDs.UTXOInputs(),
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.AccountOutput{
@@ -1281,7 +1281,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			nftIdent1 := tpkg.RandNFTAddress()
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1289,7 +1289,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: iotago.AccountID{}, // empty on purpose as validation should resolve
@@ -1299,7 +1299,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[2]: vm.OutputWithCreationTime{
+				inputIDs[2]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1307,7 +1307,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[3]: vm.OutputWithCreationTime{
+				inputIDs[3]: vm.OutputWithCreationSlot{
 					Output: &iotago.NFTOutput{
 						Amount: 100,
 						NFTID:  nftIdent1.NFTID(),
@@ -1316,7 +1316,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[4]: vm.OutputWithCreationTime{
+				inputIDs[4]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1325,7 +1325,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 					},
 				},
 				// unlockable by sender as expired
-				inputIDs[5]: vm.OutputWithCreationTime{
+				inputIDs[5]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1338,7 +1338,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 					},
 				},
 				// not unlockable by sender as not expired
-				inputIDs[6]: vm.OutputWithCreationTime{
+				inputIDs[6]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1350,7 +1350,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[7]: vm.OutputWithCreationTime{
+				inputIDs[7]: vm.OutputWithCreationSlot{
 					Output: &iotago.FoundryOutput{
 						Amount:       100,
 						SerialNumber: 0,
@@ -1380,7 +1380,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: creationSlot,
+				CreationSlot: creationSlot,
 			}
 
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys, ident2AddrKeys)
@@ -1419,7 +1419,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1456,7 +1456,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(2)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1464,7 +1464,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1501,7 +1501,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 
 			accountIdent1 := iotago.AccountAddressFromOutputID(inputIDs[0])
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: iotago.AccountID{},
@@ -1511,7 +1511,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1548,7 +1548,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 
 			nftIdent1 := iotago.NFTAddressFromOutputID(inputIDs[0])
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.NFTOutput{
 						Amount: 100,
 						NFTID:  iotago.NFTID{},
@@ -1557,7 +1557,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1595,7 +1595,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			nftIdent2 := iotago.NFTAddressFromOutputID(inputIDs[1])
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.NFTOutput{
 						Amount: 100,
 						NFTID:  nftIdent1.NFTID(),
@@ -1604,7 +1604,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.NFTOutput{
 						Amount: 100,
 						NFTID:  nftIdent2.NFTID(),
@@ -1640,7 +1640,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1655,7 +1655,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			}
 
 			creationSlot := iotago.SlotIndex(5)
-			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationTime: creationSlot}
+			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationSlot: creationSlot}
 
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident2AddressKeys)
 			require.NoError(t, err)
@@ -1686,7 +1686,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1701,7 +1701,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			}
 
 			creationSlot := iotago.SlotIndex(10)
-			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationTime: creationSlot}
+			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationSlot: creationSlot}
 
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddressKeys)
 			require.NoError(t, err)
@@ -1738,7 +1738,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 
 			inputs := vm.InputSet{
 				// owned by ident1
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: accountAddr1.AccountID(),
@@ -1749,7 +1749,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 					},
 				},
 				// owned by account1
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: accountAddr2.AccountID(),
@@ -1760,7 +1760,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 					},
 				},
 				// owned by account1
-				inputIDs[2]: vm.OutputWithCreationTime{
+				inputIDs[2]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: accountAddr3.AccountID(),
@@ -1803,7 +1803,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			accountAddr1 := tpkg.RandAccountAddress()
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: accountAddr1.AccountID(),
@@ -1813,7 +1813,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1877,7 +1877,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 			}
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						StateIndex: 0,
@@ -1888,7 +1888,7 @@ func TestTxSemanticInputUnlocks(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: foundryOutput,
 				},
 			}
@@ -1959,7 +1959,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(3)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1968,7 +1968,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 					},
 				},
 				// unlocked by ident1 as it is not expired
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 500,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -1985,7 +1985,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 					},
 				},
 				// unlocked by ident2 as it is expired
-				inputIDs[2]: vm.OutputWithCreationTime{
+				inputIDs[2]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 500,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2021,7 +2021,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: creationSlot,
+				CreationSlot: creationSlot,
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys, ident2AddrKeys)
 			require.NoError(t, err)
@@ -2054,7 +2054,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 1000,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2117,7 +2117,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 50,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2137,7 +2137,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: 5,
+				CreationSlot: 5,
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -2162,7 +2162,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2182,7 +2182,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: 5,
+				CreationSlot: 5,
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -2208,7 +2208,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 500,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2238,7 +2238,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: creationSlot,
+				CreationSlot: creationSlot,
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -2269,7 +2269,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 500,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2324,7 +2324,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 500,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2383,7 +2383,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 500,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2442,7 +2442,7 @@ func TestTxSemanticDeposit(t *testing.T) {
 			ntID := tpkg.Rand38ByteArray()
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 500,
 						NativeTokens: iotago.NativeTokens{
@@ -2563,7 +2563,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 			nativeTokens := tpkg.RandSortNativeTokens(ntCount)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: nativeTokens[:ntCount/2],
@@ -2572,7 +2572,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: nativeTokens[ntCount/2:],
@@ -2615,7 +2615,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 
 			inputs := vm.InputSet{}
 			for i := 0; i < iotago.MaxNativeTokensCount; i++ {
-				inputs[inputIDs[i]] = vm.OutputWithCreationTime{
+				inputs[inputIDs[i]] = vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						NativeTokens: []*iotago.NativeToken{
@@ -2669,7 +2669,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 			outCount := 250
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: tpkg.RandSortNativeTokens(inCount),
@@ -2712,7 +2712,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 
 			inputs := vm.InputSet{}
 			for i := 0; i < numDistinctNTs; i++ {
-				inputs[inputIDs[i]] = vm.OutputWithCreationTime{
+				inputs[inputIDs[i]] = vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: tpkg.RandSortNativeTokens(1),
@@ -2755,7 +2755,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 
 			inputs := vm.InputSet{}
 			for i := 0; i < numDistinctNTs; i++ {
-				inputs[inputIDs[i]] = vm.OutputWithCreationTime{
+				inputs[inputIDs[i]] = vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -2801,7 +2801,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 
 			inputs := vm.InputSet{}
 			for i := 0; i < iotago.MaxInputsCount; i++ {
-				inputs[inputIDs[i]] = vm.OutputWithCreationTime{
+				inputs[inputIDs[i]] = vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: tokens,
@@ -2848,7 +2848,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 
 			inputs := vm.InputSet{}
 			for i := 0; i < iotago.MaxInputsCount; i++ {
-				inputs[inputIDs[i]] = vm.OutputWithCreationTime{
+				inputs[inputIDs[i]] = vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: tokens,
@@ -2907,7 +2907,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 			nativeTokens := tpkg.RandSortNativeTokens(ntCount)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: nativeTokens,
@@ -2956,7 +2956,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 			nativeTokens := tpkg.RandSortNativeTokens(ntCount)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: nativeTokens[:ntCount/2],
@@ -2965,7 +2965,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount:       100,
 						NativeTokens: nativeTokens[ntCount/2:],
@@ -2974,7 +2974,7 @@ func TestTxSemanticNativeTokens(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[2]: vm.OutputWithCreationTime{
+				inputIDs[2]: vm.OutputWithCreationSlot{
 					Output: inUnrelatedFoundryOutput,
 				},
 			}
@@ -3047,7 +3047,7 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 			nftAddr := tpkg.RandNFTAddress()
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -3055,7 +3055,7 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.NFTOutput{
 						Amount: 100,
 						NFTID:  nftAddr.NFTID(),
@@ -3153,7 +3153,7 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -3203,7 +3203,7 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 			accountID := accountAddr.AccountID()
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: accountID,
@@ -3258,7 +3258,7 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 			currentStateIndex := uint32(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						AccountID:  accountID,
@@ -3314,7 +3314,7 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 			accountID := accountAddr.AccountID()
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: accountID,
@@ -3392,7 +3392,7 @@ func TestTxSemanticOutputsIssuer(t *testing.T) {
 			accountID := accountAddr.AccountID()
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: accountID,
@@ -3402,7 +3402,7 @@ func TestTxSemanticOutputsIssuer(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -3466,7 +3466,7 @@ func TestTxSemanticOutputsIssuer(t *testing.T) {
 
 			inputs := vm.InputSet{
 				// possible issuers: accountAddr, stateController, nftAddr, ident1
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:     100,
 						AccountID:  accountID,
@@ -3477,7 +3477,7 @@ func TestTxSemanticOutputsIssuer(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.NFTOutput{
 						Amount: 900,
 						NFTID:  nftAddr.NFTID(),
@@ -3618,7 +3618,7 @@ func TestTxSemanticOutputsIssuer(t *testing.T) {
 			accountID := accountAddr.AccountID()
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.AccountOutput{
 						Amount:    100,
 						AccountID: accountID,
@@ -3628,7 +3628,7 @@ func TestTxSemanticOutputsIssuer(t *testing.T) {
 						},
 					},
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -3707,7 +3707,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Conditions: iotago.BasicOutputUnlockConditions{
 							&iotago.AddressUnlockCondition{Address: ident1},
@@ -3720,7 +3720,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			}
 
 			creationSlot := iotago.SlotIndex(10)
-			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationTime: creationSlot}
+			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationSlot: creationSlot}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
 
@@ -3749,7 +3749,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -3763,7 +3763,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			}
 
 			creationSlot := iotago.SlotIndex(10)
-			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationTime: 10}
+			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationSlot: 10}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
 
@@ -3792,7 +3792,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -3806,7 +3806,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			}
 
 			creationSlot := iotago.SlotIndex(666)
-			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationTime: creationSlot}
+			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationSlot: creationSlot}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
 
@@ -3835,7 +3835,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 100,
 						Conditions: iotago.BasicOutputUnlockConditions{
@@ -3849,7 +3849,7 @@ func TestTxSemanticTimelocks(t *testing.T) {
 			}
 
 			creationSlot := iotago.SlotIndex(1005)
-			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationTime: creationSlot}
+			essence := &iotago.TransactionEssence{Inputs: inputIDs.UTXOInputs(), CreationSlot: creationSlot}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
 
@@ -3899,7 +3899,7 @@ func TestTxSemanticMana(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: OneMi,
 						Mana:   math.MaxUint64,
@@ -3907,7 +3907,7 @@ func TestTxSemanticMana(t *testing.T) {
 							&iotago.AddressUnlockCondition{Address: ident1},
 						},
 					},
-					CreationTime: 10,
+					CreationSlot: 10,
 				},
 			}
 
@@ -3935,7 +3935,7 @@ func TestTxSemanticMana(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: 10 + 100*testProtoParams.ParamEpochDurationInSlots(),
+				CreationSlot: 10 + 100*testProtoParams.ParamEpochDurationInSlots(),
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -3960,7 +3960,7 @@ func TestTxSemanticMana(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: OneMi,
 						Mana:   math.MaxUint64,
@@ -3968,7 +3968,7 @@ func TestTxSemanticMana(t *testing.T) {
 							&iotago.AddressUnlockCondition{Address: ident1},
 						},
 					},
-					CreationTime: 10,
+					CreationSlot: 10,
 				},
 			}
 
@@ -4000,7 +4000,7 @@ func TestTxSemanticMana(t *testing.T) {
 				Allotments: iotago.Allotments{
 					&iotago.Allotment{Value: 50},
 				},
-				CreationTime: 10 + 100*testProtoParams.ParamEpochDurationInSlots(),
+				CreationSlot: 10 + 100*testProtoParams.ParamEpochDurationInSlots(),
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -4025,7 +4025,7 @@ func TestTxSemanticMana(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 5,
 						Mana:   10,
@@ -4033,7 +4033,7 @@ func TestTxSemanticMana(t *testing.T) {
 							&iotago.AddressUnlockCondition{Address: ident1},
 						},
 					},
-					CreationTime: 20,
+					CreationSlot: 20,
 				},
 			}
 
@@ -4048,7 +4048,7 @@ func TestTxSemanticMana(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: 15,
+				CreationSlot: 15,
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -4074,7 +4074,7 @@ func TestTxSemanticMana(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 5,
 						Mana:   10,
@@ -4082,7 +4082,7 @@ func TestTxSemanticMana(t *testing.T) {
 							&iotago.AddressUnlockCondition{Address: ident1},
 						},
 					},
-					CreationTime: 15,
+					CreationSlot: 15,
 				},
 			}
 
@@ -4097,7 +4097,7 @@ func TestTxSemanticMana(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: 15,
+				CreationSlot: 15,
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -4122,7 +4122,7 @@ func TestTxSemanticMana(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(2)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 5,
 						Mana:   math.MaxUint64,
@@ -4130,9 +4130,9 @@ func TestTxSemanticMana(t *testing.T) {
 							&iotago.AddressUnlockCondition{Address: ident1},
 						},
 					},
-					CreationTime: 15,
+					CreationSlot: 15,
 				},
-				inputIDs[1]: vm.OutputWithCreationTime{
+				inputIDs[1]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 5,
 						Mana:   10,
@@ -4140,7 +4140,7 @@ func TestTxSemanticMana(t *testing.T) {
 							&iotago.AddressUnlockCondition{Address: ident1},
 						},
 					},
-					CreationTime: 15,
+					CreationSlot: 15,
 				},
 			}
 
@@ -4155,7 +4155,7 @@ func TestTxSemanticMana(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: 15,
+				CreationSlot: 15,
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -4181,7 +4181,7 @@ func TestTxSemanticMana(t *testing.T) {
 			inputIDs := tpkg.RandOutputIDs(1)
 
 			inputs := vm.InputSet{
-				inputIDs[0]: vm.OutputWithCreationTime{
+				inputIDs[0]: vm.OutputWithCreationSlot{
 					Output: &iotago.BasicOutput{
 						Amount: 5,
 						Mana:   10,
@@ -4189,7 +4189,7 @@ func TestTxSemanticMana(t *testing.T) {
 							&iotago.AddressUnlockCondition{Address: ident1},
 						},
 					},
-					CreationTime: 15,
+					CreationSlot: 15,
 				},
 			}
 
@@ -4211,7 +4211,7 @@ func TestTxSemanticMana(t *testing.T) {
 						},
 					},
 				},
-				CreationTime: 15,
+				CreationSlot: 15,
 			}
 			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddrKeys)
 			require.NoError(t, err)
@@ -4255,7 +4255,7 @@ func TestManaRewardsClaimingStaking(t *testing.T) {
 
 	inputIDs := tpkg.RandOutputIDs(1)
 	inputs := vm.InputSet{
-		inputIDs[0]: vm.OutputWithCreationTime{
+		inputIDs[0]: vm.OutputWithCreationSlot{
 			Output: &iotago.AccountOutput{
 				Amount:         OneMi * 10,
 				NativeTokens:   nil,
@@ -4341,7 +4341,7 @@ func TestManaRewardsClaimingDelegation(t *testing.T) {
 
 	inputIDs := tpkg.RandOutputIDs(1)
 	inputs := vm.InputSet{
-		inputIDs[0]: vm.OutputWithCreationTime{
+		inputIDs[0]: vm.OutputWithCreationSlot{
 			Output: &iotago.DelegationOutput{
 				Amount:          OneMi * 10,
 				DelegatedAmount: OneMi * 10,
@@ -4369,7 +4369,7 @@ func TestManaRewardsClaimingDelegation(t *testing.T) {
 				Features: nil,
 			},
 		},
-		CreationTime: currentSlot,
+		CreationSlot: currentSlot,
 	}
 
 	sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), identAddrKeys)

--- a/vm/types.go
+++ b/vm/types.go
@@ -6,13 +6,13 @@ import (
 	iotago "github.com/iotaledger/iota.go/v4"
 )
 
-type OutputWithCreationTime struct {
+type OutputWithCreationSlot struct {
 	Output       iotago.Output
-	CreationTime iotago.SlotIndex
+	CreationSlot iotago.SlotIndex
 }
 
-// InputSet is a map of OutputID to OutputWithCreationTime.
-type InputSet map[iotago.OutputID]OutputWithCreationTime
+// InputSet is a map of OutputID to OutputWithCreationSlot.
+type InputSet map[iotago.OutputID]OutputWithCreationSlot
 
 func (inputSet InputSet) OutputSet() iotago.OutputSet {
 	outputs := make(iotago.OutputSet, len(inputSet))
@@ -23,10 +23,10 @@ func (inputSet InputSet) OutputSet() iotago.OutputSet {
 	return outputs
 }
 
-type ChainOutputWithCreationTime struct {
+type ChainOutputWithCreationSlot struct {
 	ChainID      iotago.ChainID
 	Output       iotago.ChainOutput
-	CreationTime iotago.SlotIndex
+	CreationSlot iotago.SlotIndex
 }
 
 // ChainInputSet returns a ChainInputSet for all ChainOutputs in the InputSet.
@@ -49,18 +49,18 @@ func (inputSet InputSet) ChainInputSet() ChainInputSet {
 			panic(fmt.Sprintf("output of type %s has empty chain ID but is not utxo dependable", chainOutput.Type()))
 		}
 
-		set[chainID] = &ChainOutputWithCreationTime{
+		set[chainID] = &ChainOutputWithCreationSlot{
 			ChainID:      chainID,
 			Output:       chainOutput,
-			CreationTime: input.CreationTime,
+			CreationSlot: input.CreationSlot,
 		}
 	}
 
 	return set
 }
 
-// ChainInputSet is a map of ChainID to ChainOutputWithCreationTime.
-type ChainInputSet map[iotago.ChainID]*ChainOutputWithCreationTime
+// ChainInputSet is a map of ChainID to ChainOutputWithCreationSlot.
+type ChainInputSet map[iotago.ChainID]*ChainOutputWithCreationSlot
 
 type BlockIssuanceCreditInputSet map[iotago.AccountID]iotago.BlockIssuanceCredits
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -17,7 +17,7 @@ type VirtualMachine interface {
 	// Pass own ExecFunc(s) to override the VM's default execution function list.
 	Execute(t *iotago.Transaction, params *Params, inputs ResolvedInputs, overrideFuncs ...ExecFunc) error
 	// ChainSTVF executes the chain state transition validation function.
-	ChainSTVF(transType iotago.ChainTransitionType, input *ChainOutputWithCreationTime, next iotago.ChainOutput, vmParams *Params) error
+	ChainSTVF(transType iotago.ChainTransitionType, input *ChainOutputWithCreationSlot, next iotago.ChainOutput, vmParams *Params) error
 }
 
 // Params defines the VirtualMachine parameters under which the VM operates.
@@ -36,7 +36,7 @@ type WorkingSet struct {
 	// The inputs to the transaction.
 	UTXOInputs iotago.Outputs[iotago.Output]
 	// The UTXO inputs to the transaction with their creation times.
-	UTXOInputsWithCreationTime InputSet
+	UTXOInputsWithCreationSlot InputSet
 	// The mapping of inputs' OutputID to the index.
 	InputIDToIndex map[iotago.OutputID]uint16
 	// The transaction for which this semantic validation happens.
@@ -79,13 +79,13 @@ func NewVMParamsWorkingSet(api iotago.API, t *iotago.Transaction, inputs Resolve
 	workingSet := &WorkingSet{}
 	workingSet.Tx = t
 	workingSet.UnlockedIdents = make(UnlockedIdentities)
-	workingSet.UTXOInputsWithCreationTime = utxoInputsSet
+	workingSet.UTXOInputsWithCreationSlot = utxoInputsSet
 	workingSet.InputIDToIndex = make(map[iotago.OutputID]uint16)
 	for inputIndex, inputRef := range workingSet.Tx.Essence.Inputs {
 		//nolint:forcetypeassert // we can safely assume that this is an UTXOInput
 		ref := inputRef.(*iotago.UTXOInput).OutputID()
 		workingSet.InputIDToIndex[ref] = uint16(inputIndex)
-		input, ok := workingSet.UTXOInputsWithCreationTime[ref]
+		input, ok := workingSet.UTXOInputsWithCreationSlot[ref]
 		if !ok {
 			return nil, ierrors.Wrapf(iotago.ErrMissingUTXO, "utxo for input %d not supplied", inputIndex)
 		}
@@ -125,11 +125,11 @@ func NewVMParamsWorkingSet(api iotago.API, t *iotago.Transaction, inputs Resolve
 	return workingSet, nil
 }
 
-func TotalManaIn(manaDecayProvider *iotago.ManaDecayProvider, rentStructure *iotago.RentStructure, txCreationTime iotago.SlotIndex, inputSet InputSet) (iotago.Mana, error) {
+func TotalManaIn(manaDecayProvider *iotago.ManaDecayProvider, rentStructure *iotago.RentStructure, txCreationSlot iotago.SlotIndex, inputSet InputSet) (iotago.Mana, error) {
 	var totalIn iotago.Mana
 	for outputID, input := range inputSet {
 		// stored Mana
-		manaStored, err := manaDecayProvider.StoredManaWithDecay(input.Output.StoredMana(), input.CreationTime, txCreationTime)
+		manaStored, err := manaDecayProvider.StoredManaWithDecay(input.Output.StoredMana(), input.CreationSlot, txCreationSlot)
 		if err != nil {
 			return 0, ierrors.Wrapf(err, "input %s stored mana calculation failed", outputID)
 		}
@@ -145,7 +145,7 @@ func TotalManaIn(manaDecayProvider *iotago.ManaDecayProvider, rentStructure *iot
 			continue
 		}
 		excessBaseTokens := input.Output.BaseTokenAmount() - minDeposit
-		manaPotential, err := manaDecayProvider.PotentialManaWithDecay(excessBaseTokens, input.CreationTime, txCreationTime)
+		manaPotential, err := manaDecayProvider.PotentialManaWithDecay(excessBaseTokens, input.CreationSlot, txCreationSlot)
 		if err != nil {
 			return 0, ierrors.Wrapf(err, "input %s potential mana calculation failed", outputID)
 		}
@@ -524,13 +524,13 @@ func ExecFuncSenderUnlocked() ExecFunc {
 // TODO: Return Mana according to StorageDepositReturnUnlockCondition(s)?
 func ExecFuncBalancedMana() ExecFunc {
 	return func(vm VirtualMachine, vmParams *Params) error {
-		txCreationTime := vmParams.WorkingSet.Tx.Essence.CreationTime
-		for outputID, input := range vmParams.WorkingSet.UTXOInputsWithCreationTime {
-			if input.CreationTime > txCreationTime {
-				return ierrors.Wrapf(iotago.ErrInputCreationAfterTxCreation, "input %s has creation time %d, tx creation time %d", outputID, input.CreationTime, txCreationTime)
+		txCreationSlot := vmParams.WorkingSet.Tx.Essence.CreationSlot
+		for outputID, input := range vmParams.WorkingSet.UTXOInputsWithCreationSlot {
+			if input.CreationSlot > txCreationSlot {
+				return ierrors.Wrapf(iotago.ErrInputCreationAfterTxCreation, "input %s has creation time %d, tx creation time %d", outputID, input.CreationSlot, txCreationSlot)
 			}
 		}
-		manaIn, err := TotalManaIn(vmParams.API.ManaDecayProvider(), vmParams.API.ProtocolParameters().RentStructure(), txCreationTime, vmParams.WorkingSet.UTXOInputsWithCreationTime)
+		manaIn, err := TotalManaIn(vmParams.API.ManaDecayProvider(), vmParams.API.ProtocolParameters().RentStructure(), txCreationSlot, vmParams.WorkingSet.UTXOInputsWithCreationSlot)
 		if err != nil {
 			return ierrors.Join(iotago.ErrManaAmountInvalid, err)
 		}
@@ -562,7 +562,7 @@ func ExecFuncBalancedBaseTokens() ExecFunc {
 		// are always within bounds of the total token supply
 		var in, out iotago.BaseToken
 		inputSumReturnAmountPerIdent := make(map[string]iotago.BaseToken)
-		for inputID, input := range vmParams.WorkingSet.UTXOInputsWithCreationTime {
+		for inputID, input := range vmParams.WorkingSet.UTXOInputsWithCreationSlot {
 			in += input.Output.BaseTokenAmount()
 
 			returnUnlockCond := input.Output.UnlockConditionSet().StorageDepositReturn()
@@ -613,7 +613,7 @@ func ExecFuncBalancedBaseTokens() ExecFunc {
 // ExecFuncTimelocks validates that the inputs' timelocks are expired.
 func ExecFuncTimelocks() ExecFunc {
 	return func(vm VirtualMachine, vmParams *Params) error {
-		for inputIndex, input := range vmParams.WorkingSet.UTXOInputsWithCreationTime {
+		for inputIndex, input := range vmParams.WorkingSet.UTXOInputsWithCreationSlot {
 			if input.Output.UnlockConditionSet().HasTimelockCondition() {
 				commitment := vmParams.WorkingSet.Commitment
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -35,7 +35,7 @@ type WorkingSet struct {
 	UnlockedIdents UnlockedIdentities
 	// The inputs to the transaction.
 	UTXOInputs iotago.Outputs[iotago.Output]
-	// The UTXO inputs to the transaction with their creation times.
+	// The UTXO inputs to the transaction with their creation slots.
 	UTXOInputsWithCreationSlot InputSet
 	// The mapping of inputs' OutputID to the index.
 	InputIDToIndex map[iotago.OutputID]uint16
@@ -57,7 +57,7 @@ type WorkingSet struct {
 	OutNativeTokens iotago.NativeTokenSum
 	// The Unlocks carried by the transaction mapped by type.
 	UnlocksByType iotago.UnlocksByType
-	// BIC is the block issuance credit for MCA slots prior to the transaction's creation time (or for the slot to which the block commits)
+	// BIC is the block issuance credit for MCA slots prior to the transaction's creation slot (or for the slot to which the block commits)
 	// Contains one value for each account output touched in the transaction and empty if no account outputs touched.
 	BIC BlockIssuanceCreditInputSet
 	// Commitment contains set of commitment inputs necessary for transaction execution. FIXME
@@ -527,7 +527,7 @@ func ExecFuncBalancedMana() ExecFunc {
 		txCreationSlot := vmParams.WorkingSet.Tx.Essence.CreationSlot
 		for outputID, input := range vmParams.WorkingSet.UTXOInputsWithCreationSlot {
 			if input.CreationSlot > txCreationSlot {
-				return ierrors.Wrapf(iotago.ErrInputCreationAfterTxCreation, "input %s has creation time %d, tx creation time %d", outputID, input.CreationSlot, txCreationSlot)
+				return ierrors.Wrapf(iotago.ErrInputCreationAfterTxCreation, "input %s has creation slot %d, tx creation slot %d", outputID, input.CreationSlot, txCreationSlot)
 			}
 		}
 		manaIn, err := TotalManaIn(vmParams.API.ManaDecayProvider(), vmParams.API.ProtocolParameters().RentStructure(), txCreationSlot, vmParams.WorkingSet.UTXOInputsWithCreationSlot)


### PR DESCRIPTION
# Description of change

Rename `CreationTime` to `CreationSlot` since the "transaction creation time" is no longer a unix timestamp but a slot index.

Needs to be merged in concert with iotaledger/iota-core#286.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`go test`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
