### PR TITLE
Test for empty Validator Address syntactically

### DIFF
--- a/output_delegation.go
+++ b/output_delegation.go
@@ -34,7 +34,9 @@ var (
 	ErrInvalidDelegationEndEpoch = ierrors.New("invalid end epoch")
 	// ErrDelegationCommitmentInputRequired gets returned when no commitment input was passed in a TX containing a Delegation Output.
 	ErrDelegationCommitmentInputRequired = ierrors.New("delegation output validation requires a commitment input")
-	emptyDelegationID                    = [DelegationIDLength]byte{}
+	// ErrDelegationValidatorAddressEmpty gets returned when the Validator Address in a Delegation Output is empty.
+	ErrDelegationValidatorAddressEmpty = ierrors.New("delegation output's validator address is empty")
+	emptyDelegationID                  = [DelegationIDLength]byte{}
 )
 
 func EmptyDelegationID() DelegationID {
@@ -179,6 +181,10 @@ func (d *DelegationOutput) StorageScore(rentStruct *RentStructure, _ StorageScor
 }
 
 func (d *DelegationOutput) syntacticallyValidate() error {
+	if d.ValidatorAddress.AccountID().Empty() {
+		return ErrDelegationValidatorAddressEmpty
+	}
+
 	// Address should never be nil.
 	address := d.Conditions.MustSet().Address().Address
 

--- a/output_test.go
+++ b/output_test.go
@@ -75,6 +75,8 @@ func TestOutputIDString(t *testing.T) {
 }
 
 func TestOutputsDeSerialize(t *testing.T) {
+	emptyAccountAddress := iotago.AccountAddress(iotago.EmptyAccountID())
+
 	tests := []deSerializeTest{
 		{
 			name: "ok - BasicOutput",
@@ -208,6 +210,49 @@ func TestOutputsDeSerialize(t *testing.T) {
 			},
 			target:  &iotago.DelegationOutput{},
 			seriErr: iotago.ErrImplicitAccountCreationAddressInInvalidOutput,
+		},
+		{
+			name: "fail - NFT Output contains Implicit Account Creation Address",
+			source: &iotago.NFTOutput{
+				Conditions: iotago.NFTOutputUnlockConditions{
+					&iotago.AddressUnlockCondition{Address: tpkg.RandImplicitAccountCreationAddress()},
+				},
+			},
+			target:  &iotago.NFTOutput{},
+			seriErr: iotago.ErrImplicitAccountCreationAddressInInvalidOutput,
+		},
+		{
+			name: "fail - Account Output contains Implicit Account Creation Address as State Controller",
+			source: &iotago.AccountOutput{
+				Conditions: iotago.AccountOutputUnlockConditions{
+					&iotago.StateControllerAddressUnlockCondition{Address: tpkg.RandImplicitAccountCreationAddress()},
+					&iotago.GovernorAddressUnlockCondition{Address: tpkg.RandEd25519Address()},
+				},
+			},
+			target:  &iotago.AccountOutput{},
+			seriErr: iotago.ErrImplicitAccountCreationAddressInInvalidOutput,
+		},
+		{
+			name: "fail - Account Output contains Implicit Account Creation Address as Governor",
+			source: &iotago.AccountOutput{
+				Conditions: iotago.AccountOutputUnlockConditions{
+					&iotago.StateControllerAddressUnlockCondition{Address: tpkg.RandEd25519Address()},
+					&iotago.GovernorAddressUnlockCondition{Address: tpkg.RandImplicitAccountCreationAddress()},
+				},
+			},
+			target:  &iotago.AccountOutput{},
+			seriErr: iotago.ErrImplicitAccountCreationAddressInInvalidOutput,
+		},
+		{
+			name: "fail - Delegation Output contains empty validator address",
+			source: &iotago.DelegationOutput{
+				ValidatorAddress: &emptyAccountAddress,
+				Conditions: iotago.DelegationOutputUnlockConditions{
+					&iotago.AddressUnlockCondition{Address: tpkg.RandEd25519Address()},
+				},
+			},
+			target:  &iotago.DelegationOutput{},
+			seriErr: iotago.ErrDelegationValidatorAddressEmpty,
 		},
 	}
 


### PR DESCRIPTION
# Description of change

Test for empty Validator Address syntactically which was missing previously.

Also add tests for implicit account creation address syntax checks.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added tests.