### PR TITLE
Indexer improvements for v3 nodeclient

### DIFF
--- a/nodeclient/indexer_client.go
+++ b/nodeclient/indexer_client.go
@@ -11,6 +11,7 @@ import (
 
 // Indexer plugin routes.
 var (
+	IndexerAPIRouteOutputs      = "/api/" + IndexerPluginName + "/outputs"
 	IndexerAPIRouteBasicOutputs = "/api/" + IndexerPluginName + "/outputs/basic"
 	IndexerAPIRouteAliases      = "/api/" + IndexerPluginName + "/outputs/alias"
 	IndexerAPIRouteAlias        = "/api/" + IndexerPluginName + "/outputs/alias/%s"
@@ -24,13 +25,6 @@ var (
 	// ErrIndexerNotFound gets returned when the indexer doesn't find any result.
 	// Only applicable to single element queries.
 	ErrIndexerNotFound = errors.New("no result found")
-
-	outputTypeToIndexerRoute = map[iotago.OutputType]string{
-		iotago.OutputBasic:   IndexerAPIRouteBasicOutputs,
-		iotago.OutputAlias:   IndexerAPIRouteAliases,
-		iotago.OutputFoundry: IndexerAPIRouteFoundries,
-		iotago.OutputNFT:     IndexerAPIRouteNFTs,
-	}
 )
 
 type (
@@ -53,8 +47,8 @@ type (
 		SetOffset(offset *string)
 		// URLParas returns the query parameters as URL encoded query parameters.
 		URLParas() (string, error)
-		// OutputType returns the output type for which the query is for.
-		OutputType() iotago.OutputType
+		// BaseRoute returns the base route for this query.
+		BaseRoute() string
 	}
 
 	indexerClient struct {
@@ -127,7 +121,7 @@ func (client *indexerClient) Outputs(ctx context.Context, query IndexerQuery) (*
 		query:  query,
 	}
 
-	baseRoute := outputTypeToIndexerRoute[query.OutputType()]
+	baseRoute := query.BaseRoute()
 
 	// this gets executed on every Next()
 	nextFunc := func() error {

--- a/nodeclient/indexer_models.go
+++ b/nodeclient/indexer_models.go
@@ -74,6 +74,12 @@ type IndexerNativeTokenParas struct {
 	MaxNativeTokenCount *uint32 `qs:"maxNativeTokenCount,omitempty"`
 }
 
+// IndexerUnlockableByAddressParas define address unlock related query parameters.
+type IndexerUnlockableByAddressParas struct {
+	// Bech32-encoded address that should be searched for.
+	UnlockableByAddressBech32 string `qs:"unlockableByAddress,omitempty"`
+}
+
 // BasicOutputsQuery defines parameters for an basic outputs query.
 type BasicOutputsQuery struct {
 	IndexerCursorParas
@@ -82,6 +88,7 @@ type BasicOutputsQuery struct {
 	IndexerCreationParas
 	IndexerStorageDepositParas
 	IndexerNativeTokenParas
+	IndexerUnlockableByAddressParas
 
 	// Bech32-encoded address that should be searched for.
 	AddressBech32 string `qs:"address,omitempty"`
@@ -91,8 +98,8 @@ type BasicOutputsQuery struct {
 	Tag string `qs:"tag,omitempty"`
 }
 
-func (query *BasicOutputsQuery) OutputType() iotago.OutputType {
-	return iotago.OutputBasic
+func (query *BasicOutputsQuery) BaseRoute() string {
+	return IndexerAPIRouteBasicOutputs
 }
 
 func (query *BasicOutputsQuery) SetOffset(cursor *string) {
@@ -108,6 +115,7 @@ type AliasesQuery struct {
 	IndexerCursorParas
 	IndexerCreationParas
 	IndexerNativeTokenParas
+	IndexerUnlockableByAddressParas
 
 	// Bech32-encoded state controller address that should be searched for.
 	StateControllerBech32 string `qs:"stateController,omitempty"`
@@ -119,8 +127,8 @@ type AliasesQuery struct {
 	IssuerBech32 string `qs:"issuer,omitempty"`
 }
 
-func (query *AliasesQuery) OutputType() iotago.OutputType {
-	return iotago.OutputAlias
+func (query *AliasesQuery) BaseRoute() string {
+	return IndexerAPIRouteAliases
 }
 
 func (query *AliasesQuery) SetOffset(cursor *string) {
@@ -141,8 +149,8 @@ type FoundriesQuery struct {
 	AliasAddressBech32 string `qs:"aliasAddress,omitempty"`
 }
 
-func (query *FoundriesQuery) OutputType() iotago.OutputType {
-	return iotago.OutputFoundry
+func (query *FoundriesQuery) BaseRoute() string {
+	return IndexerAPIRouteFoundries
 }
 
 func (query *FoundriesQuery) SetOffset(cursor *string) {
@@ -161,6 +169,7 @@ type NFTsQuery struct {
 	IndexerStorageDepositParas
 	IndexerNativeTokenParas
 	IndexerCreationParas
+	IndexerUnlockableByAddressParas
 
 	// Bech32-encoded address that should be searched for.
 	AddressBech32 string `qs:"address,omitempty"`
@@ -172,8 +181,8 @@ type NFTsQuery struct {
 	Tag string `qs:"tag,omitempty"`
 }
 
-func (query *NFTsQuery) OutputType() iotago.OutputType {
-	return iotago.OutputNFT
+func (query *NFTsQuery) BaseRoute() string {
+	return IndexerAPIRouteNFTs
 }
 
 func (query *NFTsQuery) SetOffset(cursor *string) {
@@ -181,5 +190,24 @@ func (query *NFTsQuery) SetOffset(cursor *string) {
 }
 
 func (query *NFTsQuery) URLParas() (string, error) {
+	return qs.Marshal(query)
+}
+
+type OutputsQuery struct {
+	IndexerCursorParas
+	IndexerNativeTokenParas
+	IndexerCreationParas
+	IndexerUnlockableByAddressParas
+}
+
+func (query *OutputsQuery) BaseRoute() string {
+	return IndexerAPIRouteOutputs
+}
+
+func (query *OutputsQuery) SetOffset(cursor *string) {
+	query.Cursor = cursor
+}
+
+func (query *OutputsQuery) URLParas() (string, error) {
 	return qs.Marshal(query)
 }

--- a/output_foundry_test.go
+++ b/output_foundry_test.go
@@ -408,8 +408,9 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 				t.Run(fmt.Sprintf("%s_%s", tt.name, mutName), func(t *testing.T) {
 					cpy := copyObject(t, tt.current, muts, tpkg.TestProtoParas).(*iotago.FoundryOutput)
 					err := tt.current.ValidateStateTransition(tt.transType, cpy, tt.svCtx)
-					if tt.wantErr != nil {
-						require.ErrorAs(t, err, &tt.wantErr)
+					wantErr := tt.wantErr
+					if wantErr != nil {
+						require.ErrorAs(t, err, &wantErr)
 						return
 					}
 					require.NoError(t, err)
@@ -420,8 +421,9 @@ func TestFoundryOutput_ValidateStateTransition(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.current.ValidateStateTransition(tt.transType, tt.next, tt.svCtx)
-			if tt.wantErr != nil {
-				require.ErrorAs(t, err, &tt.wantErr)
+			wantErr := tt.wantErr
+			if wantErr != nil {
+				require.ErrorAs(t, err, &wantErr)
 				return
 			}
 			require.NoError(t, err)

--- a/output_nft_test.go
+++ b/output_nft_test.go
@@ -122,8 +122,9 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 				t.Run(fmt.Sprintf("%s_%s", tt.name, mutName), func(t *testing.T) {
 					cpy := copyObject(t, tt.current, muts, tpkg.TestProtoParas).(*iotago.NFTOutput)
 					err := tt.current.ValidateStateTransition(tt.transType, cpy, tt.svCtx)
-					if tt.wantErr != nil {
-						require.ErrorAs(t, err, &tt.wantErr)
+					wantErr := tt.wantErr
+					if wantErr != nil {
+						require.ErrorAs(t, err, &wantErr)
 						return
 					}
 					require.NoError(t, err)
@@ -134,8 +135,9 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.current.ValidateStateTransition(tt.transType, tt.next, tt.svCtx)
-			if tt.wantErr != nil {
-				require.ErrorAs(t, err, &tt.wantErr)
+			wantErr := tt.wantErr
+			if wantErr != nil {
+				require.ErrorAs(t, err, &wantErr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
Added support for the indexer’s new outputs route and new unlockableByAddress query parameter to the nodeclient
