### PR TITLE
Add mutation proof and make TransactionIDs serializable with serix

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -168,6 +168,10 @@ var (
 	blockIDsArrRules = &serix.ArrayRules{
 		ValidationMode: serializer.ArrayValidationModeNoDuplicates | serializer.ArrayValidationModeLexicalOrdering,
 	}
+
+	transactionIDsArrRules = &serix.ArrayRules{
+		ValidationMode: serializer.ArrayValidationModeNoDuplicates | serializer.ArrayValidationModeLexicalOrdering,
+	}
 )
 
 // v3api implements the iota-core 1.0 protocol core models.
@@ -578,6 +582,12 @@ func V3API(protoParams ProtocolParameters) API {
 	{
 		must(api.RegisterTypeSettings(BlockIDs{},
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsUint32).WithArrayRules(blockIDsArrRules),
+		))
+	}
+
+	{
+		must(api.RegisterTypeSettings(TransactionIDs{},
+			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsUint32).WithArrayRules(transactionIDsArrRules),
 		))
 	}
 

--- a/commitment_roots.go
+++ b/commitment_roots.go
@@ -67,6 +67,12 @@ func (r *Roots) TangleProof() *merklehasher.Proof[Identifier] {
 	return lo.PanicOnErr(merklehasher.NewHasher[Identifier](crypto.BLAKE2b_256).ComputeProofForIndex(r.values(), 0))
 }
 
+func (r *Roots) MutationProof() *merklehasher.Proof[Identifier] {
+	// We can ignore the error because Identifier.Bytes() will never return an error
+	//nolint:nosnakecase // false positive
+	return lo.PanicOnErr(merklehasher.NewHasher[Identifier](crypto.BLAKE2b_256).ComputeProofForIndex(r.values(), 1))
+}
+
 func VerifyProof(proof *merklehasher.Proof[Identifier], proofedRoot Identifier, treeRoot Identifier) bool {
 	// We can ignore the error because Identifier.Bytes() will never return an error
 	if !lo.PanicOnErr(proof.ContainsValue(proofedRoot)) {

--- a/signed_transaction.go
+++ b/signed_transaction.go
@@ -61,7 +61,7 @@ func SignedTransactionIDFromData(creationSlot SlotIndex, data []byte) SignedTran
 type TransactionID = SlotIdentifier
 
 // TransactionIDs are IDs of transactions.
-type TransactionIDs []SignedTransactionID
+type TransactionIDs []TransactionID
 
 // TransactionIDFromData returns a new SignedTransactionID for the given data by hashing it with blake2b and appending the creation slot index.
 func TransactionIDFromData(creationSlot SlotIndex, data []byte) TransactionID {


### PR DESCRIPTION
This PR adds a method to create a `MutationProof` from `Roots` and makes `TransactionID` serializable with serix by adding a rule for it.