### PR TITLE
Change TimeProvider's perception of time around Genesis, slot 0-1 and epoch 0-1

### DIFF
--- a/timeprovider.go
+++ b/timeprovider.go
@@ -27,7 +27,7 @@ type TimeProvider struct {
 func NewTimeProvider(genesisUnixTime int64, slotDurationSeconds int64, slotsPerEpochExponent uint8) *TimeProvider {
 	// if slotDurationSeconds == 0 {
 	//	panic("slot duration can't be zero")
-	//}
+	// }
 
 	return &TimeProvider{
 		genesisUnixTime:       genesisUnixTime,
@@ -98,6 +98,10 @@ func (t *TimeProvider) SlotEndTime(i SlotIndex) time.Time {
 
 // EpochFromSlot calculates the EpochIndex from the given slot.
 func (t *TimeProvider) EpochFromSlot(slot SlotIndex) EpochIndex {
+	if slot == 0 {
+		return 0
+	}
+
 	return EpochIndex(slot>>SlotIndex(t.slotsPerEpochExponent) + 1)
 }
 

--- a/timeprovider.go
+++ b/timeprovider.go
@@ -109,9 +109,11 @@ func (t *TimeProvider) EpochFromSlot(slot SlotIndex) EpochIndex {
 func (t *TimeProvider) EpochStart(epoch EpochIndex) SlotIndex {
 	if epoch == 0 {
 		return 0
+	} else if epoch == 1 {
+		return 1
 	}
 
-	return SlotIndex((epoch - 1) << EpochIndex(t.slotsPerEpochExponent))
+	return SlotIndex((epoch - 1) << t.slotsPerEpochExponent)
 }
 
 // EpochEnd calculates the end included slot of the given epoch.
@@ -120,7 +122,7 @@ func (t *TimeProvider) EpochEnd(epoch EpochIndex) SlotIndex {
 		return 0
 	}
 
-	return SlotIndex((epoch<<EpochIndex(t.slotsPerEpochExponent) - 1))
+	return SlotIndex(epoch<<EpochIndex(t.slotsPerEpochExponent) - 1)
 }
 
 // SlotsBeforeNextEpoch calculates the slots before the start of the next epoch.

--- a/timeprovider.go
+++ b/timeprovider.go
@@ -6,18 +6,18 @@ import (
 
 // TimeProvider defines the perception of time, slots and epochs.
 // It allows to convert slots to and from time, and epochs to and from slots.
-// Slots are counted starting from 1 because 0 is reserved for the genesis which has to be addressable as its own slot.
+// Slots are counted starting from 1 with 0 being reserved for times before the genesis, which has to be addressable as its own slot.
 // Epochs are counted starting from 0.
 //
 // Example: with slotDurationSeconds = 10 and slotsPerEpochExponent = 3
-// <> inclusive range boundary, () exclusive range boundary
-// slot 0: <-inf; genesis)
-// slot 1: <genesis; genesis+10)
-// slot 2: <genesis+10; genesis+20)
+// [] inclusive range boundary, () exclusive range boundary
+// slot 0: [-inf; genesis)
+// slot 1: [genesis; genesis+10)
+// slot 2: [genesis+10; genesis+20)
 // ...
-// epoch 0: <slot 0; slot 8)
-// epoch 1: <slot 8; slot 16)
-// epoch 2: <slot 16; slot 24)
+// epoch 0: [slot 0; slot 8)
+// epoch 1: [slot 8; slot 16)
+// epoch 2: [slot 16; slot 24)
 // ...
 type TimeProvider struct {
 	// genesisUnixTime is the time (Unix in seconds) of the genesis.
@@ -41,10 +41,6 @@ type TimeProvider struct {
 
 // NewTimeProvider creates a new time provider.
 func NewTimeProvider(genesisUnixTime int64, slotDurationSeconds int64, slotsPerEpochExponent uint8) *TimeProvider {
-	// if slotDurationSeconds == 0 {
-	//	panic("slot duration can't be zero")
-	// }
-
 	return &TimeProvider{
 		genesisUnixTime:       genesisUnixTime,
 		genesisTime:           time.Unix(genesisUnixTime, 0),
@@ -80,8 +76,8 @@ func (t *TimeProvider) EpochDurationSeconds() int64 {
 
 // SlotFromTime calculates the SlotIndex from the given time.
 //
-// Note: slots are counted starting from 1 because 0 is reserved for the genesis which has to be addressable as its own
-// slot as part of the commitment chains.
+// Note: The + 1 is required because slots are counted starting from 1 with 0 being reserved for times before the genesis,
+// which has to be addressable as its own slot.
 func (t *TimeProvider) SlotFromTime(targetTime time.Time) SlotIndex {
 	elapsed := targetTime.Sub(t.genesisTime)
 	if elapsed < 0 {

--- a/vm/stardust/stvf_test.go
+++ b/vm/stardust/stvf_test.go
@@ -2603,6 +2603,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 					cpy := copyObject(t, tt.input.Output, muts).(*iotago.FoundryOutput)
 					err := stardustVM.ChainSTVF(tt.transType, tt.input, cpy, tt.svCtx)
 					if tt.wantErr != nil {
+						//nolint:gosec // false positive
 						require.ErrorAs(t, err, &tt.wantErr)
 						return
 					}
@@ -2615,6 +2616,7 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := stardustVM.ChainSTVF(tt.transType, tt.input, tt.next, tt.svCtx)
 			if tt.wantErr != nil {
+				//nolint:gosec // false positive
 				require.ErrorAs(t, err, &tt.wantErr)
 				return
 			}
@@ -2742,6 +2744,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 					cpy := copyObject(t, tt.input.Output, muts).(*iotago.NFTOutput)
 					err := stardustVM.ChainSTVF(tt.transType, tt.input, cpy, tt.svCtx)
 					if tt.wantErr != nil {
+						//nolint:gosec // false positive
 						require.ErrorAs(t, err, &tt.wantErr)
 						return
 					}
@@ -2754,6 +2757,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := stardustVM.ChainSTVF(tt.transType, tt.input, tt.next, tt.svCtx)
 			if tt.wantErr != nil {
+				//nolint:gosec // false positive
 				require.ErrorAs(t, err, &tt.wantErr)
 				return
 			}


### PR DESCRIPTION
This PR fixes the `TimeProvider` and its perception of time, slots and epochs and how they relate to each other. 
Before, there were some inconsistencies especially around slot 0 and 1 and epoch 0 and 1. 

Now a new way for handling time is introduced.
```
Slots are counted starting from 1 with 0 being reserved for times before the genesis, which has to be addressable as its own slot.
Epochs are counted starting from 0.

Example: with slotDurationSeconds = 10 and slotsPerEpochExponent = 3
[] inclusive range boundary, () exclusive range boundary
slot 0: [-inf; genesis)
slot 1: [genesis; genesis+10)
slot 2: [genesis+10; genesis+20)
...
epoch 0: [slot 0; slot 8)
epoch 1: [slot 8; slot 16)
epoch 2: [slot 16; slot 24)
...
```