### PR TITLE
Add utilities in the transaction builder to allot the mana required to issue the block

### DIFF
--- a/address_signer.go
+++ b/address_signer.go
@@ -110,3 +110,16 @@ func (s *InMemoryAddressSigner) Sign(addr Address, msg []byte) (signature Signat
 		return nil, ierrors.Wrapf(ErrUnknownAddrType, "type %T", addr)
 	}
 }
+
+// EmptyAddressSigner returns an empty signature for the given address.
+// This can be used to calculate the WorkScore of transactions without actual signing the transaction.
+type EmptyAddressSigner struct{}
+
+func (s *EmptyAddressSigner) Sign(addr Address, _ []byte) (signature Signature, err error) {
+	switch addr.(type) {
+	case *Ed25519Address:
+		return &Ed25519Signature{}, nil
+	default:
+		return nil, ierrors.Wrapf(ErrUnknownAddrType, "type %T", addr)
+	}
+}

--- a/address_signer.go
+++ b/address_signer.go
@@ -112,7 +112,7 @@ func (s *InMemoryAddressSigner) Sign(addr Address, msg []byte) (signature Signat
 }
 
 // EmptyAddressSigner returns an empty signature for the given address.
-// This can be used to calculate the WorkScore of transactions without actual signing the transaction.
+// This can be used to calculate the WorkScore of transactions without actually signing the transaction.
 type EmptyAddressSigner struct{}
 
 func (s *EmptyAddressSigner) Sign(addr Address, _ []byte) (signature Signature, err error) {

--- a/block.go
+++ b/block.go
@@ -556,9 +556,9 @@ func (b *ValidationBlock) WorkScore(_ *WorkScoreStructure) (WorkScore, error) {
 
 func (b *ValidationBlock) Size() int {
 	return serializer.OneByte + // block type
-		serializer.OneByte + len(b.StrongParents)*SlotIdentifierLength +
-		serializer.OneByte + len(b.WeakParents)*SlotIdentifierLength +
-		serializer.OneByte + len(b.ShallowLikeParents)*SlotIdentifierLength +
+		serializer.OneByte + len(b.StrongParents)*SlotIdentifierLength + // StrongParents count
+		serializer.OneByte + len(b.WeakParents)*SlotIdentifierLength + // WeakParents count
+		serializer.OneByte + len(b.ShallowLikeParents)*SlotIdentifierLength + // ShallowLikeParents count
 		serializer.OneByte + // highest supported version
 		IdentifierLength // protocol parameters hash
 }

--- a/builder/output_builder.go
+++ b/builder/output_builder.go
@@ -527,15 +527,15 @@ func (trans *stakingTransition) FixedCost(fixedCost iotago.Mana) *stakingTransit
 }
 
 // StartEpoch sets the StartEpoch of iotago.StakingFeature.
-func (trans *stakingTransition) StartEpoch(slot iotago.EpochIndex) *stakingTransition {
-	trans.feature.StartEpoch = slot
+func (trans *stakingTransition) StartEpoch(epoch iotago.EpochIndex) *stakingTransition {
+	trans.feature.StartEpoch = epoch
 
 	return trans
 }
 
 // EndEpoch sets the EndEpoch of iotago.StakingFeature.
-func (trans *stakingTransition) EndEpoch(slot iotago.EpochIndex) *stakingTransition {
-	trans.feature.EndEpoch = slot
+func (trans *stakingTransition) EndEpoch(epoch iotago.EpochIndex) *stakingTransition {
+	trans.feature.EndEpoch = epoch
 
 	return trans
 }

--- a/builder/output_builder.go
+++ b/builder/output_builder.go
@@ -587,11 +587,6 @@ func (builder *FoundryOutputBuilder) Amount(amount iotago.BaseToken) *FoundryOut
 	return builder
 }
 
-// Mana sets the mana of the output.
-func (builder *FoundryOutputBuilder) Mana(mana iotago.Mana) *FoundryOutputBuilder {
-	return builder.Mana(mana)
-}
-
 // NativeToken adds/modifies a native token to/on the output.
 func (builder *FoundryOutputBuilder) NativeToken(nt *iotago.NativeToken) *FoundryOutputBuilder {
 	builder.output.NativeTokens.Upsert(nt)
@@ -898,12 +893,4 @@ func (builder *DelegationOutputBuilder) MustBuild() *iotago.DelegationOutput {
 	}
 
 	return output
-}
-
-// Build builds the iotago.DelegationOutput.
-func (builder *DelegationOutputBuilder) Build() (*iotago.DelegationOutput, error) {
-
-	builder.output.Conditions.Sort()
-
-	return builder.output, nil
 }

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -81,9 +81,21 @@ func (b *TransactionBuilder) AddContextInput(contextInput iotago.Input) *Transac
 	return b
 }
 
-// AddAllotment adds the given allotment to the builder.
-func (b *TransactionBuilder) AddAllotment(allotment *iotago.Allotment) *TransactionBuilder {
-	b.transaction.Allotments = append(b.transaction.Allotments, allotment)
+// IncreaseAllotment adds or increases the given allotment to the builder.
+func (b *TransactionBuilder) IncreaseAllotment(accountID iotago.AccountID, value iotago.Mana) *TransactionBuilder {
+	// check if the allotment already exists and add the value on top
+	for _, allotment := range b.transaction.Allotments {
+		if allotment.AccountID.ToAddress().Equal(accountID.ToAddress()) {
+			allotment.Value += value
+			return b
+		}
+	}
+
+	// allotment does not exist yet
+	b.transaction.Allotments = append(b.transaction.Allotments, &iotago.Allotment{
+		AccountID: accountID,
+		Value:     value,
+	})
 
 	return b
 }

--- a/output_nft.go
+++ b/output_nft.go
@@ -16,6 +16,10 @@ var (
 	emptyNFTID = [NFTIDLength]byte{}
 )
 
+func EmptyNFTID() NFTID {
+	return emptyNFTID
+}
+
 // NFTID is the identifier for an NFT.
 // It is computed as the Blake2b-256 hash of the OutputID of the output which created the NFT.
 type NFTID [NFTIDLength]byte

--- a/workscore_test.go
+++ b/workscore_test.go
@@ -77,8 +77,8 @@ func TestTransactionEssenceWorkScore(t *testing.T) {
 		AddContextInput(&iotago.CommitmentInput{CommitmentID: iotago.NewSlotIdentifier(85, tpkg.Rand32ByteArray())}).
 		AddContextInput(&iotago.BlockIssuanceCreditInput{AccountID: tpkg.RandAccountID()}).
 		AddContextInput(&iotago.RewardInput{Index: 0}).
-		AddAllotment(tpkg.RandAllotment()).
-		AddAllotment(tpkg.RandAllotment()).
+		IncreaseAllotment(tpkg.RandAccountID(), tpkg.RandMana(10000)+1).
+		IncreaseAllotment(tpkg.RandAccountID(), tpkg.RandMana(10000)+1).
 		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR adds some utilities to calculate the available mana on input side, and to calculate the minimum mana required to issue a default block (4 strong parents) containing the transaction.