### PR TITLE
Implement CandidacyAnnouncement payload.

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -288,6 +288,10 @@ func V3API(protoParams ProtocolParameters) API {
 		serix.TypeSettings{}.WithObjectType(uint8(PayloadTaggedData))),
 	)
 
+	must(api.RegisterTypeSettings(CandidacyAnnouncement{},
+		serix.TypeSettings{}.WithObjectType(uint8(PayloadCandidacyAnnouncement))),
+	)
+
 	{
 		must(api.RegisterTypeSettings(Ed25519Signature{},
 			serix.TypeSettings{}.WithObjectType(uint8(SignatureEd25519))),
@@ -561,7 +565,6 @@ func V3API(protoParams ProtocolParameters) API {
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte).WithMaxLen(1),
 		))
 
-		must(api.RegisterInterfaceObjects((*TxEssencePayload)(nil), (*TaggedData)(nil)))
 		must(api.RegisterInterfaceObjects((*TxEssenceOutput)(nil), (*BasicOutput)(nil)))
 		must(api.RegisterInterfaceObjects((*TxEssenceOutput)(nil), (*AccountOutput)(nil)))
 		must(api.RegisterInterfaceObjects((*TxEssenceOutput)(nil), (*DelegationOutput)(nil)))
@@ -578,6 +581,7 @@ func V3API(protoParams ProtocolParameters) API {
 			return tx.syntacticallyValidate()
 		}))
 		must(api.RegisterInterfaceObjects((*TxEssencePayload)(nil), (*TaggedData)(nil)))
+
 	}
 
 	{
@@ -610,6 +614,7 @@ func V3API(protoParams ProtocolParameters) API {
 
 		must(api.RegisterInterfaceObjects((*BlockPayload)(nil), (*SignedTransaction)(nil)))
 		must(api.RegisterInterfaceObjects((*BlockPayload)(nil), (*TaggedData)(nil)))
+		must(api.RegisterInterfaceObjects((*BlockPayload)(nil), (*CandidacyAnnouncement)(nil)))
 
 		must(api.RegisterTypeSettings(ProtocolBlock{}, serix.TypeSettings{}))
 		must(api.RegisterValidators(ProtocolBlock{}, func(ctx context.Context, bytes []byte) error {

--- a/candidacy_announcement.go
+++ b/candidacy_announcement.go
@@ -1,0 +1,24 @@
+package iotago
+
+// CandidacyAnnouncement is a payload which is used to indicate candidacy for committee selection for the next epoch.
+type CandidacyAnnouncement struct {
+}
+
+func (u *CandidacyAnnouncement) Clone() Payload {
+	return &CandidacyAnnouncement{}
+}
+
+func (u *CandidacyAnnouncement) PayloadType() PayloadType {
+	return PayloadCandidacyAnnouncement
+}
+
+func (u *CandidacyAnnouncement) Size() int {
+	// PayloadType
+	return 0
+}
+
+func (u *CandidacyAnnouncement) WorkScore(workScoreStructure *WorkScoreStructure) (WorkScore, error) {
+	// we account for the network traffic only on "Payload" level
+	// TODO: is the work score correct?
+	return workScoreStructure.DataByte.Multiply(u.Size())
+}

--- a/candidacy_announcement.go
+++ b/candidacy_announcement.go
@@ -14,7 +14,7 @@ func (u *CandidacyAnnouncement) PayloadType() PayloadType {
 
 func (u *CandidacyAnnouncement) Size() int {
 	// PayloadType
-	return 0
+	return 1
 }
 
 func (u *CandidacyAnnouncement) WorkScore(workScoreStructure *WorkScoreStructure) (WorkScore, error) {

--- a/candidacy_announcement_test.go
+++ b/candidacy_announcement_test.go
@@ -1,0 +1,21 @@
+package iotago_test
+
+import (
+	"testing"
+
+	iotago "github.com/iotaledger/iota.go/v4"
+)
+
+func TestCandidacyAnnouncmentDeSerialize(t *testing.T) {
+	tests := []deSerializeTest{
+		{
+			name:   "ok",
+			source: &iotago.CandidacyAnnouncement{},
+			target: &iotago.CandidacyAnnouncement{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.deSerialize)
+	}
+}

--- a/payload.go
+++ b/payload.go
@@ -20,6 +20,8 @@ const (
 	PayloadTaggedData PayloadType = iota
 	// PayloadSignedTransaction denotes a SignedTransaction.
 	PayloadSignedTransaction PayloadType = 1
+	// PayloadCandidacyAnnouncement denotes a CandidacyAnnouncement.
+	PayloadCandidacyAnnouncement PayloadType = 2
 )
 
 func (payloadType PayloadType) String() string {

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -717,6 +717,8 @@ func RandBasicBlock(api iotago.API, withPayloadType iotago.PayloadType) *iotago.
 		payload = RandSignedTransaction(api)
 	case iotago.PayloadTaggedData:
 		payload = RandTaggedData([]byte("tag"))
+	case iotago.PayloadCandidacyAnnouncement:
+		payload = &iotago.CandidacyAnnouncement{}
 	}
 
 	return &iotago.BasicBlock{


### PR DESCRIPTION
Implement CandidacyAnnouncement payload so that nodes that want to candidate for a committee can announce their candidacy by attaching payload of that type in a BasicBlock. 