### PR TITLE
Add PoW worker code for blockissuer client

### DIFF
--- a/blockissuer/pow/pow.go
+++ b/blockissuer/pow/pow.go
@@ -13,12 +13,14 @@ import (
 
 const (
 	// Hash defines the hash function that is used to compute the PoW digest.
-	//nolint:nosnakecase
-	Hash = crypto.BLAKE2b_256
+	Hash = crypto.BLAKE2b_256 //nolint:nosnakecase
+
 	// HashLength defines the length of the hash function in bytes.
 	HashLength = blake2b.Size256
+
 	// NonceLength defines the length of the nonce in bytes.
 	NonceLength = serializer.UInt64ByteSize
+
 	// MaxTrailingZeros defines the maximum amount of trailing zeros.
 	MaxTrailingZeros = serializer.UInt64ByteSize * 8
 )

--- a/blockissuer/pow/pow.go
+++ b/blockissuer/pow/pow.go
@@ -11,12 +11,15 @@ import (
 	"github.com/iotaledger/hive.go/serializer/v2/byteutils"
 )
 
-// Hash defines the hash function that is used to compute the PoW digest.
 const (
+	// Hash defines the hash function that is used to compute the PoW digest.
 	//nolint:nosnakecase
-	Hash             = crypto.BLAKE2b_256
-	HashLength       = blake2b.Size256
-	NonceLength      = serializer.UInt64ByteSize
+	Hash = crypto.BLAKE2b_256
+	// HashLength defines the length of the hash function in bytes.
+	HashLength = blake2b.Size256
+	// NonceLength defines the length of the nonce in bytes.
+	NonceLength = serializer.UInt64ByteSize
+	// MaxTrailingZeros defines the maximum amount of trailing zeros.
 	MaxTrailingZeros = serializer.UInt64ByteSize * 8
 )
 

--- a/blockissuer/pow/pow.go
+++ b/blockissuer/pow/pow.go
@@ -1,0 +1,35 @@
+package pow
+
+import (
+	"crypto"
+	"encoding/binary"
+	"math/bits"
+
+	"golang.org/x/crypto/blake2b"
+
+	"github.com/iotaledger/hive.go/serializer/v2"
+	"github.com/iotaledger/hive.go/serializer/v2/byteutils"
+)
+
+// Hash defines the hash function that is used to compute the PoW digest.
+const (
+	//nolint:nosnakecase
+	Hash             = crypto.BLAKE2b_256
+	HashLength       = blake2b.Size256
+	NonceLength      = serializer.UInt64ByteSize
+	MaxTrailingZeros = serializer.UInt64ByteSize * 8
+)
+
+// TrailingZeros returns amount of trailing zeros for the hash of the given msg and nonce.
+func TrailingZeros(msgBytes []byte, nonce uint64) int {
+	nonceData := make([]byte, NonceLength)
+	binary.LittleEndian.PutUint64(nonceData, nonce)
+
+	// calculate the hash of the concatenation of the msg and the nonce.
+	h := Hash.New()
+	h.Write(byteutils.ConcatBytes(msgBytes, nonceData))
+	hash := h.Sum(nil)
+
+	// calculate the amount of trailing zeros
+	return bits.TrailingZeros64(binary.LittleEndian.Uint64(hash[HashLength-serializer.UInt64ByteSize : HashLength]))
+}

--- a/blockissuer/pow/pow_test.go
+++ b/blockissuer/pow/pow_test.go
@@ -1,0 +1,48 @@
+//#nosec G404
+
+package pow_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/blake2b"
+
+	"github.com/iotaledger/hive.go/ierrors"
+	"github.com/iotaledger/iota.go/v4/blockissuer/pow"
+)
+
+const (
+	workers             = 2
+	targetTrailingZeros = 10
+)
+
+var testWorker = pow.New(workers)
+
+func TestWorker_Mine(t *testing.T) {
+	msg := []byte("Hello, World!")
+	nonce, err := testWorker.Mine(context.Background(), msg, targetTrailingZeros)
+	require.NoError(t, err)
+
+	// check the result
+	msgDigest := blake2b.Sum256(msg)
+	trailingZeros := pow.TrailingZeros(msgDigest[:], nonce)
+	assert.GreaterOrEqual(t, trailingZeros, targetTrailingZeros)
+}
+
+func TestWorker_Cancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var err error
+	go func() {
+		_, err = testWorker.Mine(ctx, nil, 64)
+	}()
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	assert.Eventually(t, func() bool { return ierrors.Is(err, pow.ErrCancelled) }, time.Second, 10*time.Millisecond)
+}

--- a/blockissuer/pow/pow_test.go
+++ b/blockissuer/pow/pow_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 const (
-	workers             = 2
+	workerCount         = 2
 	targetTrailingZeros = 10
 )
 
-var testWorker = pow.New(workers)
+var testWorker = pow.New(workerCount)
 
 func TestWorker_Mine(t *testing.T) {
 	msg := []byte("Hello, World!")
@@ -44,5 +44,5 @@ func TestWorker_Cancel(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	cancel()
 
-	assert.Eventually(t, func() bool { return ierrors.Is(err, pow.ErrCancelled) }, time.Second, 10*time.Millisecond)
+	assert.Eventually(t, func() bool { return ierrors.Is(err, pow.ErrCanceled) }, time.Second, 10*time.Millisecond)
 }

--- a/blockissuer/pow/worker.go
+++ b/blockissuer/pow/worker.go
@@ -12,6 +12,7 @@ import (
 var (
 	// ErrCanceled gets returned when the context for the PoW was canceled.
 	ErrCanceled = ierrors.New("canceled")
+
 	// ErrDone gets returned when the PoW was done but no valid nonce was found.
 	ErrDone = ierrors.New("done")
 )

--- a/blockissuer/pow/worker.go
+++ b/blockissuer/pow/worker.go
@@ -9,10 +9,11 @@ import (
 	"github.com/iotaledger/hive.go/ierrors"
 )
 
-// errors returned by the PoW.
 var (
-	ErrCancelled = ierrors.New("canceled")
-	ErrDone      = ierrors.New("done")
+	// ErrCanceled gets returned when the context for the PoW was canceled.
+	ErrCanceled = ierrors.New("canceled")
+	// ErrDone gets returned when the PoW was done but no valid nonce was found.
+	ErrDone = ierrors.New("done")
 )
 
 // The Worker performs the PoW.
@@ -80,7 +81,7 @@ func (w *Worker) Mine(ctx context.Context, data []byte, targetTrailingZeros int)
 
 	nonce, ok := <-results
 	if !ok {
-		return 0, ErrCancelled
+		return 0, ErrCanceled
 	}
 
 	return nonce, nil

--- a/blockissuer/pow/worker.go
+++ b/blockissuer/pow/worker.go
@@ -1,0 +1,101 @@
+package pow
+
+import (
+	"context"
+	"math"
+	"sync"
+	"sync/atomic"
+
+	"github.com/iotaledger/hive.go/ierrors"
+)
+
+// errors returned by the PoW.
+var (
+	ErrCancelled = ierrors.New("canceled")
+	ErrDone      = ierrors.New("done")
+)
+
+// The Worker performs the PoW.
+type Worker struct {
+	numWorkers int
+}
+
+// New creates a new PoW Worker.
+// The optional numWorkers specifies how many go routines should be used to perform the PoW.
+func New(numWorkers ...int) *Worker {
+	w := &Worker{
+		numWorkers: 1,
+	}
+	if len(numWorkers) > 0 && numWorkers[0] > 0 {
+		w.numWorkers = numWorkers[0]
+	}
+
+	return w
+}
+
+// Mine performs the PoW for data.
+// It returns a nonce that appended to data results in at least targetTrailingZeros.
+// The computation can be canceled anytime using ctx.
+func (w *Worker) Mine(ctx context.Context, data []byte, targetTrailingZeros int) (uint64, error) {
+	var (
+		done    uint32
+		wg      sync.WaitGroup
+		results = make(chan uint64, w.numWorkers)
+		closing = make(chan struct{})
+	)
+
+	// compute the digest
+	h := Hash.New()
+	h.Write(data)
+	powDigest := h.Sum(nil)
+
+	// stop when the context has been canceled
+	go func() {
+		select {
+		case <-ctx.Done():
+			atomic.StoreUint32(&done, 1)
+		case <-closing:
+			return
+		}
+	}()
+
+	workerWidth := math.MaxUint64 / uint64(w.numWorkers)
+	for i := 0; i < w.numWorkers; i++ {
+		startNonce := uint64(i) * workerWidth
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			nonce, workerErr := w.worker(powDigest, startNonce, targetTrailingZeros, &done)
+			if workerErr != nil {
+				return
+			}
+			atomic.StoreUint32(&done, 1)
+			results <- nonce
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(closing)
+
+	nonce, ok := <-results
+	if !ok {
+		return 0, ErrCancelled
+	}
+
+	return nonce, nil
+}
+
+func (w *Worker) worker(powDigest []byte, startNonce uint64, targetTrailingZeros int, done *uint32) (uint64, error) {
+	if targetTrailingZeros > MaxTrailingZeros {
+		panic("pow: invalid target trailing zeros")
+	}
+
+	for nonce := startNonce; atomic.LoadUint32(done) == 0; nonce++ {
+		if trailingZeros := TrailingZeros(powDigest, nonce); trailingZeros >= targetTrailingZeros {
+			return nonce, nil
+		}
+	}
+
+	return 0, ErrDone
+}


### PR DESCRIPTION
We protect the blockissuance service providers with blake2b PoW from client side.

This is not on protocol level. IOTA 2.0 replaced PoW with congestion control (Mana) on protocol level.