### PR TITLE
Require lexical order for `Allotments`

### DIFF
--- a/allotment.go
+++ b/allotment.go
@@ -1,7 +1,9 @@
 package iotago
 
 import (
-	"github.com/iotaledger/hive.go/ierrors"
+	"bytes"
+	"sort"
+
 	"github.com/iotaledger/hive.go/serializer/v2"
 )
 
@@ -15,6 +17,13 @@ type Allotments []*Allotment
 type Allotment struct {
 	AccountID AccountID `serix:"0"`
 	Value     Mana      `serix:"1"`
+}
+
+// Sort sorts the allotments in lexical order.
+func (a Allotments) Sort() {
+	sort.Slice(a, func(i, j int) bool {
+		return bytes.Compare(a[i].AccountID[:], a[j].AccountID[:]) < 0
+	})
 }
 
 func (a Allotments) Size() int {
@@ -45,35 +54,4 @@ func (a Allotments) Get(id AccountID) Mana {
 	}
 
 	return 0
-}
-
-// AllotmentsSyntacticalValidationFunc which given the index of an Allotment and the Allotment itself, runs syntactical validations and returns an error if any should fail.
-type AllotmentsSyntacticalValidationFunc func(index int, input *Allotment) error
-
-// SyntacticallyValidateAllotments validates the allotments by running them against the given AllotmentsSyntacticalValidationFunc(s).
-func SyntacticallyValidateAllotments(allotments TxEssenceAllotments, funcs ...AllotmentsSyntacticalValidationFunc) error {
-	for i, allotment := range allotments {
-		for _, f := range funcs {
-			if err := f(i, allotment); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// AllotmentsSyntacticalUnique returns an AllotmentsSyntacticalValidationFunc which checks that every Allotment has a unique Account.
-func AllotmentsSyntacticalUnique() AllotmentsSyntacticalValidationFunc {
-	allotmentsSet := map[string]int{}
-
-	return func(index int, allotment *Allotment) error {
-		k := string(allotment.AccountID[:])
-		if j, has := allotmentsSet[k]; has {
-			return ierrors.Wrapf(ErrAllotmentsNotUnique, "allotment %d and %d share the same Account", j, index)
-		}
-		allotmentsSet[k] = index
-
-		return nil
-	}
 }

--- a/api_test.go
+++ b/api_test.go
@@ -27,7 +27,7 @@ type deSerializeTest struct {
 func (test *deSerializeTest) deSerialize(t *testing.T) {
 	serixData, err := tpkg.TestAPI.Encode(test.source, serix.WithValidation())
 	if test.seriErr != nil {
-		require.Error(t, err, test.seriErr)
+		require.ErrorIs(t, err, test.seriErr)
 
 		return
 	}
@@ -40,7 +40,7 @@ func (test *deSerializeTest) deSerialize(t *testing.T) {
 	serixTarget := reflect.New(reflect.TypeOf(test.target).Elem()).Interface()
 	bytesRead, err := tpkg.TestAPI.Decode(serixData, serixTarget)
 	if test.deSeriErr != nil {
-		require.Error(t, err, test.deSeriErr)
+		require.ErrorIs(t, err, test.deSeriErr)
 
 		return
 	}

--- a/api_v3.go
+++ b/api_v3.go
@@ -21,10 +21,12 @@ func must(err error) {
 }
 
 var (
+	// Note that when UniquenessSliceFunc is set and the mode is no dups and lexical order, then both will use
+	// the return value of UniquenessSliceFunc for those checks.
 	nativeTokensV3ArrRules = &serix.ArrayRules{
 		Min: MinNativeTokenCountPerOutput,
 		Max: MaxNativeTokenCountPerOutput,
-		// uniqueness must be checked only by examining the actual NativeTokenID bytes
+		// Uniqueness and lexical order is checked based on the Token ID.
 		UniquenessSliceFunc: func(next []byte) []byte { return next[:NativeTokenIDLength] },
 		ValidationMode:      serializer.ArrayValidationModeNoDuplicates | serializer.ArrayValidationModeLexicalOrdering,
 	}
@@ -160,9 +162,11 @@ var (
 	}
 
 	txEssenceV3AllotmentsArrRules = &serix.ArrayRules{
-		Min:            MinAllotmentCount,
-		Max:            MaxAllotmentCount,
-		ValidationMode: serializer.ArrayValidationModeNoDuplicates, // FIXME: it was LexicalOrdering - do we need it?
+		Min: MinAllotmentCount,
+		Max: MaxAllotmentCount,
+		// Uniqueness and lexical order is checked based on the Account ID.
+		UniquenessSliceFunc: func(next []byte) []byte { return next[:AccountIDLength] },
+		ValidationMode:      serializer.ArrayValidationModeNoDuplicates | serializer.ArrayValidationModeLexicalOrdering,
 	}
 
 	txV3UnlocksArrRules = &serix.ArrayRules{

--- a/native_token.go
+++ b/native_token.go
@@ -37,20 +37,7 @@ var (
 	ErrNonUniqueNativeTokens = ierrors.New("non unique native tokens")
 	// ErrNativeTokenSumUnbalanced gets returned when two NativeTokenSum(s) are unbalanced.
 	ErrNativeTokenSumUnbalanced = ierrors.New("native token sums are unbalanced")
-
-	nativeTokensArrayRules = &serializer.ArrayRules{
-		Min: MinNativeTokenCountPerOutput,
-		Max: MaxNativeTokenCountPerOutput,
-		// uniqueness must be checked only by examining the actual NativeTokenID bytes
-		UniquenessSliceFunc: func(next []byte) []byte { return next[:NativeTokenIDLength] },
-		ValidationMode:      serializer.ArrayValidationModeNoDuplicates | serializer.ArrayValidationModeLexicalOrdering,
-	}
 )
-
-// NativeTokenArrayRules returns array rules defining the constraints on a slice of NativeTokens.
-func NativeTokenArrayRules() serializer.ArrayRules {
-	return *nativeTokensArrayRules
-}
 
 // NativeTokenID is an identifier which uniquely identifies a NativeToken.
 type NativeTokenID = FoundryID

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -2,7 +2,6 @@
 package tpkg
 
 import (
-	"bytes"
 	"crypto/ed25519"
 	"encoding/binary"
 	"fmt"
@@ -139,9 +138,7 @@ func RandSortNativeTokens(count int) iotago.NativeTokens {
 	for i := 0; i < count; i++ {
 		nativeTokens = append(nativeTokens, RandNativeToken())
 	}
-	sort.Slice(nativeTokens, func(i, j int) bool {
-		return bytes.Compare(nativeTokens[i].ID[:], nativeTokens[j].ID[:]) == -1
-	})
+	nativeTokens.Sort()
 
 	return nativeTokens
 }

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -408,11 +408,9 @@ func WithOutputCount(outputCount int) options.Option[iotago.TransactionEssence] 
 	}
 }
 
-func WithAllotmentCount(outputCount int) options.Option[iotago.TransactionEssence] {
+func WithAllotmentCount(allotmentCount int) options.Option[iotago.TransactionEssence] {
 	return func(tx *iotago.TransactionEssence) {
-		for i := outputCount; i > 0; i-- {
-			tx.Allotments = append(tx.Allotments, RandAllotment())
-		}
+		tx.Allotments = RandSortAllotment(allotmentCount)
 	}
 }
 
@@ -615,6 +613,17 @@ func RandAllotment() *iotago.Allotment {
 		AccountID: RandAccountID(),
 		Value:     RandMana(10000) + 1,
 	}
+}
+
+// RandSortAllotment returns count sorted Allotments.
+func RandSortAllotment(count int) iotago.Allotments {
+	var allotments iotago.Allotments
+	for i := 0; i < count; i++ {
+		allotments = append(allotments, RandAllotment())
+	}
+	allotments.Sort()
+
+	return allotments
 }
 
 // OneInputOutputTransaction generates a random transaction with one input and output.

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -40,8 +40,6 @@ var (
 	ErrInvalidInputsCommitment = ierrors.New("invalid inputs commitment")
 	// ErrTxEssenceNetworkIDInvalid gets returned when a network ID within a TransactionEssence is invalid.
 	ErrTxEssenceNetworkIDInvalid = ierrors.New("invalid network ID")
-	// ErrAllotmentsNotUnique gets returned if multiple Allotments reference the same Account.
-	ErrAllotmentsNotUnique = ierrors.New("allotments must each reference a unique account")
 	// ErrInputUTXORefsNotUnique gets returned if multiple inputs reference the same UTXO.
 	ErrInputUTXORefsNotUnique = ierrors.New("inputs must each reference a unique UTXO")
 	// ErrInputBICNotUnique gets returned if multiple inputs reference the same BIC.
@@ -198,7 +196,7 @@ func (u *TransactionEssence) syntacticallyValidate(protoParams ProtocolParameter
 		return err
 	}
 
-	if err := SyntacticallyValidateOutputs(u.Outputs,
+	return SyntacticallyValidateOutputs(u.Outputs,
 		OutputsSyntacticalDepositAmount(protoParams),
 		OutputsSyntacticalExpirationAndTimelock(),
 		OutputsSyntacticalNativeTokens(),
@@ -207,12 +205,6 @@ func (u *TransactionEssence) syntacticallyValidate(protoParams ProtocolParameter
 		OutputsSyntacticalAccount(),
 		OutputsSyntacticalNFT(),
 		OutputsSyntacticalDelegation(),
-	); err != nil {
-		return err
-	}
-
-	return SyntacticallyValidateAllotments(u.Allotments,
-		AllotmentsSyntacticalUnique(),
 	)
 }
 

--- a/transaction_essence_test.go
+++ b/transaction_essence_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/iotaledger/hive.go/ierrors"
+	"github.com/iotaledger/hive.go/serializer/v2"
 	iotago "github.com/iotaledger/iota.go/v4"
 	"github.com/iotaledger/iota.go/v4/tpkg"
 )
@@ -171,7 +172,9 @@ func TestAllotmentUniqueness(t *testing.T) {
 			source: tpkg.RandTransactionWithEssence(&iotago.TransactionEssence{
 				NetworkID: tpkg.TestNetworkID,
 				Inputs:    inputIDs.UTXOInputs(),
-				Outputs:   iotago.TxEssenceOutputs{},
+				Outputs: iotago.TxEssenceOutputs{
+					tpkg.RandBasicOutput(iotago.AddressEd25519),
+				},
 				Allotments: iotago.Allotments{
 					&iotago.Allotment{
 						AccountID: accountID,
@@ -188,7 +191,7 @@ func TestAllotmentUniqueness(t *testing.T) {
 				},
 			}),
 			target:    &iotago.Transaction{},
-			seriErr:   iotago.ErrAllotmentsNotUnique,
+			seriErr:   serializer.ErrArrayValidationOrderViolatesLexicalOrder,
 			deSeriErr: nil,
 		},
 	}


### PR DESCRIPTION
# Description of change

Require lexical order for `Allotments`. The argument in favor of lexical order is to more easily check whether two transactions are the same. This is also required for many other arrays, so this is a move towards more consistency.

This is implemented using the hive serializer and the custom uniqueness check for allotments is removed. An interesting finding is also that the behavior of the serializer's lexical order check is different when used with no duplicates or without. With no duplicates mode, the lexical order is checked using the same bytes as uniqueness is checked for (based on `UniquenessSliceFunc`), while all bytes are used when duplicates mode is not activated. Fortunately, this is exactly what we need for allotments, where the Account ID is what matters for uniqueness and lexical order, analogous to native tokens.

This PR also fixes an error in the (de)serialize test implementation, where the serialization and deserialization errors were not actually correctly checked (`require.Error` was used instead of `require.ErrorIs`). Fortunately, no test was actually broken.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Existing tests pass or were adapted.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
