### PR TITLE
Allow Restricted Addresses in Sender & Issuer Feature

### DIFF
--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -5144,7 +5144,7 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 			require.NoError(t, err)
 
 			return &test{
-				name: "ok - multi addr in sender feature",
+				name: "ok - multi address in sender feature",
 				vmParams: &vm.Params{
 					API: testAPI,
 				},
@@ -5230,7 +5230,7 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 			require.NoError(t, err)
 
 			return &test{
-				name: "ok - restricted multi addr in sender feature",
+				name: "ok - restricted multi address in sender and issuer feature",
 				vmParams: &vm.Params{
 					API: testAPI,
 				},

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -325,7 +325,9 @@ func IsIssuerOnOutputUnlocked(output iotago.ChainOutputImmutable, unlockedIdents
 	if issuerFeat == nil {
 		return nil
 	}
-	if _, isUnlocked := unlockedIdents[issuerFeat.Address.Key()]; !isUnlocked {
+
+	issuer := resolveUnderlyingIdent(issuerFeat.Address)
+	if _, isUnlocked := unlockedIdents[issuer.Key()]; !isUnlocked {
 		return iotago.ErrIssuerFeatureNotUnlocked
 	}
 
@@ -570,7 +572,7 @@ func ExecFuncSenderUnlocked() ExecFunc {
 			}
 
 			// check unlocked
-			sender := senderFeat.Address
+			sender := resolveUnderlyingIdent(senderFeat.Address)
 			if _, isUnlocked := vmParams.WorkingSet.UnlockedIdents[sender.Key()]; !isUnlocked {
 				return ierrors.Wrapf(iotago.ErrSenderFeatureNotUnlocked, "output %d", outputIndex)
 			}


### PR DESCRIPTION
# Description of change

Before this change, putting a Restricted Address(Ed25519 Address X) in a Sender Feature where Ed25519 Address X was unlocked resulted in an invalid transaction. This is because during unlocking, the Restricted Address is resolved to its underlying address, but the sender and issuer features were not doing this resolution step.

Two reasonable ways of dealing with this would be to 1) disallow Restricted Addresses in those features or 2) adding the resolution step during the validation of those features.

The reason for choosing 2) is that users then do not have to be aware of this special handling of Restricted Addresses. They can simply put the address that is unlocked on the input side in the Sender/Issuer Feature on the output side and be done, perhaps not even being aware that a restricted address is used. If we forced users to put the underlying address into those features, they could no longer abstract over addresses as nicely as before where they can always deal with an abstract address.

Another secondary reason is that the code change for 2) is simpler than for 1). In 1) we would have to to add custom syntactic validation in those features or introduce more serix rules.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Added tests for sender & issuer feature with a Multi Address contained in a Restricted Address.