### PR TITLE
Add Equal method to Outputs

### DIFF
--- a/address.go
+++ b/address.go
@@ -105,6 +105,7 @@ type Address interface {
 	NonEphemeralObject
 	fmt.Stringer
 	constraints.Cloneable[Address]
+	constraints.Equalable[Address]
 
 	// Type returns the type of the address.
 	Type() AddressType
@@ -115,9 +116,6 @@ type Address interface {
 
 	// Bech32 encodes the address as a bech32 string.
 	Bech32(hrp NetworkPrefix) string
-
-	// Equal checks whether other is equal to this Address.
-	Equal(other Address) bool
 
 	// Key returns a string which can be used to index the Address in a map.
 	Key() string

--- a/block_issuer_key.go
+++ b/block_issuer_key.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"slices"
 
+	"github.com/iotaledger/hive.go/constraints"
 	"github.com/iotaledger/hive.go/ierrors"
 	"github.com/iotaledger/hive.go/serializer/v2"
 )
@@ -67,11 +68,10 @@ func (keys BlockIssuerKeys) VBytes(rentStruct *RentStructure, _ VBytesFunc) VByt
 type BlockIssuerKey interface {
 	Sizer
 	NonEphemeralObject
+	constraints.Equalable[BlockIssuerKey]
 
 	// Bytes returns a byte slice consisting of the type prefix and the unique identifier of the key.
 	Bytes() []byte
 	// Type returns the BlockIssuerKeyType.
 	Type() BlockIssuerKeyType
-	// Equal checks whether other is equal to this BlockIssuerKey.
-	Equal(other BlockIssuerKey) bool
 }

--- a/feat.go
+++ b/feat.go
@@ -23,12 +23,10 @@ type Feature interface {
 	NonEphemeralObject
 	ProcessableObject
 	constraints.Cloneable[Feature]
+	constraints.Equalable[Feature]
 
 	// Type returns the type of the Feature.
 	Type() FeatureType
-
-	// Equal tells whether this Feature is equal to other.
-	Equal(other Feature) bool
 }
 
 // FeatureType defines the type of features.
@@ -136,8 +134,9 @@ func (f Features[T]) Equal(other Features[T]) bool {
 	if len(f) != len(other) {
 		return false
 	}
-	for i, feat := range f {
-		if !feat.Equal(other[i]) {
+
+	for idx, feat := range f {
+		if !feat.Equal(other[idx]) {
 			return false
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.3
 	github.com/ethereum/go-ethereum v1.12.2
-	github.com/iotaledger/hive.go/constraints v0.0.0-20230921132212-c286a9bd46ea
+	github.com/iotaledger/hive.go/constraints v0.0.0-20230926103137-8f457ed70521
 	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230921132212-c286a9bd46ea
 	github.com/iotaledger/hive.go/crypto v0.0.0-20230921132212-c286a9bd46ea
 	github.com/iotaledger/hive.go/ierrors v0.0.0-20230921132212-c286a9bd46ea

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o
 github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
 github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
-github.com/iotaledger/hive.go/constraints v0.0.0-20230921132212-c286a9bd46ea h1:g3AtHNI6MNhhjDjh91JYoHRYpjcIWQoLjGEqO6Mvxrw=
-github.com/iotaledger/hive.go/constraints v0.0.0-20230921132212-c286a9bd46ea/go.mod h1:dOBOM2s4se3HcWefPe8sQLUalGXJ8yVXw58oK8jke3s=
+github.com/iotaledger/hive.go/constraints v0.0.0-20230926103137-8f457ed70521 h1:+Ugqsn7jqmghi0lI432L2hN/N62rRzAfQOBJvSY15BE=
+github.com/iotaledger/hive.go/constraints v0.0.0-20230926103137-8f457ed70521/go.mod h1:dOBOM2s4se3HcWefPe8sQLUalGXJ8yVXw58oK8jke3s=
 github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230921132212-c286a9bd46ea h1:B4fy7MUg4CKv7ytjT+7PE7niEqmw6DHXOv9UMaD2o7c=
 github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230921132212-c286a9bd46ea/go.mod h1:jn3TNmiNRIiQm/rS4VD+7wFHI2+UXABHvCA3PbQxBqI=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230921132212-c286a9bd46ea h1:8hAOYMoDZLGDr6oqok+LjC64OAffHNH2Q5eisF55LWA=

--- a/output.go
+++ b/output.go
@@ -37,6 +37,7 @@ type Output interface {
 	NonEphemeralObject
 	ProcessableObject
 	constraints.Cloneable[Output]
+	constraints.Equalable[Output]
 
 	// BaseTokenAmount returns the amount of base tokens held by this Output.
 	BaseTokenAmount() BaseToken

--- a/output_account.go
+++ b/output_account.go
@@ -1,6 +1,8 @@
 package iotago
 
 import (
+	"bytes"
+
 	"golang.org/x/crypto/blake2b"
 
 	"github.com/iotaledger/hive.go/ierrors"
@@ -192,6 +194,55 @@ func (a *AccountOutput) Clone() Output {
 		Features:          a.Features.Clone(),
 		ImmutableFeatures: a.ImmutableFeatures.Clone(),
 	}
+}
+
+func (a *AccountOutput) Equal(other Output) bool {
+	otherOutput, isSameType := other.(*AccountOutput)
+	if !isSameType {
+		return false
+	}
+
+	if a.Amount != otherOutput.Amount {
+		return false
+	}
+
+	if a.Mana != otherOutput.Mana {
+		return false
+	}
+
+	if !a.NativeTokens.Equal(otherOutput.NativeTokens) {
+		return false
+	}
+
+	if a.AccountID != otherOutput.AccountID {
+		return false
+	}
+
+	if a.StateIndex != otherOutput.StateIndex {
+		return false
+	}
+
+	if !bytes.Equal(a.StateMetadata, otherOutput.StateMetadata) {
+		return false
+	}
+
+	if a.FoundryCounter != otherOutput.FoundryCounter {
+		return false
+	}
+
+	if !a.Conditions.Equal(otherOutput.Conditions) {
+		return false
+	}
+
+	if !a.Features.Equal(otherOutput.Features) {
+		return false
+	}
+
+	if !a.ImmutableFeatures.Equal(otherOutput.ImmutableFeatures) {
+		return false
+	}
+
+	return true
 }
 
 func (a *AccountOutput) UnlockableBy(ident Address, next TransDepIdentOutput, pastBoundedSlotIndex SlotIndex, futureBoundedSlotIndex SlotIndex) (bool, error) {

--- a/output_basic.go
+++ b/output_basic.go
@@ -43,6 +43,35 @@ func (e *BasicOutput) Clone() Output {
 	}
 }
 
+func (e *BasicOutput) Equal(other Output) bool {
+	otherOutput, isSameType := other.(*BasicOutput)
+	if !isSameType {
+		return false
+	}
+
+	if e.Amount != otherOutput.Amount {
+		return false
+	}
+
+	if e.Mana != otherOutput.Mana {
+		return false
+	}
+
+	if !e.NativeTokens.Equal(otherOutput.NativeTokens) {
+		return false
+	}
+
+	if !e.Conditions.Equal(otherOutput.Conditions) {
+		return false
+	}
+
+	if !e.Features.Equal(otherOutput.Features) {
+		return false
+	}
+
+	return true
+}
+
 func (e *BasicOutput) UnlockableBy(ident Address, pastBoundedSlotIndex SlotIndex, futureBoundedSlotIndex SlotIndex) bool {
 	ok, _ := outputUnlockableBy(e, nil, ident, pastBoundedSlotIndex, futureBoundedSlotIndex)
 	return ok

--- a/output_delegation.go
+++ b/output_delegation.go
@@ -125,6 +125,43 @@ func (d *DelegationOutput) Clone() Output {
 	}
 }
 
+func (d *DelegationOutput) Equal(other Output) bool {
+	otherOutput, isSameType := other.(*DelegationOutput)
+	if !isSameType {
+		return false
+	}
+
+	if d.Amount != otherOutput.Amount {
+		return false
+	}
+
+	if d.DelegatedAmount != otherOutput.DelegatedAmount {
+		return false
+	}
+
+	if d.DelegationID != otherOutput.DelegationID {
+		return false
+	}
+
+	if !d.ValidatorAddress.Equal(otherOutput.ValidatorAddress) {
+		return false
+	}
+
+	if d.StartEpoch != otherOutput.StartEpoch {
+		return false
+	}
+
+	if d.EndEpoch != otherOutput.EndEpoch {
+		return false
+	}
+
+	if !d.Conditions.Equal(otherOutput.Conditions) {
+		return false
+	}
+
+	return true
+}
+
 func (d *DelegationOutput) Ident() Address {
 	return d.Conditions.MustSet().Address().Address
 }

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -109,6 +109,43 @@ func (f *FoundryOutput) Clone() Output {
 	}
 }
 
+func (f *FoundryOutput) Equal(other Output) bool {
+	otherOutput, isSameType := other.(*FoundryOutput)
+	if !isSameType {
+		return false
+	}
+
+	if f.Amount != otherOutput.Amount {
+		return false
+	}
+
+	if !f.NativeTokens.Equal(otherOutput.NativeTokens) {
+		return false
+	}
+
+	if f.SerialNumber != otherOutput.SerialNumber {
+		return false
+	}
+
+	if !f.TokenScheme.Equal(otherOutput.TokenScheme) {
+		return false
+	}
+
+	if !f.Conditions.Equal(otherOutput.Conditions) {
+		return false
+	}
+
+	if !f.Features.Equal(otherOutput.Features) {
+		return false
+	}
+
+	if !f.ImmutableFeatures.Equal(otherOutput.ImmutableFeatures) {
+		return false
+	}
+
+	return true
+}
+
 func (f *FoundryOutput) Ident() Address {
 	return f.UnlockConditionSet().ImmutableAccount().Address
 }

--- a/output_nft.go
+++ b/output_nft.go
@@ -112,6 +112,43 @@ func (n *NFTOutput) Clone() Output {
 	}
 }
 
+func (n *NFTOutput) Equal(other Output) bool {
+	otherOutput, isSameType := other.(*NFTOutput)
+	if !isSameType {
+		return false
+	}
+
+	if n.Amount != otherOutput.Amount {
+		return false
+	}
+
+	if n.Mana != otherOutput.Mana {
+		return false
+	}
+
+	if !n.NativeTokens.Equal(otherOutput.NativeTokens) {
+		return false
+	}
+
+	if n.NFTID != otherOutput.NFTID {
+		return false
+	}
+
+	if !n.Conditions.Equal(otherOutput.Conditions) {
+		return false
+	}
+
+	if !n.Features.Equal(otherOutput.Features) {
+		return false
+	}
+
+	if !n.ImmutableFeatures.Equal(otherOutput.ImmutableFeatures) {
+		return false
+	}
+
+	return true
+}
+
 func (n *NFTOutput) Ident() Address {
 	return n.Conditions.MustSet().Address().Address
 }

--- a/token_scheme.go
+++ b/token_scheme.go
@@ -35,6 +35,7 @@ type TokenScheme interface {
 	NonEphemeralObject
 	ProcessableObject
 	constraints.Cloneable[TokenScheme]
+	constraints.Equalable[TokenScheme]
 
 	// Type returns the type of the TokenScheme.
 	Type() TokenSchemeType

--- a/token_scheme_simple.go
+++ b/token_scheme_simple.go
@@ -37,6 +37,27 @@ func (s *SimpleTokenScheme) Clone() TokenScheme {
 	}
 }
 
+func (s *SimpleTokenScheme) Equal(other TokenScheme) bool {
+	otherTokenScheme, isSameType := other.(*SimpleTokenScheme)
+	if !isSameType {
+		return false
+	}
+
+	if s.MintedTokens.Cmp(otherTokenScheme.MintedTokens) != 0 {
+		return false
+	}
+
+	if s.MeltedTokens.Cmp(otherTokenScheme.MeltedTokens) != 0 {
+		return false
+	}
+
+	if s.MaximumSupply.Cmp(otherTokenScheme.MaximumSupply) != 0 {
+		return false
+	}
+
+	return true
+}
+
 func (s *SimpleTokenScheme) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	return rentStruct.VBFactorData.Multiply(serializer.OneByte) +
 		// minted/melted supply, max. supply

--- a/unlock_cond.go
+++ b/unlock_cond.go
@@ -74,16 +74,28 @@ type UnlockCondition interface {
 	NonEphemeralObject
 	ProcessableObject
 	constraints.Cloneable[UnlockCondition]
+	constraints.Equalable[UnlockCondition]
 
 	// Type returns the type of the UnlockCondition.
 	Type() UnlockConditionType
-
-	// Equal tells whether this UnlockCondition is equal to other.
-	Equal(other UnlockCondition) bool
 }
 
 // UnlockConditions is a slice of UnlockCondition(s).
 type UnlockConditions[T UnlockCondition] []T
+
+func (f UnlockConditions[T]) Equal(other UnlockConditions[T]) bool {
+	if len(f) != len(other) {
+		return false
+	}
+
+	for idx, unlockCondition := range f {
+		if !unlockCondition.Equal(other[idx]) {
+			return false
+		}
+	}
+
+	return true
+}
 
 func (f UnlockConditions[T]) VBytes(rentStruct *RentStructure, _ VBytesFunc) VBytes {
 	var sumCost VBytes


### PR DESCRIPTION
This PR adds the `constraints.Equalable` to `Output`.
This way we can compare outputs for equality.