### PR TITLE
Fix block issuer keys serialization

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -619,8 +619,8 @@ func V3API(protoParams ProtocolParameters) API {
 		must(api.RegisterTypeSettings(Ed25519AddressBlockIssuerKey{},
 			serix.TypeSettings{}.WithObjectType(byte(BlockIssuerKeyEd25519Address)),
 		))
-		must(api.RegisterInterfaceObjects((*BlockIssuerKey)(nil), Ed25519PublicKeyBlockIssuerKey{}))
-		must(api.RegisterInterfaceObjects((*BlockIssuerKey)(nil), Ed25519AddressBlockIssuerKey{}))
+		must(api.RegisterInterfaceObjects((*BlockIssuerKey)(nil), (*Ed25519PublicKeyBlockIssuerKey)(nil)))
+		must(api.RegisterInterfaceObjects((*BlockIssuerKey)(nil), (*Ed25519AddressBlockIssuerKey)(nil)))
 
 		must(api.RegisterTypeSettings(BlockIssuerKeys{},
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte).WithArrayRules(accountOutputV3BlockIssuerKeysArrRules),

--- a/block_issuer_key_ed25519_address.go
+++ b/block_issuer_key_ed25519_address.go
@@ -1,7 +1,7 @@
 package iotago
 
 import (
-	"context"
+	"bytes"
 
 	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/serializer/v2"
@@ -13,25 +13,38 @@ type Ed25519AddressBlockIssuerKey struct {
 }
 
 // Ed25519AddressBlockIssuerKeyFromAddress creates a block issuer key from an Ed25519 address.
-func Ed25519AddressBlockIssuerKeyFromAddress(address *Ed25519Address) Ed25519AddressBlockIssuerKey {
-	return Ed25519AddressBlockIssuerKey{Address: address}
+func Ed25519AddressBlockIssuerKeyFromAddress(address *Ed25519Address) *Ed25519AddressBlockIssuerKey {
+	return &Ed25519AddressBlockIssuerKey{Address: address}
 }
 
 // BlockIssuerKeyBytes returns a byte slice consisting of the type prefix and the raw address.
-func (key Ed25519AddressBlockIssuerKey) BlockIssuerKeyBytes() []byte {
-	return lo.PanicOnErr(CommonSerixAPI().Encode(context.TODO(), key))
+func (key *Ed25519AddressBlockIssuerKey) BlockIssuerKeyBytes(api API) []byte {
+	return lo.PanicOnErr(api.Encode(key))
 }
 
 // Type returns the BlockIssuerKeyType.
-func (key Ed25519AddressBlockIssuerKey) Type() BlockIssuerKeyType {
+func (key *Ed25519AddressBlockIssuerKey) Type() BlockIssuerKeyType {
 	return BlockIssuerKeyEd25519Address
 }
 
+func (key *Ed25519AddressBlockIssuerKey) Equal(other BlockIssuerKey) bool {
+	otherBlockIssuerKey, is := other.(*Ed25519AddressBlockIssuerKey)
+	if !is {
+		return false
+	}
+
+	return key.Address.Equal(otherBlockIssuerKey.Address)
+}
+
+func (key *Ed25519AddressBlockIssuerKey) Compare(other *Ed25519AddressBlockIssuerKey) int {
+	return bytes.Compare(key.Address[:], other.Address[:])
+}
+
 // Size returns the size of the block issuer key when serialized.
-func (key Ed25519AddressBlockIssuerKey) Size() int {
+func (key *Ed25519AddressBlockIssuerKey) Size() int {
 	return serializer.SmallTypeDenotationByteSize + key.Address.Size()
 }
 
-func (key Ed25519AddressBlockIssuerKey) VBytes(rentStructure *RentStructure, _ VBytesFunc) VBytes {
+func (key *Ed25519AddressBlockIssuerKey) VBytes(rentStructure *RentStructure, _ VBytesFunc) VBytes {
 	return rentStructure.VBFactorBlockIssuerKey.Multiply(VBytes(key.Size()))
 }

--- a/block_issuer_key_ed25519_pubkey.go
+++ b/block_issuer_key_ed25519_pubkey.go
@@ -1,7 +1,7 @@
 package iotago
 
 import (
-	"context"
+	"bytes"
 
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/lo"
@@ -14,30 +14,43 @@ type Ed25519PublicKeyBlockIssuerKey struct {
 }
 
 // Ed25519PublicKeyBlockIssuerKeyFromPublicKey creates a block issuer key from an Ed25519 public key.
-func Ed25519PublicKeyBlockIssuerKeyFromPublicKey(publicKey ed25519.PublicKey) Ed25519PublicKeyBlockIssuerKey {
-	return Ed25519PublicKeyBlockIssuerKey{PublicKey: publicKey}
+func Ed25519PublicKeyBlockIssuerKeyFromPublicKey(publicKey ed25519.PublicKey) *Ed25519PublicKeyBlockIssuerKey {
+	return &Ed25519PublicKeyBlockIssuerKey{PublicKey: publicKey}
 }
 
 // ToEd25519PublicKey returns the underlying Ed25519 Public Key.
-func (key Ed25519PublicKeyBlockIssuerKey) ToEd25519PublicKey() ed25519.PublicKey {
+func (key *Ed25519PublicKeyBlockIssuerKey) ToEd25519PublicKey() ed25519.PublicKey {
 	return key.PublicKey
 }
 
 // BlockIssuerKeyBytes returns a byte slice consisting of the type prefix and the public key bytes.
-func (key Ed25519PublicKeyBlockIssuerKey) BlockIssuerKeyBytes() []byte {
-	return lo.PanicOnErr(CommonSerixAPI().Encode(context.TODO(), key))
+func (key *Ed25519PublicKeyBlockIssuerKey) BlockIssuerKeyBytes(api API) []byte {
+	return lo.PanicOnErr(api.Encode(key))
 }
 
 // Type returns the BlockIssuerKeyType.
-func (key Ed25519PublicKeyBlockIssuerKey) Type() BlockIssuerKeyType {
+func (key *Ed25519PublicKeyBlockIssuerKey) Type() BlockIssuerKeyType {
 	return BlockIssuerKeyEd25519PublicKey
 }
 
+func (key *Ed25519PublicKeyBlockIssuerKey) Equal(other BlockIssuerKey) bool {
+	otherBlockIssuerKey, is := other.(*Ed25519PublicKeyBlockIssuerKey)
+	if !is {
+		return false
+	}
+
+	return bytes.Equal(key.PublicKey[:], otherBlockIssuerKey.PublicKey[:])
+}
+
+func (key *Ed25519PublicKeyBlockIssuerKey) Compare(other *Ed25519PublicKeyBlockIssuerKey) int {
+	return bytes.Compare(key.PublicKey[:], other.PublicKey[:])
+}
+
 // Size returns the size of the block issuer key when serialized.
-func (key Ed25519PublicKeyBlockIssuerKey) Size() int {
+func (key *Ed25519PublicKeyBlockIssuerKey) Size() int {
 	return serializer.SmallTypeDenotationByteSize + ed25519.PublicKeySize
 }
 
-func (key Ed25519PublicKeyBlockIssuerKey) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
+func (key *Ed25519PublicKeyBlockIssuerKey) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorBlockIssuerKey.Multiply(VBytes(key.Size()))
 }

--- a/builder/output_builder.go
+++ b/builder/output_builder.go
@@ -1,7 +1,6 @@
 package builder
 
 import (
-	"bytes"
 	"math"
 
 	"github.com/iotaledger/hive.go/ierrors"
@@ -457,7 +456,7 @@ func (trans *blockIssuerTransition) AddKeys(keys ...iotago.BlockIssuerKey) *bloc
 // RemoveKey deletes the key of the iotago.BlockIssuerFeature.
 func (trans *blockIssuerTransition) RemoveKey(keyToDelete iotago.BlockIssuerKey) *blockIssuerTransition {
 	for i, blockIssuerKey := range trans.feature.BlockIssuerKeys {
-		if bytes.Equal(keyToDelete.BlockIssuerKeyBytes(), blockIssuerKey.BlockIssuerKeyBytes()) {
+		if blockIssuerKey.Equal(keyToDelete) {
 			// To remove the element at index i, we move the last element to this index.
 			trans.feature.BlockIssuerKeys[i] = trans.feature.BlockIssuerKeys[len(trans.feature.BlockIssuerKeys)-1]
 			// Then we reduce the slice length by one to effectively remove the last element.

--- a/feat_blockissuer.go
+++ b/feat_blockissuer.go
@@ -1,8 +1,6 @@
 package iotago
 
 import (
-	"bytes"
-
 	"github.com/iotaledger/hive.go/serializer/v2"
 )
 
@@ -45,7 +43,7 @@ func (s *BlockIssuerFeature) Equal(other Feature) bool {
 		return false
 	}
 	for i := range s.BlockIssuerKeys {
-		if !bytes.Equal(s.BlockIssuerKeys[i].BlockIssuerKeyBytes(), otherFeat.BlockIssuerKeys[i].BlockIssuerKeyBytes()) {
+		if !s.BlockIssuerKeys[i].Equal(otherFeat.BlockIssuerKeys[i]) {
 			return false
 		}
 	}


### PR DESCRIPTION
We used the common serix API, which was wrong because the types are not registered there.