### PR TITLE
Cleanup and reset payload and output type prefixes

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -284,7 +284,7 @@ func V3API(protoParams ProtocolParameters) API {
 	}
 
 	must(api.RegisterTypeSettings(TaggedData{},
-		serix.TypeSettings{}.WithObjectType(uint32(PayloadTaggedData))),
+		serix.TypeSettings{}.WithObjectType(uint8(PayloadTaggedData))),
 	)
 
 	{
@@ -569,7 +569,7 @@ func V3API(protoParams ProtocolParameters) API {
 	}
 
 	{
-		must(api.RegisterTypeSettings(SignedTransaction{}, serix.TypeSettings{}.WithObjectType(uint32(PayloadSignedTransaction))))
+		must(api.RegisterTypeSettings(SignedTransaction{}, serix.TypeSettings{}.WithObjectType(uint8(PayloadSignedTransaction))))
 		must(api.RegisterTypeSettings(Unlocks{},
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsUint16).WithArrayRules(txV3UnlocksArrRules),
 		))

--- a/block_test.go
+++ b/block_test.go
@@ -24,17 +24,12 @@ func TestBlock_DeSerialize(t *testing.T) {
 	tests := []deSerializeTest{
 		{
 			name:   "ok - no payload",
-			source: tpkg.RandProtocolBlock(tpkg.RandBasicBlock(tpkg.TestAPI, 1337), tpkg.TestAPI, 0),
+			source: tpkg.RandProtocolBlock(tpkg.RandBasicBlock(tpkg.TestAPI, 255), tpkg.TestAPI, 0),
 			target: &iotago.ProtocolBlock{},
 		},
 		{
 			name:   "ok - transaction",
 			source: tpkg.RandProtocolBlock(tpkg.RandBasicBlock(tpkg.TestAPI, iotago.PayloadSignedTransaction), tpkg.TestAPI, 0),
-			target: &iotago.ProtocolBlock{},
-		},
-		{
-			name:   "ok - milestone",
-			source: tpkg.RandProtocolBlock(tpkg.RandBasicBlock(tpkg.TestAPI, iotago.PayloadMilestone), tpkg.TestAPI, 0),
 			target: &iotago.ProtocolBlock{},
 		},
 		{

--- a/feat.go
+++ b/feat.go
@@ -58,7 +58,7 @@ func (featType FeatureType) String() string {
 }
 
 var featNames = [FeatureStaking + 1]string{
-	"SenderFeature", "Issuer", "MetadataFeature", "TagFeature", "NativeTokenFeature", "BlockIssuerFeature", "StakingFeature",
+	"SenderFeature", "IssuerFeature", "MetadataFeature", "TagFeature", "NativeTokenFeature", "BlockIssuerFeature", "StakingFeature",
 }
 
 // Features is a slice of Feature(s).

--- a/output.go
+++ b/output.go
@@ -64,18 +64,16 @@ type Output interface {
 type OutputType byte
 
 const (
-	// OutputTreasury denotes the type of the TreasuryOutput.
-	OutputTreasury OutputType = 2
 	// OutputBasic denotes an BasicOutput.
-	OutputBasic OutputType = 3
+	OutputBasic OutputType = iota
 	// OutputAccount denotes an AccountOutput.
-	OutputAccount OutputType = 4
+	OutputAccount
 	// OutputFoundry denotes a FoundryOutput.
-	OutputFoundry OutputType = 5
+	OutputFoundry
 	// OutputNFT denotes an NFTOutput.
-	OutputNFT OutputType = 6
+	OutputNFT
 	// OutputDelegation denotes a DelegationOutput.
-	OutputDelegation OutputType = 7
+	OutputDelegation
 )
 
 func (outputType OutputType) String() string {
@@ -87,9 +85,6 @@ func (outputType OutputType) String() string {
 }
 
 var outputNames = [OutputDelegation + 1]string{
-	"SigLockedSingleOutput",
-	"SigLockedDustAllowanceOutput",
-	"TreasuryOutput",
 	"BasicOutput",
 	"AccountOutput",
 	"FoundryOutput",

--- a/output_test.go
+++ b/output_test.go
@@ -18,7 +18,6 @@ func TestOutputTypeString(t *testing.T) {
 		outputTypeString string
 	}{
 		{iotago.OutputNFT, "NFTOutput"},
-		{iotago.OutputTreasury, "TreasuryOutput"},
 		{iotago.OutputBasic, "BasicOutput"},
 		{iotago.OutputAccount, "AccountOutput"},
 		{iotago.OutputFoundry, "FoundryOutput"},
@@ -27,6 +26,7 @@ func TestOutputTypeString(t *testing.T) {
 		require.Equal(t, tt.outputType.String(), tt.outputTypeString)
 	}
 }
+
 func TestOutputsCommitment(t *testing.T) {
 	outputs1 := iotago.Outputs[iotago.Output]{
 		&iotago.BasicOutput{

--- a/payload.go
+++ b/payload.go
@@ -12,24 +12,14 @@ const (
 	MaxPayloadSize = MaxBlockSize - BlockHeaderLength - BasicBlockSizeEmptyParentsAndEmptyPayload - SlotIdentifierLength - Ed25519SignatureSerializedBytesSize
 )
 
-// PayloadType denotes a type of payload.
-type PayloadType uint32
+// PayloadType denotes the type of a payload.
+type PayloadType uint8
 
 const (
-	// Deprecated payload types
-	// PayloadTransactionTIP7 = 0
-	// PayloadMilestoneTIP8 = 1
-	// PayloadIndexationTIP6 = 2
-	// PayloadReceiptTIP17TIP8 = 3.
-
-	// PayloadTreasuryTransaction denotes a TreasuryTransaction.
-	PayloadTreasuryTransaction PayloadType = 4
 	// PayloadTaggedData denotes a TaggedData payload.
-	PayloadTaggedData PayloadType = 5
-	// PayloadMilestone denotes a Milestone.
-	PayloadMilestone PayloadType = 7
+	PayloadTaggedData PayloadType = iota
 	// PayloadSignedTransaction denotes a SignedTransaction.
-	PayloadSignedTransaction PayloadType = 8
+	PayloadSignedTransaction PayloadType = 1
 )
 
 func (payloadType PayloadType) String() string {
@@ -41,15 +31,9 @@ func (payloadType PayloadType) String() string {
 }
 
 var (
-	payloadNames = [PayloadMilestone + 1]string{
-		"Deprecated-TransactionTIP7",
-		"Deprecated-MilestoneTIP8",
-		"Deprecated-IndexationTIP6",
-		"Deprecated-ReceiptTIP17TIP8",
-		"TreasuryTransaction",
+	payloadNames = [PayloadSignedTransaction + 1]string{
 		"TaggedData",
 		"SignedTransaction",
-		"Milestone",
 	}
 )
 

--- a/signed_transaction.go
+++ b/signed_transaction.go
@@ -62,7 +62,7 @@ func (t *SignedTransaction) ID() (SignedTransactionID, error) {
 
 func (t *SignedTransaction) Size() int {
 	// PayloadType
-	return serializer.TypeDenotationByteSize +
+	return serializer.SmallTypeDenotationByteSize +
 		t.Transaction.Size() +
 		t.Unlocks.Size()
 }

--- a/tagged_data.go
+++ b/tagged_data.go
@@ -26,7 +26,7 @@ func (u *TaggedData) PayloadType() PayloadType {
 
 func (u *TaggedData) Size() int {
 	// PayloadType
-	return serializer.TypeDenotationByteSize +
+	return serializer.SmallTypeDenotationByteSize +
 		serializer.OneByte + len(u.Tag) +
 		serializer.UInt32ByteSize + len(u.Data)
 }


### PR DESCRIPTION
# Description of change

- Set Payload Type to `uint8`, which should be plenty of types. If we ever get to `255`, this value can indicate continuation and a second byte can be introduced to denote more payload types.
- Remove deprecated payload types.
- Reset Output and Payload type bytes to 0.
- Account and NFT type bytes changing has no impact on the addresses derived from their IDs, since the addresses have their own type bytes. Therefore the Foundry ID or Token ID owned by accounts also does not change.

The motivation to do this change now is to finalize the type prefixes in the TIPs.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How the change has been tested

Serialization tests pass. Verified manually that Account Address does not change with changing Accout type prefix.