### PR TITLE
Let Governor control the Block Issuer Feature

### DIFF
--- a/feat.go
+++ b/feat.go
@@ -57,8 +57,8 @@ func (featType FeatureType) String() string {
 	return featNames[featType]
 }
 
-var featNames = [FeatureBlockIssuer + 1]string{
-	"SenderFeature", "Issuer", "MetadataFeature", "TagFeature", "BlockIssuerFeature",
+var featNames = [FeatureStaking + 1]string{
+	"SenderFeature", "Issuer", "MetadataFeature", "TagFeature", "BlockIssuerFeature", "StakingFeature",
 }
 
 // Features is a slice of Feature(s).

--- a/output_account.go
+++ b/output_account.go
@@ -21,6 +21,11 @@ var (
 	ErrInvalidAccountGovernanceTransition = ierrors.New("invalid account governance transition")
 	// ErrInvalidBlockIssuerTransition gets returned when an account tries to transition block issuer expiry too soon.
 	ErrInvalidBlockIssuerTransition = ierrors.New("invalid block issuer transition")
+	// ErrAccountLocked gets returned when an account has negative block issuance credits.
+	ErrAccountLocked = ierrors.New("account is locked due to negative block issuance credits")
+	// ErrBlockIssuanceCreditInputRequired gets returned when a transaction containing an account with a block issuer feature
+	// does not have a Block Issuance Credit Input.
+	ErrBlockIssuanceCreditInputRequired = ierrors.New("account with block issuer feature requires a block issuance credit input")
 	// ErrInvalidStakingTransition gets returned when an account tries to do an invalid transition with a Staking Feature.
 	ErrInvalidStakingTransition = ierrors.New("invalid staking transition")
 	// ErrAccountMissing gets returned when an account is missing.

--- a/vm/stardust/vm_stardust.go
+++ b/vm/stardust/vm_stardust.go
@@ -203,11 +203,7 @@ func accountGovernanceSTVF(input *vm.ChainOutputWithCreationSlot, next *iotago.A
 		return ierrors.Wrapf(iotago.ErrInvalidAccountGovernanceTransition, "%w", iotago.ErrInvalidStakingBlockIssuerRequired)
 	}
 
-	if err := accountBlockIssuerSTVF(input, next, vmParams); err != nil {
-		return err
-	}
-
-	return nil
+	return accountBlockIssuerSTVF(input, next, vmParams)
 }
 
 func accountStateSTVF(input *vm.ChainOutputWithCreationSlot, next *iotago.AccountOutput, vmParams *vm.Params) error {

--- a/vm/stardust/vm_stardust.go
+++ b/vm/stardust/vm_stardust.go
@@ -195,6 +195,7 @@ func accountGovernanceSTVF(input *vm.ChainOutputWithCreationSlot, next *iotago.A
 		return ierrors.Wrapf(iotago.ErrInvalidAccountGovernanceTransition, "foundry counter changed, in %d / out %d", current.FoundryCounter, next.FoundryCounter)
 	}
 
+	// staking feature cannot change during account governance transition
 	if err := iotago.FeatureUnchanged(iotago.FeatureStaking, current.Features.MustSet(), next.Features.MustSet()); err != nil {
 		return ierrors.Join(iotago.ErrInvalidAccountGovernanceTransition, err)
 	}
@@ -224,6 +225,7 @@ func accountStateSTVF(input *vm.ChainOutputWithCreationSlot, next *iotago.Accoun
 		return ierrors.Wrapf(iotago.ErrInvalidAccountStateTransition, "%w", err)
 	}
 
+	// block issuer feature cannot change during account state transition
 	if err := iotago.FeatureUnchanged(iotago.FeatureBlockIssuer, current.Features.MustSet(), next.Features.MustSet()); err != nil {
 		return ierrors.Wrapf(iotago.ErrInvalidAccountStateTransition, "%w", err)
 	}

--- a/vm/stardust/vm_stardust.go
+++ b/vm/stardust/vm_stardust.go
@@ -179,6 +179,7 @@ func accountStateChangeValid(input *vm.ChainOutputWithCreationSlot, vmParams *vm
 }
 
 func accountGovernanceSTVF(input *vm.ChainOutputWithCreationSlot, next *iotago.AccountOutput, vmParams *vm.Params) error {
+	//nolint:forcetypeassert // we can safely assume that this is an AccountOutput
 	current := input.Output.(*iotago.AccountOutput)
 
 	switch {
@@ -311,7 +312,7 @@ func accountBlockIssuerSTVF(input *vm.ChainOutputWithCreationSlot, next *iotago.
 		// or the current feature has expired but it was not removed.
 		// In both cases the expiry slot must be set sufficiently far in the future.
 		if nextBlockIssuerFeat.ExpirySlot < pastBoundedSlotIndex {
-			return ierrors.Wrapf(iotago.ErrInvalidBlockIssuerTransition, "block issuer feature expiry set too soon %d, %d", nextBlockIssuerFeat.ExpirySlot, pastBoundedSlotIndex)
+			return ierrors.Wrapf(iotago.ErrInvalidBlockIssuerTransition, "block issuer feature expiry set too soon (is %d, must be >= %d)", nextBlockIssuerFeat.ExpirySlot, pastBoundedSlotIndex)
 		}
 	}
 

--- a/vm/stardust/vm_stardust.go
+++ b/vm/stardust/vm_stardust.go
@@ -509,7 +509,7 @@ func accountStakingExpiredValidation(
 	} else {
 		if isClaiming {
 			// When claiming with a feature on the output side, it must be transitioned as if it was newly added,
-			// so that the new epoch range is different.
+			// so that the new epoch range is disjoint from the current staking feature.
 			if err := accountStakingGenesisValidation(next, nextStakingFeat, vmParams); err != nil {
 				return ierrors.Wrapf(iotago.ErrInvalidStakingTransition, "%w: rewards claiming without removing the feature requires updating the feature", err)
 			}

--- a/vm/stardust/vm_stardust_test.go
+++ b/vm/stardust/vm_stardust_test.go
@@ -814,8 +814,8 @@ func TestStardustTransactionExecution(t *testing.T) {
 		func() test {
 			accountAddr1 := tpkg.RandAccountAddress()
 
-			_, ident1, ident1AddressKeys := tpkg.RandEd25519Identity()
-			_, ident2, _ := tpkg.RandEd25519Identity()
+			_, ident1, _ := tpkg.RandEd25519Identity()
+			_, ident2, ident2AddressKeys := tpkg.RandEd25519Identity()
 
 			inputIDs := tpkg.RandOutputIDs(1)
 
@@ -850,7 +850,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.AccountOutput{
 						Amount:     100,
-						StateIndex: 1,
+						StateIndex: 0,
 						AccountID:  accountAddr1.AccountID(),
 						Features: iotago.AccountOutputFeatures{
 							&iotago.BlockIssuerFeature{
@@ -874,7 +874,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 				Index: 110,
 			}
 
-			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddressKeys)
+			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident2AddressKeys)
 			require.NoError(t, err)
 
 			return test{
@@ -896,8 +896,8 @@ func TestStardustTransactionExecution(t *testing.T) {
 		func() test {
 			accountAddr1 := tpkg.RandAccountAddress()
 
-			_, ident1, ident1AddressKeys := tpkg.RandEd25519Identity()
-			_, ident2, _ := tpkg.RandEd25519Identity()
+			_, ident1, _ := tpkg.RandEd25519Identity()
+			_, ident2, ident2AddressKeys := tpkg.RandEd25519Identity()
 
 			inputIDs := tpkg.RandOutputIDs(1)
 
@@ -932,7 +932,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.AccountOutput{
 						Amount:     100,
-						StateIndex: 1,
+						StateIndex: 0,
 						AccountID:  accountAddr1.AccountID(),
 						Features: iotago.AccountOutputFeatures{
 							&iotago.BlockIssuerFeature{
@@ -956,7 +956,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 				Index: 110,
 			}
 
-			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident1AddressKeys)
+			sigs, err := essence.Sign(testAPI, inputIDs.OrderedSet(inputs.OutputSet()).MustCommitment(testAPI), ident2AddressKeys)
 			require.NoError(t, err)
 
 			return test{
@@ -1179,7 +1179,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						&iotago.SignatureUnlock{Signature: sigs[0]},
 					},
 				},
-				wantErr: iotago.ErrInvalidBlockIssuerTransition,
+				wantErr: iotago.ErrBlockIssuanceCreditInputRequired,
 			}
 		}(),
 		func() test {
@@ -1215,7 +1215,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.AccountOutput{
 						Amount:     100,
-						StateIndex: 1,
+						StateIndex: 0,
 						AccountID:  accountAddr1.AccountID(),
 						Features: iotago.AccountOutputFeatures{
 							&iotago.BlockIssuerFeature{
@@ -1246,7 +1246,7 @@ func TestStardustTransactionExecution(t *testing.T) {
 						&iotago.SignatureUnlock{Signature: sigs[0]},
 					},
 				},
-				wantErr: iotago.ErrInvalidBlockIssuerTransition,
+				wantErr: iotago.ErrBlockIssuanceCreditInputRequired,
 			}
 		}(),
 	}


### PR DESCRIPTION
# Description of change

Change permissions for governor and state controller with respect to the Block Issuer Feature (BIF) and Staking Feature (SF).

- The BIF can be modified by the governor.
- The SF can be modified by state controller.

Additionally, handle other cases:
- Check for negative BIC (= account locked) more generally, even when BIF is untouched in the transaction. Introduce dedicated error types for these cases making it easier to test for them and those tests more precise.
- Staking & block issuer feature creation during regular account transitions. Previously this was only handled during account genesis itself.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added various STVF tests and adapted existing ones.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
