### PR TITLE
Remove De-/Serializable interface from addresses

### DIFF
--- a/address_account.go
+++ b/address_account.go
@@ -22,19 +22,6 @@ const (
 // An AccountAddress is the Blake2b-256 hash of the OutputID which created it.
 type AccountAddress [AccountAddressBytesLength]byte
 
-func (addr *AccountAddress) Decode(b []byte) (int, error) {
-	copy(addr[:], b)
-
-	return AccountAddressSerializedBytesSize - 1, nil
-}
-
-func (addr *AccountAddress) Encode() ([]byte, error) {
-	var b [AccountAddressSerializedBytesSize - 1]byte
-	copy(b[:], addr[:])
-
-	return b[:], nil
-}
-
 func (addr *AccountAddress) Clone() Address {
 	cpy := &AccountAddress{}
 	copy(cpy[:], addr[:])

--- a/address_ed25519.go
+++ b/address_ed25519.go
@@ -23,19 +23,6 @@ const (
 // An Ed25519Address is the Blake2b-256 hash of an Ed25519 public key.
 type Ed25519Address [Ed25519AddressBytesLength]byte
 
-func (addr *Ed25519Address) Decode(b []byte) (int, error) {
-	copy(addr[:], b)
-
-	return Ed25519AddressSerializedBytesSize - 1, nil
-}
-
-func (addr *Ed25519Address) Encode() ([]byte, error) {
-	var b [Ed25519AddressSerializedBytesSize - 1]byte
-	copy(b[:], addr[:])
-
-	return b[:], nil
-}
-
 func (addr *Ed25519Address) Clone() Address {
 	cpy := &Ed25519Address{}
 	copy(cpy[:], addr[:])

--- a/address_implicit_account_creation.go
+++ b/address_implicit_account_creation.go
@@ -46,19 +46,6 @@ func MustParseImplicitAccountCreationAddressFromHexString(hexAddr string) *Impli
 	return addr
 }
 
-func (addr *ImplicitAccountCreationAddress) Decode(b []byte) (int, error) {
-	copy(addr[:], b)
-
-	return ImplicitAccountCreationAddressSerializedBytesSize - 1, nil
-}
-
-func (addr *ImplicitAccountCreationAddress) Encode() ([]byte, error) {
-	var b [ImplicitAccountCreationAddressSerializedBytesSize - 1]byte
-	copy(b[:], addr[:])
-
-	return b[:], nil
-}
-
 func (addr *ImplicitAccountCreationAddress) Clone() Address {
 	cpy := &ImplicitAccountCreationAddress{}
 	copy(cpy[:], addr[:])

--- a/address_nft.go
+++ b/address_nft.go
@@ -22,19 +22,6 @@ const (
 // An NFTAddress is the Blake2b-256 hash of the OutputID which created it.
 type NFTAddress [NFTAddressBytesLength]byte
 
-func (addr *NFTAddress) Decode(b []byte) (int, error) {
-	copy(addr[:], b)
-
-	return NFTAddressSerializedBytesSize - 1, nil
-}
-
-func (addr *NFTAddress) Encode() ([]byte, error) {
-	var b [NFTAddressSerializedBytesSize - 1]byte
-	copy(b[:], addr[:])
-
-	return b[:], nil
-}
-
 func (addr *NFTAddress) Clone() Address {
 	cpy := &NFTAddress{}
 	copy(cpy[:], addr[:])

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/iotaledger/hive.go/ierrors v0.0.0-20230829152614-7afc7a4d89b3
 	github.com/iotaledger/hive.go/lo v0.0.0-20230829152614-7afc7a4d89b3
 	github.com/iotaledger/hive.go/runtime v0.0.0-20230829152614-7afc7a4d89b3
-	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230829152614-7afc7a4d89b3
+	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230911090834-85fc1ae2eba1
 	github.com/iotaledger/hive.go/stringify v0.0.0-20230829152614-7afc7a4d89b3
 	github.com/pasztorpisti/qs v0.0.0-20171216220353-8d6c33ee906c
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/iotaledger/hive.go/lo v0.0.0-20230829152614-7afc7a4d89b3 h1:ZAg8B2w9J
 github.com/iotaledger/hive.go/lo v0.0.0-20230829152614-7afc7a4d89b3/go.mod h1:/LERu5vqcessCqr40Wxmbx4x0bbymsK7GuL+TK/ckKo=
 github.com/iotaledger/hive.go/runtime v0.0.0-20230829152614-7afc7a4d89b3 h1:fwJri2b4PXJJ19/W0iGjZSpu/vwK4QAytJ7PwDPNjMM=
 github.com/iotaledger/hive.go/runtime v0.0.0-20230829152614-7afc7a4d89b3/go.mod h1:fXVyQ1MAwxe/EmjAnG8WcQqbzGk9EW/FsJ/n16H/f/w=
-github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230829152614-7afc7a4d89b3 h1:WpL8R5ltMAf8rgksjBgdO2FXDa3zKN2R29lZ2C6pJGU=
-github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230829152614-7afc7a4d89b3/go.mod h1:IJgaaxbgKCsNat18jlJJEAxCY2oVYR3F30B+M4vJ89I=
+github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230911090834-85fc1ae2eba1 h1:11wPg6n2fYJdAoh4sh/3t8Tv97rx1Zx0KqkftbuBH7E=
+github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230911090834-85fc1ae2eba1/go.mod h1:IJgaaxbgKCsNat18jlJJEAxCY2oVYR3F30B+M4vJ89I=
 github.com/iotaledger/hive.go/stringify v0.0.0-20230829152614-7afc7a4d89b3 h1:iJ+AkAO6hj5tzoOvEFIfm67eG8g5UvvGYP+6xMA98sg=
 github.com/iotaledger/hive.go/stringify v0.0.0-20230829152614-7afc7a4d89b3/go.mod h1:FTo/UWzNYgnQ082GI9QVM9HFDERqf9rw9RivNpqrnTs=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
We changed serix in a way, that it now understands how to serialize arrays of bytes with an objectType.
No need for custom serialization of the addresses anymore.