### PR TITLE
Use serix duplication check for Multi Address

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -658,10 +658,10 @@ func TestMultiAddressSyntacticalValidation(t *testing.T) {
 			}
 		}(),
 
-		// fail - raw address part of all addresses inside MultiAddress need to be unique
+		// fail - the binary encoding of all addresses inside a MultiAddress need to be unique
 		func() *outputsSyntacticalValidationTest {
 			return &outputsSyntacticalValidationTest{
-				name:           "fail - raw address part of all addresses inside MultiAddress need to be unique",
+				name:           "fail - the binary encoding of all addresses inside a MultiAddress need to be unique",
 				ed25519AddrCnt: 1,
 				outputsFunc: func(ed25519Addresses []iotago.Address) iotago.TxEssenceOutputs {
 					return iotago.TxEssenceOutputs{

--- a/api_common.go
+++ b/api_common.go
@@ -19,9 +19,8 @@ var (
 
 	// multiAddressValidatorFunc is a validator which checks that:
 	//  1. ImplicitAccountCreationAddress, MultiAddresses, RestrictedAddress are not nested inside the MultiAddress.
-	//  2. "raw address part" of all addresses are unique (without type byte and capabilities).
-	//  3. The weight of each address is at least 1.
-	//  4. The threshold is smaller or equal to the cumulative weight of all addresses.
+	//  2. The weight of each address is at least 1.
+	//  3. The threshold is smaller or equal to the cumulative weight of all addresses.
 	multiAddressValidatorFunc = func(ctx context.Context, addr MultiAddress) error {
 		var cumulativeWeight uint16
 		for idx, address := range addr.Addresses {

--- a/api_common.go
+++ b/api_common.go
@@ -14,7 +14,7 @@ var (
 	addressesWithWeightArrRules = &serix.ArrayRules{
 		Min:            1,
 		Max:            10,
-		ValidationMode: serializer.ArrayValidationModeLexicalOrdering,
+		ValidationMode: serializer.ArrayValidationModeLexicalOrdering | serializer.ArrayValidationModeNoDuplicates,
 	}
 
 	// multiAddressValidatorFunc is a validator which checks that:
@@ -23,19 +23,12 @@ var (
 	//  3. The weight of each address is at least 1.
 	//  4. The threshold is smaller or equal to the cumulative weight of all addresses.
 	multiAddressValidatorFunc = func(ctx context.Context, addr MultiAddress) error {
-		addrSet := map[string]int{}
-
 		var cumulativeWeight uint16
 		for idx, address := range addr.Addresses {
-			var addrWithoutTypeAndCapabilities []byte
-
 			switch addr := address.Address.(type) {
 			case *Ed25519Address:
-				addrWithoutTypeAndCapabilities = addr[:]
 			case *AccountAddress:
-				addrWithoutTypeAndCapabilities = addr[:]
 			case *NFTAddress:
-				addrWithoutTypeAndCapabilities = addr[:]
 			case *ImplicitAccountCreationAddress:
 				return ierrors.Wrapf(ErrInvalidNestedAddressType, "address with index %d is an implicit account creation address inside a multi address", idx)
 			case *MultiAddress:
@@ -45,14 +38,6 @@ var (
 			default:
 				return ierrors.Wrapf(ErrUnknownAddrType, "address with index %d has an unknown address type (%T) inside a multi address", idx, addr)
 			}
-
-			// we need to check for uniqueness of the address, but instead of the whole serialized address, we need to ignore
-			// different address types or capabilities, that might result in the same signature.
-			addrString := string(addrWithoutTypeAndCapabilities)
-			if j, has := addrSet[addrString]; has {
-				return ierrors.Wrapf(serializer.ErrArrayValidationViolatesUniqueness, "addresses with indices %d and %d in multi address are duplicates", j, idx)
-			}
-			addrSet[addrString] = idx
 
 			// check for minimum address weight
 			if address.Weight == 0 {


### PR DESCRIPTION
# Description of change

Use serix duplication check for Multi Address instead of reimplementing it.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

`fail - the binary encoding of all addresses inside a MultiAddress need to be unique` tests that the serix uniqueness check works.