### PR TITLE
fix account builder for genesis accounts

### DIFF
--- a/builder/output_builder_account.go
+++ b/builder/output_builder_account.go
@@ -162,11 +162,10 @@ func (builder *AccountOutputBuilder) Build() (*iotago.AccountOutput, error) {
 		return nil, ierrors.New("builder calls require both state and governor transitions which is not possible")
 	}
 
-	if builder.stateCtrlReq {
-		builder.output.StateIndex++
-	}
-
 	if builder.prev != nil {
+		if builder.stateCtrlReq {
+			builder.output.StateIndex++
+		}
 		if !builder.prev.ImmutableFeatures.Equal(builder.output.ImmutableFeatures) {
 			return nil, ierrors.New("immutable features are not allowed to be changed")
 		}

--- a/builder/output_builder_test.go
+++ b/builder/output_builder_test.go
@@ -77,7 +77,7 @@ func TestAccountOutputBuilder(t *testing.T) {
 
 	expected := &iotago.AccountOutput{
 		Amount:         1337,
-		StateIndex:     1,
+		StateIndex:     0,
 		StateMetadata:  metadata,
 		FoundryCounter: 5,
 		Conditions: iotago.AccountOutputUnlockConditions{
@@ -130,7 +130,7 @@ func TestAccountOutputBuilder(t *testing.T) {
 
 	expectedFeatures := &iotago.AccountOutput{
 		Amount:         1337,
-		StateIndex:     1,
+		StateIndex:     0,
 		StateMetadata:  metadata,
 		FoundryCounter: 5,
 		Conditions: iotago.AccountOutputUnlockConditions{


### PR DESCRIPTION
Fixes a bug in the account builder for creating new accounts (not from a previous account). The new account should have state index 0.
