### PR TITLE
Fix Transaction Essence Work Score

### DIFF
--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -227,6 +227,10 @@ func (u *TransactionEssence) syntacticallyValidate(protoParams ProtocolParameter
 	)
 }
 
+// Calculates the Work Score of the TransactionEssence.
+//
+// Does not specifically include the work score of the optional payload because that is already
+// included in the Work Score of the Transaction.
 func (u *TransactionEssence) WorkScore(workScoreStructure *WorkScoreStructure) (WorkScore, error) {
 	workScoreContextInputs, err := u.ContextInputs.WorkScore(workScoreStructure)
 	if err != nil {

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -248,13 +248,5 @@ func (u *TransactionEssence) WorkScore(workScoreStructure *WorkScoreStructure) (
 		return 0, err
 	}
 
-	var workScorePayload WorkScore
-	if u.Payload != nil {
-		workScorePayload, err = u.Payload.WorkScore(workScoreStructure)
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	return workScoreContextInputs.Add(workScoreInputs, workScoreOutputs, workScoreAllotments, workScorePayload)
+	return workScoreContextInputs.Add(workScoreInputs, workScoreOutputs, workScoreAllotments)
 }

--- a/workscore_test.go
+++ b/workscore_test.go
@@ -91,6 +91,7 @@ func TestTransactionEssenceWorkScore(t *testing.T) {
 	expectedWorkScore := workScoreStructure.DataByte*iotago.WorkScore(tx.Size()) +
 		workScoreStructure.Input*2 +
 		workScoreStructure.ContextInput*3 +
+		// Accounts for one Signature unlock.
 		workScoreStructure.SignatureEd25519 +
 		workScoreStructure.BlockIssuer +
 		workScoreStructure.Staking +
@@ -98,7 +99,4 @@ func TestTransactionEssenceWorkScore(t *testing.T) {
 		workScoreStructure.Allotment*2
 
 	require.Equal(t, expectedWorkScore, workScore, "work score expected: %d, actual: %d", expectedWorkScore, workScore)
-
-	// fmt.Println(string(lo.PanicOnErr(api.JSONEncode(workScoreStructure))))
-	// fmt.Println(string(lo.PanicOnErr(api.JSONEncode(tx))))
 }

--- a/workscore_test.go
+++ b/workscore_test.go
@@ -1,0 +1,104 @@
+package iotago_test
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	hiveEd25519 "github.com/iotaledger/hive.go/crypto/ed25519"
+	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/builder"
+	"github.com/iotaledger/iota.go/v4/tpkg"
+)
+
+func TestTransactionEssenceWorkScore(t *testing.T) {
+	keyPair := hiveEd25519.GenerateKeyPair()
+	keyPair2 := hiveEd25519.GenerateKeyPair()
+	// Derive a dummy account from addr.
+	addr := iotago.Ed25519AddressFromPubKey(keyPair.PublicKey[:])
+
+	output1 := &iotago.BasicOutput{
+		Amount:       100000,
+		NativeTokens: tpkg.RandSortNativeTokens(2),
+		Conditions: iotago.BasicOutputUnlockConditions{
+			&iotago.AddressUnlockCondition{
+				Address: addr,
+			},
+		},
+	}
+	output2 := &iotago.AccountOutput{
+		Amount:       1_000_000,
+		NativeTokens: tpkg.RandSortNativeTokens(3),
+		Conditions: iotago.AccountOutputUnlockConditions{
+			&iotago.StateControllerAddressUnlockCondition{
+				Address: addr,
+			},
+			&iotago.GovernorAddressUnlockCondition{
+				Address: addr,
+			},
+		},
+		Features: iotago.AccountOutputFeatures{
+			&iotago.BlockIssuerFeature{
+				ExpirySlot: 300,
+				BlockIssuerKeys: iotago.BlockIssuerKeys{
+					iotago.Ed25519PublicKeyBlockIssuerKeyFromPublicKey(keyPair.PublicKey),
+					iotago.Ed25519PublicKeyBlockIssuerKeyFromPublicKey(keyPair2.PublicKey),
+				},
+			},
+			&iotago.StakingFeature{
+				StakedAmount: 500_00,
+				FixedCost:    500,
+			},
+		},
+	}
+
+	api := iotago.V3API(
+		iotago.NewV3ProtocolParameters(
+			iotago.WithNetworkOptions("TestJungle", "tgl"),
+			iotago.WithSupplyOptions(tpkg.TestTokenSupply, 0, 0, 0, 0, 0, 0),
+			iotago.WithWorkScoreOptions(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+		),
+	)
+
+	tx, err := builder.NewTransactionBuilder(api).
+		AddInput(&builder.TxInput{
+			UnlockTarget: addr,
+			InputID:      tpkg.RandOutputID(0),
+			Input:        output1,
+		}).
+		AddInput(&builder.TxInput{
+			UnlockTarget: addr,
+			InputID:      tpkg.RandOutputID(0),
+			Input:        output1,
+		}).
+		AddOutput(output1).
+		AddOutput(output2).
+		AddContextInput(&iotago.CommitmentInput{CommitmentID: iotago.NewSlotIdentifier(85, tpkg.Rand32ByteArray())}).
+		AddContextInput(&iotago.BlockIssuanceCreditInput{AccountID: tpkg.RandAccountID()}).
+		AddContextInput(&iotago.RewardInput{Index: 0}).
+		AddAllotment(tpkg.RandAllotment()).
+		AddAllotment(tpkg.RandAllotment()).
+		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+	require.NoError(t, err)
+
+	workScoreStructure := api.ProtocolParameters().WorkScoreStructure()
+
+	workScore, err := tx.WorkScore(workScoreStructure)
+	require.NoError(t, err)
+
+	// Calculate work score as defined in TIP-45 for verification.
+	expectedWorkScore := workScoreStructure.DataByte*iotago.WorkScore(tx.Size()) +
+		workScoreStructure.Input*2 +
+		workScoreStructure.ContextInput*3 +
+		workScoreStructure.SignatureEd25519 +
+		workScoreStructure.BlockIssuer +
+		workScoreStructure.Staking +
+		workScoreStructure.NativeToken*5 +
+		workScoreStructure.Allotment*2
+
+	require.Equal(t, expectedWorkScore, workScore, "work score expected: %d, actual: %d", expectedWorkScore, workScore)
+
+	// fmt.Println(string(lo.PanicOnErr(api.JSONEncode(workScoreStructure))))
+	// fmt.Println(string(lo.PanicOnErr(api.JSONEncode(tx))))
+}


### PR DESCRIPTION
# Description of change

Fix Transaction Essence Work Score which previously accounted twice for a possibly contained Tagged Data Payload due to `workScoreStructure.DataByte.Multiply(t.Size())` in the transaction, which includes the size of the tagged data payload, and the explicit `u.Payload.WorkScore(workScoreStructure)` in the transaction essence.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added a work score test for transaction essence.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
