### PR TITLE
Remove dummy address in Implicit Account Creation Address storage score calculation

### DIFF
--- a/rent.go
+++ b/rent.go
@@ -53,7 +53,7 @@ type RentStructure struct {
 	RentParameters *RentParameters
 	// The storage score that a minimal block issuer account needs to have minus the wrapping Basic Output.
 	// Since this value is used for implicit account creation addresses, this value plus the wrapping
-	// Basic Output (the Implicit Account Creation Address is contained in) results in the
+	// Basic Output (in which the Implicit Account Creation Address is contained in) results in the
 	// minimum storage score of a block issuer account.
 	StorageScoreOffsetImplicitAccountCreationAddress StorageScore
 }
@@ -132,11 +132,11 @@ func NewRentStructure(rentParameters *RentParameters) *RentStructure {
 
 	// Set the storage score offset for implicit account creation addresses as
 	// the difference between the storage score of the dummy account and the storage
-	// score of the dummy basic output minus the storage score of the dummy address.
+	// score of the dummy basic output.
 	storageScoreAccountOutput := dummyAccountOutput.StorageScore(rentStructure, nil)
-	storageScoreBasicOutputWithoutAddress := dummyBasicOutput.StorageScore(rentStructure, nil) - dummyAddress.StorageScore(rentStructure, nil)
+	storageScoreBasicOutput := dummyBasicOutput.StorageScore(rentStructure, nil)
 	rentStructure.StorageScoreOffsetImplicitAccountCreationAddress = lo.PanicOnErr(
-		safemath.SafeSub(storageScoreAccountOutput, storageScoreBasicOutputWithoutAddress),
+		safemath.SafeSub(storageScoreAccountOutput, storageScoreBasicOutput),
 	)
 
 	return rentStructure


### PR DESCRIPTION
# Description of change

Remove dummy address in Implicit Account Creation Address storage score calculation. Due to the recent changes in the storage score, the storage score of a plain Ed25519 Address is 0, so it no longer affects the calculation like it did before. Previously we had to subtract the Ed25519 Address because it added an extra vbyte cost on top of what the basic output itself had. With the change that the output's serialized size is only taken into account at the top-level, this no longer matters. The size of an Ed25519 Address and an Implicit Account Creation Address is the same, so the storage score of the data part of the equation is the same for a regular Basic Output and an Implicit Account. Hence now the implicit account creation address storage score offset can simply be that of a minimal block issuer account minus that of a minimal basic output.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Existing tests pass.