### PR TITLE
Rename Block Types

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -614,9 +614,9 @@ func V3API(protoParams ProtocolParameters) API {
 		must(api.RegisterInterfaceObjects((*Block)(nil), (*BasicBlock)(nil)))
 		must(api.RegisterInterfaceObjects((*Block)(nil), (*ValidationBlock)(nil)))
 
-		must(api.RegisterInterfaceObjects((*BlockPayload)(nil), (*SignedTransaction)(nil)))
-		must(api.RegisterInterfaceObjects((*BlockPayload)(nil), (*TaggedData)(nil)))
-		must(api.RegisterInterfaceObjects((*BlockPayload)(nil), (*CandidacyAnnouncement)(nil)))
+		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*SignedTransaction)(nil)))
+		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*TaggedData)(nil)))
+		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*CandidacyAnnouncement)(nil)))
 
 		must(api.RegisterTypeSettings(ProtocolBlock{}, serix.TypeSettings{}))
 		must(api.RegisterValidators(ProtocolBlock{}, func(ctx context.Context, bytes []byte) error {

--- a/api_v3.go
+++ b/api_v3.go
@@ -618,14 +618,14 @@ func V3API(protoParams ProtocolParameters) API {
 		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*TaggedData)(nil)))
 		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*CandidacyAnnouncement)(nil)))
 
-		must(api.RegisterTypeSettings(ProtocolBlock{}, serix.TypeSettings{}))
-		must(api.RegisterValidators(ProtocolBlock{}, func(ctx context.Context, bytes []byte) error {
+		must(api.RegisterTypeSettings(Block{}, serix.TypeSettings{}))
+		must(api.RegisterValidators(Block{}, func(ctx context.Context, bytes []byte) error {
 			if len(bytes) > MaxBlockSize {
 				return ierrors.Errorf("max size of a block is %d but got %d bytes", MaxBlockSize, len(bytes))
 			}
 
 			return nil
-		}, func(ctx context.Context, protocolBlock ProtocolBlock) error {
+		}, func(ctx context.Context, protocolBlock Block) error {
 			return protocolBlock.syntacticallyValidate()
 		}))
 	}

--- a/api_v3.go
+++ b/api_v3.go
@@ -599,20 +599,20 @@ func V3API(protoParams ProtocolParameters) API {
 	}
 
 	{
-		must(api.RegisterTypeSettings(BasicBlock{},
+		must(api.RegisterTypeSettings(BasicBlockBody{},
 			serix.TypeSettings{}.WithObjectType(byte(BlockBodyTypeBasic))),
 		)
 	}
 
 	{
-		must(api.RegisterTypeSettings(ValidationBlock{},
+		must(api.RegisterTypeSettings(ValidationBlockBody{},
 			serix.TypeSettings{}.WithObjectType(byte(BlockBodyTypeValidation))),
 		)
 	}
 
 	{
-		must(api.RegisterInterfaceObjects((*BlockBody)(nil), (*BasicBlock)(nil)))
-		must(api.RegisterInterfaceObjects((*BlockBody)(nil), (*ValidationBlock)(nil)))
+		must(api.RegisterInterfaceObjects((*BlockBody)(nil), (*BasicBlockBody)(nil)))
+		must(api.RegisterInterfaceObjects((*BlockBody)(nil), (*ValidationBlockBody)(nil)))
 
 		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*SignedTransaction)(nil)))
 		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*TaggedData)(nil)))

--- a/api_v3.go
+++ b/api_v3.go
@@ -600,19 +600,19 @@ func V3API(protoParams ProtocolParameters) API {
 
 	{
 		must(api.RegisterTypeSettings(BasicBlock{},
-			serix.TypeSettings{}.WithObjectType(byte(BlockTypeBasic))),
+			serix.TypeSettings{}.WithObjectType(byte(BlockBodyTypeBasic))),
 		)
 	}
 
 	{
 		must(api.RegisterTypeSettings(ValidationBlock{},
-			serix.TypeSettings{}.WithObjectType(byte(BlockTypeValidation))),
+			serix.TypeSettings{}.WithObjectType(byte(BlockBodyTypeValidation))),
 		)
 	}
 
 	{
-		must(api.RegisterInterfaceObjects((*Block)(nil), (*BasicBlock)(nil)))
-		must(api.RegisterInterfaceObjects((*Block)(nil), (*ValidationBlock)(nil)))
+		must(api.RegisterInterfaceObjects((*BlockBody)(nil), (*BasicBlock)(nil)))
+		must(api.RegisterInterfaceObjects((*BlockBody)(nil), (*ValidationBlock)(nil)))
 
 		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*SignedTransaction)(nil)))
 		must(api.RegisterInterfaceObjects((*ApplicationPayload)(nil), (*TaggedData)(nil)))

--- a/attestation.go
+++ b/attestation.go
@@ -20,7 +20,7 @@ type Attestation struct {
 	Signature   Signature  `serix:"2,mapKey=signature"`
 }
 
-func NewAttestation(api API, block *ProtocolBlock) *Attestation {
+func NewAttestation(api API, block *Block) *Attestation {
 	return &Attestation{
 		API:         api,
 		BlockHeader: block.BlockHeader,

--- a/attestation.go
+++ b/attestation.go
@@ -15,7 +15,7 @@ type Attestations = []*Attestation
 
 type Attestation struct {
 	API       API
-	Header    BlockHeader `serix:"0,nest"`
+	Header    BlockHeader `serix:"0,mapKey=header"`
 	BodyHash  Identifier  `serix:"1,mapKey=bodyHash"`
 	Signature Signature   `serix:"2,mapKey=signature"`
 }

--- a/attestation.go
+++ b/attestation.go
@@ -24,7 +24,7 @@ func NewAttestation(api API, block *ProtocolBlock) *Attestation {
 	return &Attestation{
 		API:         api,
 		BlockHeader: block.BlockHeader,
-		BlockHash:   lo.PanicOnErr(block.Block.Hash()),
+		BlockHash:   lo.PanicOnErr(block.Body.Hash()),
 		Signature:   block.Signature,
 	}
 }

--- a/attestation.go
+++ b/attestation.go
@@ -23,7 +23,7 @@ type Attestation struct {
 func NewAttestation(api API, block *Block) *Attestation {
 	return &Attestation{
 		API:         api,
-		BlockHeader: block.BlockHeader,
+		BlockHeader: block.Header,
 		BlockHash:   lo.PanicOnErr(block.Body.Hash()),
 		Signature:   block.Signature,
 	}

--- a/attestation_test.go
+++ b/attestation_test.go
@@ -18,14 +18,14 @@ func TestAttestation(t *testing.T) {
 		Build()
 
 	require.NoError(t, err)
-	require.Equal(t, iotago.BlockBodyTypeValidation, block.Block.Type())
+	require.Equal(t, iotago.BlockBodyTypeValidation, block.Body.Type())
 
 	attestation := iotago.NewAttestation(tpkg.TestAPI, block)
 
 	// Compare fields of block and attestation.
 	{
 		require.Equal(t, block.BlockHeader, attestation.BlockHeader)
-		require.Equal(t, lo.PanicOnErr(block.Block.Hash()), attestation.BlockHash)
+		require.Equal(t, lo.PanicOnErr(block.Body.Hash()), attestation.BlockHash)
 		require.Equal(t, block.Signature, attestation.Signature)
 	}
 

--- a/attestation_test.go
+++ b/attestation_test.go
@@ -24,7 +24,7 @@ func TestAttestation(t *testing.T) {
 
 	// Compare fields of block and attestation.
 	{
-		require.Equal(t, block.Header, attestation.BlockHeader)
+		require.Equal(t, block.Header, attestation.Header)
 		require.Equal(t, lo.PanicOnErr(block.Body.Hash()), attestation.BodyHash)
 		require.Equal(t, block.Signature, attestation.Signature)
 	}

--- a/attestation_test.go
+++ b/attestation_test.go
@@ -18,7 +18,7 @@ func TestAttestation(t *testing.T) {
 		Build()
 
 	require.NoError(t, err)
-	require.Equal(t, iotago.BlockTypeValidation, block.Block.Type())
+	require.Equal(t, iotago.BlockBodyTypeValidation, block.Block.Type())
 
 	attestation := iotago.NewAttestation(tpkg.TestAPI, block)
 

--- a/attestation_test.go
+++ b/attestation_test.go
@@ -24,7 +24,7 @@ func TestAttestation(t *testing.T) {
 
 	// Compare fields of block and attestation.
 	{
-		require.Equal(t, block.BlockHeader, attestation.BlockHeader)
+		require.Equal(t, block.Header, attestation.BlockHeader)
 		require.Equal(t, lo.PanicOnErr(block.Body.Hash()), attestation.BlockHash)
 		require.Equal(t, block.Signature, attestation.Signature)
 	}

--- a/attestation_test.go
+++ b/attestation_test.go
@@ -25,7 +25,7 @@ func TestAttestation(t *testing.T) {
 	// Compare fields of block and attestation.
 	{
 		require.Equal(t, block.Header, attestation.BlockHeader)
-		require.Equal(t, lo.PanicOnErr(block.Body.Hash()), attestation.BlockHash)
+		require.Equal(t, lo.PanicOnErr(block.Body.Hash()), attestation.BodyHash)
 		require.Equal(t, block.Signature, attestation.Signature)
 	}
 

--- a/benches_test.go
+++ b/benches_test.go
@@ -169,7 +169,7 @@ func BenchmarkSerializeAndHashBlockWithTransactionPayload(b *testing.B) {
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion: tpkg.TestAPI.Version(),
 		},
-		Body: &iotago.BasicBlock{
+		Body: &iotago.BasicBlockBody{
 			API:                tpkg.TestAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(2),
 			WeakParents:        iotago.BlockIDs{},

--- a/benches_test.go
+++ b/benches_test.go
@@ -164,7 +164,7 @@ func BenchmarkVerifyEd25519OneIOTxEssence(b *testing.B) {
 func BenchmarkSerializeAndHashBlockWithTransactionPayload(b *testing.B) {
 	txPayload := tpkg.OneInputOutputTransaction()
 
-	m := &iotago.ProtocolBlock{
+	m := &iotago.Block{
 		API: tpkg.TestAPI,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion: tpkg.TestAPI.Version(),

--- a/benches_test.go
+++ b/benches_test.go
@@ -169,7 +169,7 @@ func BenchmarkSerializeAndHashBlockWithTransactionPayload(b *testing.B) {
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion: tpkg.TestAPI.Version(),
 		},
-		Block: &iotago.BasicBlock{
+		Body: &iotago.BasicBlock{
 			API:                tpkg.TestAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(2),
 			WeakParents:        iotago.BlockIDs{},

--- a/benches_test.go
+++ b/benches_test.go
@@ -166,7 +166,7 @@ func BenchmarkSerializeAndHashBlockWithTransactionPayload(b *testing.B) {
 
 	m := &iotago.Block{
 		API: tpkg.TestAPI,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion: tpkg.TestAPI.Version(),
 		},
 		Body: &iotago.BasicBlockBody{

--- a/block.go
+++ b/block.go
@@ -47,7 +47,7 @@ const (
 	BlockTypeValidation BlockType = 1
 )
 
-type BlockPayload interface {
+type ApplicationPayload interface {
 	Payload
 }
 
@@ -337,7 +337,7 @@ type BasicBlock struct {
 	ShallowLikeParents BlockIDs `serix:"2,lengthPrefixType=uint8,mapKey=shallowLikeParents,minLen=0,maxLen=8"`
 
 	// The inner payload of the block. Can be nil.
-	Payload BlockPayload `serix:"3,optional,mapKey=payload,omitempty"`
+	Payload ApplicationPayload `serix:"3,optional,mapKey=payload,omitempty"`
 
 	MaxBurnedMana Mana `serix:"4,mapKey=maxBurnedMana"`
 }

--- a/block.go
+++ b/block.go
@@ -39,12 +39,12 @@ var (
 	ErrCommitmentInputNewerThanCommitment = ierrors.New("a block cannot contain a commitment input with index newer than the commitment index")
 )
 
-// BlockType denotes a type of Block.
-type BlockType byte
+// BlockBodyType denotes a type of Block Body.
+type BlockBodyType byte
 
 const (
-	BlockTypeBasic      BlockType = 0
-	BlockTypeValidation BlockType = 1
+	BlockBodyTypeBasic      BlockBodyType = 0
+	BlockBodyTypeValidation BlockBodyType = 1
 )
 
 type ApplicationPayload interface {
@@ -85,7 +85,7 @@ func (b *BlockHeader) Size() int {
 type ProtocolBlock struct {
 	API         API
 	BlockHeader `serix:"0,nest"`
-	Block       Block     `serix:"1,mapKey=block"`
+	Block       BlockBody `serix:"1,mapKey=block"`
 	Signature   Signature `serix:"2,mapKey=signature"`
 }
 
@@ -312,8 +312,8 @@ func (b *ProtocolBlock) syntacticallyValidate() error {
 	return b.Block.syntacticallyValidate(b)
 }
 
-type Block interface {
-	Type() BlockType
+type BlockBody interface {
+	Type() BlockBodyType
 
 	StrongParentIDs() BlockIDs
 	WeakParentIDs() BlockIDs
@@ -346,8 +346,8 @@ func (b *BasicBlock) SetDeserializationContext(ctx context.Context) {
 	b.API = APIFromContext(ctx)
 }
 
-func (b *BasicBlock) Type() BlockType {
-	return BlockTypeBasic
+func (b *BasicBlock) Type() BlockBodyType {
+	return BlockBodyTypeBasic
 }
 
 func (b *BasicBlock) StrongParentIDs() BlockIDs {
@@ -464,8 +464,8 @@ func (b *ValidationBlock) SetDeserializationContext(ctx context.Context) {
 	b.API = APIFromContext(ctx)
 }
 
-func (b *ValidationBlock) Type() BlockType {
-	return BlockTypeValidation
+func (b *ValidationBlock) Type() BlockBodyType {
+	return BlockBodyTypeValidation
 }
 
 func (b *ValidationBlock) StrongParentIDs() BlockIDs {

--- a/block.go
+++ b/block.go
@@ -82,27 +82,27 @@ func (b *BlockHeader) Size() int {
 	return BlockHeaderLength
 }
 
-type ProtocolBlock struct {
+type Block struct {
 	API         API
 	BlockHeader `serix:"0,nest"`
 	Body        BlockBody `serix:"1,mapKey=body"`
 	Signature   Signature `serix:"2,mapKey=signature"`
 }
 
-func ProtocolBlockFromBytes(apiProvider APIProvider) func(bytes []byte) (protocolBlock *ProtocolBlock, consumedBytes int, err error) {
-	return func(bytes []byte) (protocolBlock *ProtocolBlock, consumedBytes int, err error) {
-		protocolBlock = new(ProtocolBlock)
+func BlockFromBytes(apiProvider APIProvider) func(bytes []byte) (block *Block, consumedBytes int, err error) {
+	return func(bytes []byte) (block *Block, consumedBytes int, err error) {
+		block = new(Block)
 
 		var version Version
 		if version, consumedBytes, err = VersionFromBytes(bytes); err != nil {
 			err = ierrors.Wrap(err, "failed to parse version")
-		} else if protocolBlock.API, err = apiProvider.APIForVersion(version); err != nil {
+		} else if block.API, err = apiProvider.APIForVersion(version); err != nil {
 			err = ierrors.Wrapf(err, "failed to retrieve API for version %d", version)
-		} else if consumedBytes, err = protocolBlock.API.Decode(bytes, protocolBlock, serix.WithValidation()); err != nil {
-			err = ierrors.Wrap(err, "failed to deserialize ProtocolBlock")
+		} else if consumedBytes, err = block.API.Decode(bytes, block, serix.WithValidation()); err != nil {
+			err = ierrors.Wrap(err, "failed to deserialize Block")
 		}
 
-		return protocolBlock, consumedBytes, err
+		return block, consumedBytes, err
 	}
 }
 
@@ -124,14 +124,14 @@ func blockIdentifier(headerHash Identifier, blockHash Identifier, signatureBytes
 	return IdentifierFromData(byteutils.ConcatBytes(headerHash[:], blockHash[:], signatureBytes))
 }
 
-func (b *ProtocolBlock) SetDeserializationContext(ctx context.Context) {
+func (b *Block) SetDeserializationContext(ctx context.Context) {
 	b.API = APIFromContext(ctx)
 }
 
 // SigningMessage returns the to be signed message.
 // The BlockHeader and Block are separately hashed and concatenated to enable the verification of the signature for
 // an Attestation where only the BlockHeader and the hash of Block is known.
-func (b *ProtocolBlock) SigningMessage() ([]byte, error) {
+func (b *Block) SigningMessage() ([]byte, error) {
 	headerHash, err := b.BlockHeader.Hash(b.API)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func blockSigningMessage(headerHash Identifier, blockHash Identifier) []byte {
 
 // Sign produces signatures signing the essence for every given AddressKeys.
 // The produced signatures are in the same order as the AddressKeys.
-func (b *ProtocolBlock) Sign(addrKey AddressKeys) (Signature, error) {
+func (b *Block) Sign(addrKey AddressKeys) (Signature, error) {
 	signMsg, err := b.SigningMessage()
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func (b *ProtocolBlock) Sign(addrKey AddressKeys) (Signature, error) {
 }
 
 // VerifySignature verifies the Signature of the block.
-func (b *ProtocolBlock) VerifySignature() (valid bool, err error) {
+func (b *Block) VerifySignature() (valid bool, err error) {
 	signingMessage, err := b.SigningMessage()
 	if err != nil {
 		return false, err
@@ -182,7 +182,7 @@ func (b *ProtocolBlock) VerifySignature() (valid bool, err error) {
 }
 
 // ID computes the ID of the Block.
-func (b *ProtocolBlock) ID() (BlockID, error) {
+func (b *Block) ID() (BlockID, error) {
 	data, err := b.API.Encode(b)
 	if err != nil {
 		return BlockID{}, ierrors.Errorf("can't compute block ID: %w", err)
@@ -199,7 +199,7 @@ func (b *ProtocolBlock) ID() (BlockID, error) {
 }
 
 // MustID works like ID but panics if the BlockID can't be computed.
-func (b *ProtocolBlock) MustID() BlockID {
+func (b *Block) MustID() BlockID {
 	blockID, err := b.ID()
 	if err != nil {
 		panic(err)
@@ -208,7 +208,7 @@ func (b *ProtocolBlock) MustID() BlockID {
 	return blockID
 }
 
-func (b *ProtocolBlock) Parents() (parents []BlockID) {
+func (b *Block) Parents() (parents []BlockID) {
 	parents = make([]BlockID, 0)
 
 	parents = append(parents, b.Body.StrongParentIDs()...)
@@ -218,7 +218,7 @@ func (b *ProtocolBlock) Parents() (parents []BlockID) {
 	return parents
 }
 
-func (b *ProtocolBlock) ParentsWithType() (parents []Parent) {
+func (b *Block) ParentsWithType() (parents []Parent) {
 	parents = make([]Parent, 0)
 
 	for _, parentBlockID := range b.Body.StrongParentIDs() {
@@ -237,13 +237,13 @@ func (b *ProtocolBlock) ParentsWithType() (parents []Parent) {
 }
 
 // ForEachParent executes a consumer func for each parent.
-func (b *ProtocolBlock) ForEachParent(consumer func(parent Parent)) {
+func (b *Block) ForEachParent(consumer func(parent Parent)) {
 	for _, parent := range b.ParentsWithType() {
 		consumer(parent)
 	}
 }
 
-func (b *ProtocolBlock) WorkScore() (WorkScore, error) {
+func (b *Block) WorkScore() (WorkScore, error) {
 	workScoreParameters := b.API.ProtocolParameters().WorkScoreParameters()
 
 	workScoreHeader, err := b.BlockHeader.WorkScore(workScoreParameters)
@@ -265,12 +265,12 @@ func (b *ProtocolBlock) WorkScore() (WorkScore, error) {
 }
 
 // Size returns the size of the block in bytes.
-func (b *ProtocolBlock) Size() int {
+func (b *Block) Size() int {
 	return b.BlockHeader.Size() + b.Body.Size() + b.Signature.Size()
 }
 
-// syntacticallyValidate syntactically validates the ProtocolBlock.
-func (b *ProtocolBlock) syntacticallyValidate() error {
+// syntacticallyValidate syntactically validates the Block.
+func (b *Block) syntacticallyValidate() error {
 	if b.API.ProtocolParameters().Version() != b.ProtocolVersion {
 		return ierrors.Wrapf(ErrInvalidBlockVersion, "mismatched protocol version: wanted %d, got %d in block", b.API.ProtocolParameters().Version(), b.ProtocolVersion)
 	}
@@ -321,7 +321,7 @@ type BlockBody interface {
 
 	Hash() (Identifier, error)
 
-	syntacticallyValidate(protocolBlock *ProtocolBlock) error
+	syntacticallyValidate(block *Block) error
 
 	ProcessableObject
 	Sizer
@@ -408,16 +408,16 @@ func (b *BasicBlock) Size() int {
 }
 
 // syntacticallyValidate syntactically validates the BasicBlock.
-func (b *BasicBlock) syntacticallyValidate(protocolBlock *ProtocolBlock) error {
+func (b *BasicBlock) syntacticallyValidate(block *Block) error {
 	if b.Payload != nil && b.Payload.PayloadType() == PayloadSignedTransaction {
-		blockID, err := protocolBlock.ID()
+		blockID, err := block.ID()
 		if err != nil {
 			return ierrors.Wrap(err, "error while calculating block ID during syntactical validation")
 		}
 		blockSlot := blockID.Slot()
 
-		minCommittableAge := protocolBlock.API.ProtocolParameters().MinCommittableAge()
-		maxCommittableAge := protocolBlock.API.ProtocolParameters().MaxCommittableAge()
+		minCommittableAge := block.API.ProtocolParameters().MinCommittableAge()
+		maxCommittableAge := block.API.ProtocolParameters().MaxCommittableAge()
 
 		signedTransaction, _ := b.Payload.(*SignedTransaction)
 
@@ -438,8 +438,8 @@ func (b *BasicBlock) syntacticallyValidate(protocolBlock *ProtocolBlock) error {
 				return ierrors.Wrapf(ErrCommitmentInputTooOld, "block at slot %d committing to slot %d, max committable age %d", blockSlot, cInput.CommitmentID.Slot(), maxCommittableAge)
 			}
 
-			if cInputSlot > protocolBlock.SlotCommitmentID.Slot() {
-				return ierrors.Wrapf(ErrCommitmentInputNewerThanCommitment, "transaction in a block contains CommitmentInput to slot %d while max allowed is %d", cInput.CommitmentID.Slot(), protocolBlock.SlotCommitmentID.Slot())
+			if cInputSlot > block.SlotCommitmentID.Slot() {
+				return ierrors.Wrapf(ErrCommitmentInputNewerThanCommitment, "transaction in a block contains CommitmentInput to slot %d while max allowed is %d", cInput.CommitmentID.Slot(), block.SlotCommitmentID.Slot())
 			}
 		}
 	}
@@ -504,9 +504,9 @@ func (b *ValidationBlock) Size() int {
 }
 
 // syntacticallyValidate syntactically validates the ValidationBlock.
-func (b *ValidationBlock) syntacticallyValidate(protocolBlock *ProtocolBlock) error {
-	if b.HighestSupportedVersion < protocolBlock.ProtocolVersion {
-		return ierrors.Errorf("highest supported version %d must be greater equal protocol version %d", b.HighestSupportedVersion, protocolBlock.ProtocolVersion)
+func (b *ValidationBlock) syntacticallyValidate(block *Block) error {
+	if b.HighestSupportedVersion < block.ProtocolVersion {
+		return ierrors.Errorf("highest supported version %d must be greater equal protocol version %d", b.HighestSupportedVersion, block.ProtocolVersion)
 	}
 
 	return nil

--- a/block.go
+++ b/block.go
@@ -84,7 +84,7 @@ func (b *BlockHeader) Size() int {
 
 type Block struct {
 	API       API
-	Header    BlockHeader `serix:"0,nest"`
+	Header    BlockHeader `serix:"0,mapKey=header"`
 	Body      BlockBody   `serix:"1,mapKey=body"`
 	Signature Signature   `serix:"2,mapKey=signature"`
 }

--- a/block_test.go
+++ b/block_test.go
@@ -445,7 +445,7 @@ func TestBasicBlock_MinSize(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI.Version()).MustID(),
 		},
 		Signature: tpkg.RandEd25519Signature(),
-		Body: &iotago.BasicBlock{
+		Body: &iotago.BasicBlockBody{
 			API:                tpkg.TestAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(1),
 			WeakParents:        iotago.BlockIDs{},
@@ -473,7 +473,7 @@ func TestValidationBlock_MinSize(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI.Version()).MustID(),
 		},
 		Signature: tpkg.RandEd25519Signature(),
-		Body: &iotago.ValidationBlock{
+		Body: &iotago.ValidationBlockBody{
 			API:                     tpkg.TestAPI,
 			StrongParents:           tpkg.SortedRandBlockIDs(1),
 			WeakParents:             iotago.BlockIDs{},
@@ -505,7 +505,7 @@ func TestValidationBlock_HighestSupportedVersion(t *testing.T) {
 
 	// Invalid HighestSupportedVersion.
 	{
-		block.Body = &iotago.ValidationBlock{
+		block.Body = &iotago.ValidationBlockBody{
 			API:                     tpkg.TestAPI,
 			StrongParents:           tpkg.SortedRandBlockIDs(1),
 			WeakParents:             iotago.BlockIDs{},
@@ -522,7 +522,7 @@ func TestValidationBlock_HighestSupportedVersion(t *testing.T) {
 
 	// Valid HighestSupportedVersion.
 	{
-		block.Body = &iotago.ValidationBlock{
+		block.Body = &iotago.ValidationBlockBody{
 			API:                     tpkg.TestAPI,
 			StrongParents:           tpkg.SortedRandBlockIDs(1),
 			WeakParents:             iotago.BlockIDs{},
@@ -556,7 +556,7 @@ func TestBlockJSONMarshalling(t *testing.T) {
 			NetworkID:        networkID,
 			SlotCommitmentID: commitmentID,
 		},
-		Body: &iotago.ValidationBlock{
+		Body: &iotago.ValidationBlockBody{
 			API:                     tpkg.TestAPI,
 			StrongParents:           strongParents,
 			HighestSupportedVersion: tpkg.TestAPI.Version(),

--- a/block_test.go
+++ b/block_test.go
@@ -439,7 +439,7 @@ func TestBlock_DeserializationNotEnoughData(t *testing.T) {
 func TestBasicBlock_MinSize(t *testing.T) {
 	minBlock := &iotago.Block{
 		API: tpkg.TestAPI,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI.Version()).MustID(),
@@ -467,7 +467,7 @@ func TestBasicBlock_MinSize(t *testing.T) {
 func TestValidationBlock_MinSize(t *testing.T) {
 	minBlock := &iotago.Block{
 		API: tpkg.TestAPI,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI.Version()).MustID(),
@@ -495,7 +495,7 @@ func TestValidationBlock_MinSize(t *testing.T) {
 func TestValidationBlock_HighestSupportedVersion(t *testing.T) {
 	block := &iotago.Block{
 		API: tpkg.TestAPI,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI.Version()).MustID(),
@@ -549,7 +549,7 @@ func TestBlockJSONMarshalling(t *testing.T) {
 	strongParents := tpkg.SortedRandBlockIDs(1)
 	validationBlock := &iotago.Block{
 		API: tpkg.TestAPI,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
 			IssuingTime:      issuingTime,
 			IssuerID:         issuerID,

--- a/block_test.go
+++ b/block_test.go
@@ -445,7 +445,7 @@ func TestBasicBlock_MinSize(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI.Version()).MustID(),
 		},
 		Signature: tpkg.RandEd25519Signature(),
-		Block: &iotago.BasicBlock{
+		Body: &iotago.BasicBlock{
 			API:                tpkg.TestAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(1),
 			WeakParents:        iotago.BlockIDs{},
@@ -473,7 +473,7 @@ func TestValidationBlock_MinSize(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI.Version()).MustID(),
 		},
 		Signature: tpkg.RandEd25519Signature(),
-		Block: &iotago.ValidationBlock{
+		Body: &iotago.ValidationBlock{
 			API:                     tpkg.TestAPI,
 			StrongParents:           tpkg.SortedRandBlockIDs(1),
 			WeakParents:             iotago.BlockIDs{},
@@ -505,7 +505,7 @@ func TestValidationBlock_HighestSupportedVersion(t *testing.T) {
 
 	// Invalid HighestSupportedVersion.
 	{
-		protocolBlock.Block = &iotago.ValidationBlock{
+		protocolBlock.Body = &iotago.ValidationBlock{
 			API:                     tpkg.TestAPI,
 			StrongParents:           tpkg.SortedRandBlockIDs(1),
 			WeakParents:             iotago.BlockIDs{},
@@ -522,7 +522,7 @@ func TestValidationBlock_HighestSupportedVersion(t *testing.T) {
 
 	// Valid HighestSupportedVersion.
 	{
-		protocolBlock.Block = &iotago.ValidationBlock{
+		protocolBlock.Body = &iotago.ValidationBlock{
 			API:                     tpkg.TestAPI,
 			StrongParents:           tpkg.SortedRandBlockIDs(1),
 			WeakParents:             iotago.BlockIDs{},
@@ -556,7 +556,7 @@ func TestBlockJSONMarshalling(t *testing.T) {
 			NetworkID:        networkID,
 			SlotCommitmentID: commitmentID,
 		},
-		Block: &iotago.ValidationBlock{
+		Body: &iotago.ValidationBlock{
 			API:                     tpkg.TestAPI,
 			StrongParents:           strongParents,
 			HighestSupportedVersion: tpkg.TestAPI.Version(),
@@ -564,7 +564,7 @@ func TestBlockJSONMarshalling(t *testing.T) {
 		Signature: signature,
 	}
 
-	blockJSON := fmt.Sprintf(`{"protocolVersion":%d,"networkId":"%d","issuingTime":"%s","slotCommitmentId":"%s","latestFinalizedSlot":0,"issuerId":"%s","block":{"type":%d,"strongParents":["%s"],"weakParents":[],"shallowLikeParents":[],"highestSupportedVersion":%d,"protocolParametersHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"signature":{"type":%d,"publicKey":"%s","signature":"%s"}}`,
+	blockJSON := fmt.Sprintf(`{"protocolVersion":%d,"networkId":"%d","issuingTime":"%s","slotCommitmentId":"%s","latestFinalizedSlot":0,"issuerId":"%s","body":{"type":%d,"strongParents":["%s"],"weakParents":[],"shallowLikeParents":[],"highestSupportedVersion":%d,"protocolParametersHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"signature":{"type":%d,"publicKey":"%s","signature":"%s"}}`,
 		tpkg.TestAPI.Version(),
 		networkID,
 		strconv.FormatUint(serializer.TimeToUint64(issuingTime), 10),

--- a/block_test.go
+++ b/block_test.go
@@ -97,7 +97,7 @@ func createBlockAtSlotWithVersion(t *testing.T, blockIndex iotago.SlotIndex, ver
 }
 
 //nolint:unparam // in the test we always issue at blockIndex=100, but let's keep this flexibility.
-func createBlockAtSlotWithPayload(t *testing.T, blockIndex, commitmentIndex iotago.SlotIndex, payload iotago.BlockPayload, apiProvider *api.EpochBasedProvider) error {
+func createBlockAtSlotWithPayload(t *testing.T, blockIndex, commitmentIndex iotago.SlotIndex, payload iotago.ApplicationPayload, apiProvider *api.EpochBasedProvider) error {
 	t.Helper()
 
 	apiForSlot := apiProvider.APIForSlot(blockIndex)

--- a/block_test.go
+++ b/block_test.go
@@ -24,23 +24,23 @@ func TestBlock_DeSerialize(t *testing.T) {
 	tests := []deSerializeTest{
 		{
 			name:   "ok - no payload",
-			source: tpkg.RandProtocolBlock(tpkg.RandBasicBlock(tpkg.TestAPI, 255), tpkg.TestAPI, 0),
-			target: &iotago.ProtocolBlock{},
+			source: tpkg.RandBlock(tpkg.RandBasicBlock(tpkg.TestAPI, 255), tpkg.TestAPI, 0),
+			target: &iotago.Block{},
 		},
 		{
 			name:   "ok - transaction",
-			source: tpkg.RandProtocolBlock(tpkg.RandBasicBlock(tpkg.TestAPI, iotago.PayloadSignedTransaction), tpkg.TestAPI, 0),
-			target: &iotago.ProtocolBlock{},
+			source: tpkg.RandBlock(tpkg.RandBasicBlock(tpkg.TestAPI, iotago.PayloadSignedTransaction), tpkg.TestAPI, 0),
+			target: &iotago.Block{},
 		},
 		{
 			name:   "ok - tagged data",
-			source: tpkg.RandProtocolBlock(tpkg.RandBasicBlock(tpkg.TestAPI, iotago.PayloadTaggedData), tpkg.TestAPI, 0),
-			target: &iotago.ProtocolBlock{},
+			source: tpkg.RandBlock(tpkg.RandBasicBlock(tpkg.TestAPI, iotago.PayloadTaggedData), tpkg.TestAPI, 0),
+			target: &iotago.Block{},
 		},
 		{
 			name:   "ok - validation block",
-			source: tpkg.RandProtocolBlock(tpkg.RandValidationBlock(tpkg.TestAPI), tpkg.TestAPI, 0),
-			target: &iotago.ProtocolBlock{},
+			source: tpkg.RandBlock(tpkg.RandValidationBlock(tpkg.TestAPI), tpkg.TestAPI, 0),
+			target: &iotago.Block{},
 		},
 	}
 
@@ -113,7 +113,7 @@ func createBlockAtSlotWithPayload(t *testing.T, blockIndex, commitmentIndex iota
 	return lo.Return2(apiForSlot.Encode(block, serix.WithValidation()))
 }
 
-func TestProtocolBlock_ProtocolVersionSyntactical(t *testing.T) {
+func TestBlock_ProtocolVersionSyntactical(t *testing.T) {
 	apiProvider := api.NewEpochBasedProvider(
 		api.WithAPIForMissingVersionCallback(
 			func(parameters iotago.ProtocolParameters) (iotago.API, error) {
@@ -149,7 +149,7 @@ func TestProtocolBlock_ProtocolVersionSyntactical(t *testing.T) {
 	require.NoError(t, createBlockAtSlotWithVersion(t, timeProvider.EpochStart(10), 5, apiProvider))
 }
 
-func TestProtocolBlock_Commitments(t *testing.T) {
+func TestBlock_Commitments(t *testing.T) {
 	// with the following parameters, a block issued in slot 100 can commit between slot 80 and 90
 	apiProvider := api.NewEpochBasedProvider()
 	apiProvider.AddProtocolParametersAtEpoch(
@@ -169,7 +169,7 @@ func TestProtocolBlock_Commitments(t *testing.T) {
 	require.NoError(t, createBlockAtSlot(t, 100, 85, apiProvider))
 }
 
-func TestProtocolBlock_Commitments1(t *testing.T) {
+func TestBlock_Commitments1(t *testing.T) {
 	// with the following parameters, a block issued in slot 100 can commit between slot 80 and 90
 	apiProvider := api.NewEpochBasedProvider()
 	apiProvider.AddProtocolParametersAtEpoch(
@@ -182,7 +182,7 @@ func TestProtocolBlock_Commitments1(t *testing.T) {
 
 }
 
-func TestProtocolBlock_TransactionCreationTime(t *testing.T) {
+func TestBlock_TransactionCreationTime(t *testing.T) {
 	keyPair := hiveEd25519.GenerateKeyPair()
 	// We derive a dummy account from addr.
 	addr := iotago.Ed25519AddressFromPubKey(keyPair.PublicKey[:])
@@ -261,7 +261,7 @@ func TestProtocolBlock_TransactionCreationTime(t *testing.T) {
 	require.NoError(t, createBlockAtSlotWithPayload(t, 100, 89, creationSlotCorrectLargerThanCommitment, apiProvider))
 }
 
-func TestProtocolBlock_WeakParents(t *testing.T) {
+func TestBlock_WeakParents(t *testing.T) {
 	// with the following parameters, a block issued in slot 100 can commit between slot 80 and 90
 	apiProvider := api.NewEpochBasedProvider()
 	apiProvider.AddProtocolParametersAtEpoch(
@@ -308,7 +308,7 @@ func TestProtocolBlock_WeakParents(t *testing.T) {
 	))
 }
 
-func TestProtocolBlock_TransactionCommitmentInput(t *testing.T) {
+func TestBlock_TransactionCommitmentInput(t *testing.T) {
 	keyPair := hiveEd25519.GenerateKeyPair()
 	// We derive a dummy account from addr.
 	addr := iotago.Ed25519AddressFromPubKey(keyPair.PublicKey[:])
@@ -428,16 +428,16 @@ func TestProtocolBlock_TransactionCommitmentInput(t *testing.T) {
 	require.NoError(t, createBlockAtSlotWithPayload(t, 100, 89, commitmentCorrectMiddle, apiProvider))
 }
 
-func TestProtocolBlock_DeserializationNotEnoughData(t *testing.T) {
+func TestBlock_DeserializationNotEnoughData(t *testing.T) {
 	blockBytes := []byte{byte(tpkg.TestAPI.Version()), 1}
 
-	block := &iotago.ProtocolBlock{}
+	block := &iotago.Block{}
 	_, err := tpkg.TestAPI.Decode(blockBytes, block)
 	require.ErrorIs(t, err, serializer.ErrDeserializationNotEnoughData)
 }
 
 func TestBasicBlock_MinSize(t *testing.T) {
-	minProtocolBlock := &iotago.ProtocolBlock{
+	minBlock := &iotago.Block{
 		API: tpkg.TestAPI,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
@@ -454,18 +454,18 @@ func TestBasicBlock_MinSize(t *testing.T) {
 		},
 	}
 
-	blockBytes, err := tpkg.TestAPI.Encode(minProtocolBlock)
+	blockBytes, err := tpkg.TestAPI.Encode(minBlock)
 	require.NoError(t, err)
 
-	block2 := &iotago.ProtocolBlock{}
+	block2 := &iotago.Block{}
 	consumedBytes, err := tpkg.TestAPI.Decode(blockBytes, block2, serix.WithValidation())
 	require.NoError(t, err)
-	require.Equal(t, minProtocolBlock, block2)
+	require.Equal(t, minBlock, block2)
 	require.Equal(t, len(blockBytes), consumedBytes)
 }
 
 func TestValidationBlock_MinSize(t *testing.T) {
-	minProtocolBlock := &iotago.ProtocolBlock{
+	minBlock := &iotago.Block{
 		API: tpkg.TestAPI,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
@@ -482,18 +482,18 @@ func TestValidationBlock_MinSize(t *testing.T) {
 		},
 	}
 
-	blockBytes, err := tpkg.TestAPI.Encode(minProtocolBlock)
+	blockBytes, err := tpkg.TestAPI.Encode(minBlock)
 	require.NoError(t, err)
 
-	block2 := &iotago.ProtocolBlock{}
+	block2 := &iotago.Block{}
 	consumedBytes, err := tpkg.TestAPI.Decode(blockBytes, block2, serix.WithValidation())
 	require.NoError(t, err)
-	require.Equal(t, minProtocolBlock, block2)
+	require.Equal(t, minBlock, block2)
 	require.Equal(t, len(blockBytes), consumedBytes)
 }
 
 func TestValidationBlock_HighestSupportedVersion(t *testing.T) {
-	protocolBlock := &iotago.ProtocolBlock{
+	block := &iotago.Block{
 		API: tpkg.TestAPI,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
@@ -505,37 +505,37 @@ func TestValidationBlock_HighestSupportedVersion(t *testing.T) {
 
 	// Invalid HighestSupportedVersion.
 	{
-		protocolBlock.Body = &iotago.ValidationBlock{
+		block.Body = &iotago.ValidationBlock{
 			API:                     tpkg.TestAPI,
 			StrongParents:           tpkg.SortedRandBlockIDs(1),
 			WeakParents:             iotago.BlockIDs{},
 			ShallowLikeParents:      iotago.BlockIDs{},
 			HighestSupportedVersion: tpkg.TestAPI.Version() - 1,
 		}
-		blockBytes, err := tpkg.TestAPI.Encode(protocolBlock)
+		blockBytes, err := tpkg.TestAPI.Encode(block)
 		require.NoError(t, err)
 
-		block2 := &iotago.ProtocolBlock{}
+		block2 := &iotago.Block{}
 		_, err = tpkg.TestAPI.Decode(blockBytes, block2, serix.WithValidation())
 		require.ErrorContains(t, err, "highest supported version")
 	}
 
 	// Valid HighestSupportedVersion.
 	{
-		protocolBlock.Body = &iotago.ValidationBlock{
+		block.Body = &iotago.ValidationBlock{
 			API:                     tpkg.TestAPI,
 			StrongParents:           tpkg.SortedRandBlockIDs(1),
 			WeakParents:             iotago.BlockIDs{},
 			ShallowLikeParents:      iotago.BlockIDs{},
 			HighestSupportedVersion: tpkg.TestAPI.Version(),
 		}
-		blockBytes, err := tpkg.TestAPI.Encode(protocolBlock)
+		blockBytes, err := tpkg.TestAPI.Encode(block)
 		require.NoError(t, err)
 
-		block2 := &iotago.ProtocolBlock{}
+		block2 := &iotago.Block{}
 		consumedBytes, err := tpkg.TestAPI.Decode(blockBytes, block2, serix.WithValidation())
 		require.NoError(t, err)
-		require.Equal(t, protocolBlock, block2)
+		require.Equal(t, block, block2)
 		require.Equal(t, len(blockBytes), consumedBytes)
 	}
 }
@@ -547,7 +547,7 @@ func TestBlockJSONMarshalling(t *testing.T) {
 	issuerID := tpkg.RandAccountID()
 	signature := tpkg.RandEd25519Signature()
 	strongParents := tpkg.SortedRandBlockIDs(1)
-	validationBlock := &iotago.ProtocolBlock{
+	validationBlock := &iotago.Block{
 		API: tpkg.TestAPI,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),

--- a/block_test.go
+++ b/block_test.go
@@ -564,7 +564,7 @@ func TestBlockJSONMarshalling(t *testing.T) {
 		Signature: signature,
 	}
 
-	blockJSON := fmt.Sprintf(`{"protocolVersion":%d,"networkId":"%d","issuingTime":"%s","slotCommitmentId":"%s","latestFinalizedSlot":0,"issuerId":"%s","body":{"type":%d,"strongParents":["%s"],"weakParents":[],"shallowLikeParents":[],"highestSupportedVersion":%d,"protocolParametersHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"signature":{"type":%d,"publicKey":"%s","signature":"%s"}}`,
+	blockJSON := fmt.Sprintf(`{"header":{"protocolVersion":%d,"networkId":"%d","issuingTime":"%s","slotCommitmentId":"%s","latestFinalizedSlot":0,"issuerId":"%s"},"body":{"type":%d,"strongParents":["%s"],"weakParents":[],"shallowLikeParents":[],"highestSupportedVersion":%d,"protocolParametersHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"signature":{"type":%d,"publicKey":"%s","signature":"%s"}}`,
 		tpkg.TestAPI.Version(),
 		networkID,
 		strconv.FormatUint(serializer.TimeToUint64(issuingTime), 10),

--- a/block_test.go
+++ b/block_test.go
@@ -570,7 +570,7 @@ func TestBlockJSONMarshalling(t *testing.T) {
 		strconv.FormatUint(serializer.TimeToUint64(issuingTime), 10),
 		commitmentID.ToHex(),
 		issuerID.ToHex(),
-		iotago.BlockTypeValidation,
+		iotago.BlockBodyTypeValidation,
 		strongParents[0].ToHex(),
 		tpkg.TestAPI.Version(),
 		iotago.SignatureEd25519,

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -153,7 +153,7 @@ func (b *BasicBlockBuilder) ShallowLikeParents(parents iotago.BlockIDs) *BasicBl
 }
 
 // Payload sets the payload.
-func (b *BasicBlockBuilder) Payload(payload iotago.BlockPayload) *BasicBlockBuilder {
+func (b *BasicBlockBuilder) Payload(payload iotago.ApplicationPayload) *BasicBlockBuilder {
 	if b.err != nil {
 		return b
 	}

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -11,7 +11,7 @@ import (
 // NewBasicBlockBuilder creates a new BasicBlockBuilder.
 func NewBasicBlockBuilder(api iotago.API) *BasicBlockBuilder {
 	// TODO: burn the correct amount of Mana in all cases according to block work and RMC with issue #285
-	basicBlock := &iotago.BasicBlock{
+	basicBlock := &iotago.BasicBlockBody{
 		API:                api,
 		StrongParents:      iotago.BlockIDs{},
 		WeakParents:        iotago.BlockIDs{},
@@ -37,7 +37,7 @@ func NewBasicBlockBuilder(api iotago.API) *BasicBlockBuilder {
 
 // BasicBlockBuilder is used to easily build up a Basic Block.
 type BasicBlockBuilder struct {
-	basicBlock *iotago.BasicBlock
+	basicBlock *iotago.BasicBlockBody
 
 	protocolBlock *iotago.Block
 	err           error
@@ -193,7 +193,7 @@ func (b *BasicBlockBuilder) CalculateAndSetMaxBurnedMana(rmc iotago.Mana) *Basic
 
 // NewValidationBlockBuilder creates a new ValidationBlockBuilder.
 func NewValidationBlockBuilder(api iotago.API) *ValidationBlockBuilder {
-	validationBlock := &iotago.ValidationBlock{
+	validationBlock := &iotago.ValidationBlockBody{
 		API:                api,
 		StrongParents:      iotago.BlockIDs{},
 		WeakParents:        iotago.BlockIDs{},
@@ -219,7 +219,7 @@ func NewValidationBlockBuilder(api iotago.API) *ValidationBlockBuilder {
 
 // ValidationBlockBuilder is used to easily build up a Validation Block.
 type ValidationBlockBuilder struct {
-	validationBlock *iotago.ValidationBlock
+	validationBlock *iotago.ValidationBlockBody
 
 	protocolBlock *iotago.Block
 	err           error

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -18,7 +18,7 @@ func NewBasicBlockBuilder(api iotago.API) *BasicBlockBuilder {
 		ShallowLikeParents: iotago.BlockIDs{},
 	}
 
-	protocolBlock := &iotago.ProtocolBlock{
+	protocolBlock := &iotago.Block{
 		API: api,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  api.ProtocolParameters().Version(),
@@ -39,12 +39,12 @@ func NewBasicBlockBuilder(api iotago.API) *BasicBlockBuilder {
 type BasicBlockBuilder struct {
 	basicBlock *iotago.BasicBlock
 
-	protocolBlock *iotago.ProtocolBlock
+	protocolBlock *iotago.Block
 	err           error
 }
 
-// Build builds the ProtocolBlock or returns any error which occurred during the build steps.
-func (b *BasicBlockBuilder) Build() (*iotago.ProtocolBlock, error) {
+// Build builds the Block or returns any error which occurred during the build steps.
+func (b *BasicBlockBuilder) Build() (*iotago.Block, error) {
 	if b.err != nil {
 		return nil, b.err
 	}
@@ -200,7 +200,7 @@ func NewValidationBlockBuilder(api iotago.API) *ValidationBlockBuilder {
 		ShallowLikeParents: iotago.BlockIDs{},
 	}
 
-	protocolBlock := &iotago.ProtocolBlock{
+	protocolBlock := &iotago.Block{
 		API: api,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  api.ProtocolParameters().Version(),
@@ -221,12 +221,12 @@ func NewValidationBlockBuilder(api iotago.API) *ValidationBlockBuilder {
 type ValidationBlockBuilder struct {
 	validationBlock *iotago.ValidationBlock
 
-	protocolBlock *iotago.ProtocolBlock
+	protocolBlock *iotago.Block
 	err           error
 }
 
-// Build builds the ProtocolBlock or returns any error which occurred during the build steps.
-func (v *ValidationBlockBuilder) Build() (*iotago.ProtocolBlock, error) {
+// Build builds the Block or returns any error which occurred during the build steps.
+func (v *ValidationBlockBuilder) Build() (*iotago.Block, error) {
 	if v.err != nil {
 		return nil, v.err
 	}

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -20,7 +20,7 @@ func NewBasicBlockBuilder(api iotago.API) *BasicBlockBuilder {
 
 	protocolBlock := &iotago.Block{
 		API: api,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  api.ProtocolParameters().Version(),
 			SlotCommitmentID: iotago.EmptyCommitmentID,
 			IssuingTime:      time.Now().UTC(),
@@ -58,7 +58,7 @@ func (b *BasicBlockBuilder) ProtocolVersion(version iotago.Version) *BasicBlockB
 		return b
 	}
 
-	b.protocolBlock.ProtocolVersion = version
+	b.protocolBlock.Header.ProtocolVersion = version
 
 	return b
 }
@@ -68,7 +68,7 @@ func (b *BasicBlockBuilder) IssuingTime(time time.Time) *BasicBlockBuilder {
 		return b
 	}
 
-	b.protocolBlock.IssuingTime = time.UTC()
+	b.protocolBlock.Header.IssuingTime = time.UTC()
 
 	return b
 }
@@ -79,7 +79,7 @@ func (b *BasicBlockBuilder) SlotCommitmentID(commitment iotago.CommitmentID) *Ba
 		return b
 	}
 
-	b.protocolBlock.SlotCommitmentID = commitment
+	b.protocolBlock.Header.SlotCommitmentID = commitment
 
 	return b
 }
@@ -90,7 +90,7 @@ func (b *BasicBlockBuilder) LatestFinalizedSlot(slot iotago.SlotIndex) *BasicBlo
 		return b
 	}
 
-	b.protocolBlock.LatestFinalizedSlot = slot
+	b.protocolBlock.Header.LatestFinalizedSlot = slot
 
 	return b
 }
@@ -100,7 +100,7 @@ func (b *BasicBlockBuilder) Sign(accountID iotago.AccountID, prvKey ed25519.Priv
 		return b
 	}
 
-	b.protocolBlock.IssuerID = accountID
+	b.protocolBlock.Header.IssuerID = accountID
 
 	signature, err := b.protocolBlock.Sign(iotago.NewAddressKeysForEd25519Address(iotago.Ed25519AddressFromPubKey(prvKey.Public().(ed25519.PublicKey)), prvKey))
 	if err != nil {
@@ -202,7 +202,7 @@ func NewValidationBlockBuilder(api iotago.API) *ValidationBlockBuilder {
 
 	protocolBlock := &iotago.Block{
 		API: api,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  api.ProtocolParameters().Version(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(api.ProtocolParameters().Version()).MustID(),
 			IssuingTime:      time.Now().UTC(),
@@ -240,7 +240,7 @@ func (v *ValidationBlockBuilder) ProtocolVersion(version iotago.Version) *Valida
 		return v
 	}
 
-	v.protocolBlock.ProtocolVersion = version
+	v.protocolBlock.Header.ProtocolVersion = version
 
 	return v
 }
@@ -250,7 +250,7 @@ func (v *ValidationBlockBuilder) IssuingTime(time time.Time) *ValidationBlockBui
 		return v
 	}
 
-	v.protocolBlock.IssuingTime = time.UTC()
+	v.protocolBlock.Header.IssuingTime = time.UTC()
 
 	return v
 }
@@ -261,7 +261,7 @@ func (v *ValidationBlockBuilder) SlotCommitmentID(commitmentID iotago.Commitment
 		return v
 	}
 
-	v.protocolBlock.SlotCommitmentID = commitmentID
+	v.protocolBlock.Header.SlotCommitmentID = commitmentID
 
 	return v
 }
@@ -272,7 +272,7 @@ func (v *ValidationBlockBuilder) LatestFinalizedSlot(slot iotago.SlotIndex) *Val
 		return v
 	}
 
-	v.protocolBlock.LatestFinalizedSlot = slot
+	v.protocolBlock.Header.LatestFinalizedSlot = slot
 
 	return v
 }
@@ -282,7 +282,7 @@ func (v *ValidationBlockBuilder) Sign(accountID iotago.AccountID, prvKey ed25519
 		return v
 	}
 
-	v.protocolBlock.IssuerID = accountID
+	v.protocolBlock.Header.IssuerID = accountID
 
 	signature, err := v.protocolBlock.Sign(iotago.NewAddressKeysForEd25519Address(iotago.Ed25519AddressFromPubKey(prvKey.Public().(ed25519.PublicKey)), prvKey))
 	if err != nil {

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -26,7 +26,7 @@ func NewBasicBlockBuilder(api iotago.API) *BasicBlockBuilder {
 			IssuingTime:      time.Now().UTC(),
 		},
 		Signature: &iotago.Ed25519Signature{},
-		Block:     basicBlock,
+		Body:      basicBlock,
 	}
 
 	return &BasicBlockBuilder{
@@ -208,7 +208,7 @@ func NewValidationBlockBuilder(api iotago.API) *ValidationBlockBuilder {
 			IssuingTime:      time.Now().UTC(),
 		},
 		Signature: &iotago.Ed25519Signature{},
-		Block:     validationBlock,
+		Body:      validationBlock,
 	}
 
 	return &ValidationBlockBuilder{

--- a/builder/block_builder_test.go
+++ b/builder/block_builder_test.go
@@ -25,7 +25,7 @@ func TestBasicBlockBuilder(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	require.Equal(t, iotago.BlockTypeBasic, block.Block.Type())
+	require.Equal(t, iotago.BlockBodyTypeBasic, block.Block.Type())
 
 	basicBlock := block.Block.(*iotago.BasicBlock)
 	expectedBurnedMana, err := basicBlock.ManaCost(100, tpkg.TestAPI.ProtocolParameters().WorkScoreParameters())
@@ -42,7 +42,7 @@ func TestValidationBlockBuilder(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	require.Equal(t, iotago.BlockTypeValidation, block.Block.Type())
+	require.Equal(t, iotago.BlockBodyTypeValidation, block.Block.Type())
 
 	basicBlock := block.Block.(*iotago.ValidationBlock)
 	require.EqualValues(t, 100, basicBlock.HighestSupportedVersion)

--- a/builder/block_builder_test.go
+++ b/builder/block_builder_test.go
@@ -27,7 +27,7 @@ func TestBasicBlockBuilder(t *testing.T) {
 
 	require.Equal(t, iotago.BlockBodyTypeBasic, block.Body.Type())
 
-	basicBlock := block.Body.(*iotago.BasicBlock)
+	basicBlock := block.Body.(*iotago.BasicBlockBody)
 	expectedBurnedMana, err := basicBlock.ManaCost(100, tpkg.TestAPI.ProtocolParameters().WorkScoreParameters())
 	require.NoError(t, err)
 	require.EqualValues(t, expectedBurnedMana, basicBlock.MaxBurnedMana)
@@ -44,6 +44,6 @@ func TestValidationBlockBuilder(t *testing.T) {
 
 	require.Equal(t, iotago.BlockBodyTypeValidation, block.Body.Type())
 
-	basicBlock := block.Body.(*iotago.ValidationBlock)
+	basicBlock := block.Body.(*iotago.ValidationBlockBody)
 	require.EqualValues(t, 100, basicBlock.HighestSupportedVersion)
 }

--- a/builder/block_builder_test.go
+++ b/builder/block_builder_test.go
@@ -25,9 +25,9 @@ func TestBasicBlockBuilder(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	require.Equal(t, iotago.BlockBodyTypeBasic, block.Block.Type())
+	require.Equal(t, iotago.BlockBodyTypeBasic, block.Body.Type())
 
-	basicBlock := block.Block.(*iotago.BasicBlock)
+	basicBlock := block.Body.(*iotago.BasicBlock)
 	expectedBurnedMana, err := basicBlock.ManaCost(100, tpkg.TestAPI.ProtocolParameters().WorkScoreParameters())
 	require.NoError(t, err)
 	require.EqualValues(t, expectedBurnedMana, basicBlock.MaxBurnedMana)
@@ -42,8 +42,8 @@ func TestValidationBlockBuilder(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	require.Equal(t, iotago.BlockBodyTypeValidation, block.Block.Type())
+	require.Equal(t, iotago.BlockBodyTypeValidation, block.Body.Type())
 
-	basicBlock := block.Block.(*iotago.ValidationBlock)
+	basicBlock := block.Body.(*iotago.ValidationBlock)
 	require.EqualValues(t, 100, basicBlock.HighestSupportedVersion)
 }

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -459,7 +459,7 @@ func (b *TransactionBuilder) CalculateAvailableMana(targetSlot iotago.SlotIndex)
 	return result, nil
 }
 
-// MinRequiredAllotedMana returns the minimum alloted mana required to issue a ProtocolBlock
+// MinRequiredAllotedMana returns the minimum alloted mana required to issue a Block
 // with 4 strong parents, the transaction payload from the builder and 1 allotment for the block issuer.
 func (b *TransactionBuilder) MinRequiredAllotedMana(workScoreParameters *iotago.WorkScoreParameters, rmc iotago.Mana, blockIssuerAccountID iotago.AccountID) (iotago.Mana, error) {
 	// clone the essence allotments to not modify the original transaction

--- a/nodeclient/blockissuer_client.go
+++ b/nodeclient/blockissuer_client.go
@@ -29,10 +29,10 @@ type (
 	BlockIssuerClient interface {
 		// Info returns the info of the block issuer.
 		Info(ctx context.Context) (*apimodels.BlockIssuerInfo, error)
-		// SendPayload sends a BlockPayload to the block issuer.
-		SendPayload(ctx context.Context, payload iotago.BlockPayload, commitmentID iotago.CommitmentID, numPoWWorkers ...int) (*apimodels.BlockCreatedResponse, error)
-		// SendPayloadWithTransactionBuilder automatically allots the needed mana and sends a BlockPayload to the block issuer.
-		SendPayloadWithTransactionBuilder(ctx context.Context, builder *builder.TransactionBuilder, signer iotago.AddressSigner, storedManaOutputIndex int, numPoWWorkers ...int) (iotago.BlockPayload, *apimodels.BlockCreatedResponse, error)
+		// SendPayload sends an ApplicationPayload to the block issuer.
+		SendPayload(ctx context.Context, payload iotago.ApplicationPayload, commitmentID iotago.CommitmentID, numPoWWorkers ...int) (*apimodels.BlockCreatedResponse, error)
+		// SendPayloadWithTransactionBuilder automatically allots the needed mana and sends an ApplicationPayload to the block issuer.
+		SendPayloadWithTransactionBuilder(ctx context.Context, builder *builder.TransactionBuilder, signer iotago.AddressSigner, storedManaOutputIndex int, numPoWWorkers ...int) (iotago.ApplicationPayload, *apimodels.BlockCreatedResponse, error)
 	}
 
 	blockIssuerClient struct {
@@ -63,7 +63,7 @@ func (client *blockIssuerClient) Info(ctx context.Context) (*apimodels.BlockIssu
 	return res, nil
 }
 
-func (client *blockIssuerClient) mineNonceAndSendPayload(ctx context.Context, payload iotago.BlockPayload, commitmentID iotago.CommitmentID, powTargetTrailingZeros uint8, numPoWWorkers ...int) (*apimodels.BlockCreatedResponse, error) {
+func (client *blockIssuerClient) mineNonceAndSendPayload(ctx context.Context, payload iotago.ApplicationPayload, commitmentID iotago.CommitmentID, powTargetTrailingZeros uint8, numPoWWorkers ...int) (*apimodels.BlockCreatedResponse, error) {
 	payloadBytes, err := client.core.CommittedAPI().Encode(payload, serix.WithValidation())
 	if err != nil {
 		return nil, ierrors.Wrap(err, "failed to encode the payload")
@@ -93,7 +93,7 @@ func (client *blockIssuerClient) mineNonceAndSendPayload(ctx context.Context, pa
 	return res, nil
 }
 
-func (client *blockIssuerClient) SendPayload(ctx context.Context, payload iotago.BlockPayload, commitmentID iotago.CommitmentID, numPoWWorkers ...int) (*apimodels.BlockCreatedResponse, error) {
+func (client *blockIssuerClient) SendPayload(ctx context.Context, payload iotago.ApplicationPayload, commitmentID iotago.CommitmentID, numPoWWorkers ...int) (*apimodels.BlockCreatedResponse, error) {
 	// get the info from the block issuer
 	blockIssuerInfo, err := client.Info(ctx)
 	if err != nil {
@@ -103,7 +103,7 @@ func (client *blockIssuerClient) SendPayload(ctx context.Context, payload iotago
 	return client.mineNonceAndSendPayload(ctx, payload, commitmentID, blockIssuerInfo.PowTargetTrailingZeros, numPoWWorkers...)
 }
 
-func (client *blockIssuerClient) SendPayloadWithTransactionBuilder(ctx context.Context, builder *builder.TransactionBuilder, signer iotago.AddressSigner, storedManaOutputIndex int, numPoWWorkers ...int) (iotago.BlockPayload, *apimodels.BlockCreatedResponse, error) {
+func (client *blockIssuerClient) SendPayloadWithTransactionBuilder(ctx context.Context, builder *builder.TransactionBuilder, signer iotago.AddressSigner, storedManaOutputIndex int, numPoWWorkers ...int) (iotago.ApplicationPayload, *apimodels.BlockCreatedResponse, error) {
 	// get the info from the block issuer
 	blockIssuerInfo, err := client.Info(ctx)
 	if err != nil {

--- a/nodeclient/event_api_client.go
+++ b/nodeclient/event_api_client.go
@@ -242,8 +242,8 @@ func (eac *EventAPIClient) subscribeToBlockMetadataTopic(topic string) (<-chan *
 	})
 }
 
-func (eac *EventAPIClient) subscribeToBlocksTopic(topic string) (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
-	return subscribeToTopic(eac, topic, func(payload []byte) (*iotago.ProtocolBlock, error) {
+func (eac *EventAPIClient) subscribeToBlocksTopic(topic string) (<-chan *iotago.Block, *EventAPIClientSubscription) {
+	return subscribeToTopic(eac, topic, func(payload []byte) (*iotago.Block, error) {
 		version, _, err := iotago.VersionFromBytes(payload)
 		if err != nil {
 			sendErrOrDrop(eac.Errors, err)
@@ -255,7 +255,7 @@ func (eac *EventAPIClient) subscribeToBlocksTopic(topic string) (<-chan *iotago.
 			return nil, err
 		}
 
-		block := new(iotago.ProtocolBlock)
+		block := new(iotago.Block)
 		if _, err := apiForVersion.Decode(payload, block); err != nil {
 			sendErrOrDrop(eac.Errors, err)
 			return nil, err
@@ -266,44 +266,44 @@ func (eac *EventAPIClient) subscribeToBlocksTopic(topic string) (<-chan *iotago.
 }
 
 // Blocks returns a channel of newly received blocks.
-func (eac *EventAPIClient) Blocks() (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) Blocks() (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	return eac.subscribeToBlocksTopic(EventAPIBlocks)
 }
 
 // AcceptedBlocks returns a channel of blocks of newly accepted blocks.
-func (eac *EventAPIClient) AcceptedBlocks() (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) AcceptedBlocks() (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	return eac.subscribeToBlocksTopic(EventAPIBlocksAccepted)
 }
 
 // ConfirmedBlocks returns a channel of blocks of newly confirmed blocks.
-func (eac *EventAPIClient) ConfirmedBlocks() (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) ConfirmedBlocks() (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	return eac.subscribeToBlocksTopic(EventAPIBlocksConfirmed)
 }
 
 // TransactionBlocks returns a channel of blocks containing transactions.
-func (eac *EventAPIClient) TransactionBlocks() (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) TransactionBlocks() (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	return eac.subscribeToBlocksTopic(EventAPIBlocksTransaction)
 }
 
 // TransactionTaggedDataBlocks returns a channel of blocks containing transactions with tagged data.
-func (eac *EventAPIClient) TransactionTaggedDataBlocks() (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) TransactionTaggedDataBlocks() (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	return eac.subscribeToBlocksTopic(EventAPIBlocksTransactionTaggedData)
 }
 
 // TransactionTaggedDataWithTagBlocks returns a channel of blocks containing transactions with tagged data containing the given tag.
-func (eac *EventAPIClient) TransactionTaggedDataWithTagBlocks(tag []byte) (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) TransactionTaggedDataWithTagBlocks(tag []byte) (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	topic := strings.Replace(EventAPIBlocksTransactionTaggedDataTag, "{tag}", hexutil.EncodeHex(tag), 1)
 
 	return eac.subscribeToBlocksTopic(topic)
 }
 
 // TaggedDataBlocks returns a channel of blocks containing tagged data containing the given tag.
-func (eac *EventAPIClient) TaggedDataBlocks() (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) TaggedDataBlocks() (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	return eac.subscribeToBlocksTopic(EventAPIBlocksTaggedData)
 }
 
 // TaggedDataWithTagBlocks returns a channel of blocks containing tagged data.
-func (eac *EventAPIClient) TaggedDataWithTagBlocks(tag []byte) (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) TaggedDataWithTagBlocks(tag []byte) (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	topic := strings.Replace(EventAPIBlocksTaggedDataTag, "{tag}", hexutil.EncodeHex(tag), 1)
 
 	return eac.subscribeToBlocksTopic(topic)
@@ -354,7 +354,7 @@ func (eac *EventAPIClient) SpentOutputsByUnlockConditionAndAddress(addr iotago.A
 }
 
 // TransactionIncludedBlock returns a channel of the included block which carries the transaction with the given ID.
-func (eac *EventAPIClient) TransactionIncludedBlock(txID iotago.TransactionID) (<-chan *iotago.ProtocolBlock, *EventAPIClientSubscription) {
+func (eac *EventAPIClient) TransactionIncludedBlock(txID iotago.TransactionID) (<-chan *iotago.Block, *EventAPIClientSubscription) {
 	topic := strings.Replace(EventAPITransactionsIncludedBlock, "{transactionId}", txID.ToHex(), 1)
 
 	return eac.subscribeToBlocksTopic(topic)

--- a/nodeclient/event_api_client_test.go
+++ b/nodeclient/event_api_client_test.go
@@ -46,7 +46,7 @@ func Test_EventAPIDisabled(t *testing.T) {
 }
 
 func Test_NewEventAPIClient(t *testing.T) {
-	block := tpkg.RandProtocolBlock(tpkg.RandBasicBlock(tpkg.TestAPI, iotago.PayloadTaggedData), tpkg.TestAPI, 0)
+	block := tpkg.RandBlock(tpkg.RandBasicBlock(tpkg.TestAPI, iotago.PayloadTaggedData), tpkg.TestAPI, 0)
 	originBlockBytes, err := tpkg.TestAPI.Encode(block)
 	require.NoError(t, err)
 	mock := &mockMqttClient{payload: originBlockBytes}

--- a/nodeclient/http_api_client.go
+++ b/nodeclient/http_api_client.go
@@ -468,7 +468,7 @@ func (client *Client) NodeSupportsRoute(ctx context.Context, route string) (bool
 // The node will take care of filling missing information.
 // This function returns the blockID of the finalized block.
 // To get the finalized block you need to call "BlockByBlockID".
-func (client *Client) SubmitBlock(ctx context.Context, m *iotago.ProtocolBlock) (iotago.BlockID, error) {
+func (client *Client) SubmitBlock(ctx context.Context, m *iotago.Block) (iotago.BlockID, error) {
 	// do not check the block because the validation would fail if
 	// no parents were given. The node will first add this missing information and
 	// validate the block afterward.
@@ -512,7 +512,7 @@ func (client *Client) BlockMetadataByBlockID(ctx context.Context, blockID iotago
 }
 
 // BlockByBlockID get a block by its block ID from the node.
-func (client *Client) BlockByBlockID(ctx context.Context, blockID iotago.BlockID) (*iotago.ProtocolBlock, error) {
+func (client *Client) BlockByBlockID(ctx context.Context, blockID iotago.BlockID) (*iotago.Block, error) {
 	query := fmt.Sprintf(RouteBlock, hexutil.EncodeHex(blockID[:]))
 
 	res := new(RawDataEnvelope)
@@ -521,7 +521,7 @@ func (client *Client) BlockByBlockID(ctx context.Context, blockID iotago.BlockID
 		return nil, err
 	}
 
-	block, _, err := iotago.ProtocolBlockFromBytes(client)(res.Data)
+	block, _, err := iotago.BlockFromBytes(client)(res.Data)
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +530,7 @@ func (client *Client) BlockByBlockID(ctx context.Context, blockID iotago.BlockID
 }
 
 // TransactionIncludedBlock get a block that included the given transaction ID in the ledger.
-func (client *Client) TransactionIncludedBlock(ctx context.Context, txID iotago.TransactionID) (*iotago.ProtocolBlock, error) {
+func (client *Client) TransactionIncludedBlock(ctx context.Context, txID iotago.TransactionID) (*iotago.Block, error) {
 	query := fmt.Sprintf(RouteTransactionsIncludedBlock, hexutil.EncodeHex(txID[:]))
 
 	res := new(RawDataEnvelope)
@@ -539,7 +539,7 @@ func (client *Client) TransactionIncludedBlock(ctx context.Context, txID iotago.
 		return nil, err
 	}
 
-	block, _, err := iotago.ProtocolBlockFromBytes(client)(res.Data)
+	block, _, err := iotago.BlockFromBytes(client)(res.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/nodeclient/http_api_client.go
+++ b/nodeclient/http_api_client.go
@@ -473,7 +473,7 @@ func (client *Client) SubmitBlock(ctx context.Context, m *iotago.Block) (iotago.
 	// no parents were given. The node will first add this missing information and
 	// validate the block afterward.
 
-	apiForVersion, err := client.APIForVersion(m.ProtocolVersion)
+	apiForVersion, err := client.APIForVersion(m.Header.ProtocolVersion)
 	if err != nil {
 		return iotago.EmptyBlockID, err
 	}

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -320,7 +320,7 @@ func TestClient_SubmitBlock(t *testing.T) {
 	blockHash := tpkg.Rand36ByteArray()
 	blockHashStr := hexutil.EncodeHex(blockHash[:])
 
-	incompleteBlock := &iotago.ProtocolBlock{
+	incompleteBlock := &iotago.Block{
 		API: mockAPI,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),
@@ -376,7 +376,7 @@ func TestClient_BlockByBlockID(t *testing.T) {
 	identifier := tpkg.Rand36ByteArray()
 	queryHash := hexutil.EncodeHex(identifier[:])
 
-	originBlock := &iotago.ProtocolBlock{
+	originBlock := &iotago.Block{
 		API: mockAPI,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),
@@ -407,7 +407,7 @@ func TestClient_TransactionIncludedBlock(t *testing.T) {
 	txID := tpkg.Rand36ByteArray()
 	queryHash := hexutil.EncodeHex(txID[:])
 
-	originBlock := &iotago.ProtocolBlock{
+	originBlock := &iotago.Block{
 		API: mockAPI,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -327,7 +327,7 @@ func TestClient_SubmitBlock(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),
 		},
 		Signature: &iotago.Ed25519Signature{},
-		Body: &iotago.BasicBlock{
+		Body: &iotago.BasicBlockBody{
 			API:                mockAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(1),
 			WeakParents:        iotago.BlockIDs{},
@@ -384,7 +384,7 @@ func TestClient_BlockByBlockID(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),
 		},
 		Signature: tpkg.RandEd25519Signature(),
-		Body: &iotago.BasicBlock{
+		Body: &iotago.BasicBlockBody{
 			API:                mockAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 			WeakParents:        iotago.BlockIDs{},
@@ -415,7 +415,7 @@ func TestClient_TransactionIncludedBlock(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),
 		},
 		Signature: tpkg.RandEd25519Signature(),
-		Body: &iotago.BasicBlock{
+		Body: &iotago.BasicBlockBody{
 			API:                mockAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 			WeakParents:        iotago.BlockIDs{},

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -327,7 +327,7 @@ func TestClient_SubmitBlock(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),
 		},
 		Signature: &iotago.Ed25519Signature{},
-		Block: &iotago.BasicBlock{
+		Body: &iotago.BasicBlock{
 			API:                mockAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(1),
 			WeakParents:        iotago.BlockIDs{},
@@ -384,7 +384,7 @@ func TestClient_BlockByBlockID(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),
 		},
 		Signature: tpkg.RandEd25519Signature(),
-		Block: &iotago.BasicBlock{
+		Body: &iotago.BasicBlock{
 			API:                mockAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 			WeakParents:        iotago.BlockIDs{},
@@ -415,7 +415,7 @@ func TestClient_TransactionIncludedBlock(t *testing.T) {
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),
 		},
 		Signature: tpkg.RandEd25519Signature(),
-		Block: &iotago.BasicBlock{
+		Body: &iotago.BasicBlock{
 			API:                mockAPI,
 			StrongParents:      tpkg.SortedRandBlockIDs(1 + rand.Intn(7)),
 			WeakParents:        iotago.BlockIDs{},

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -322,7 +322,7 @@ func TestClient_SubmitBlock(t *testing.T) {
 
 	incompleteBlock := &iotago.Block{
 		API: mockAPI,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),
 		},
@@ -378,7 +378,7 @@ func TestClient_BlockByBlockID(t *testing.T) {
 
 	originBlock := &iotago.Block{
 		API: mockAPI,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),
@@ -409,7 +409,7 @@ func TestClient_TransactionIncludedBlock(t *testing.T) {
 
 	originBlock := &iotago.Block{
 		API: mockAPI,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI.Version()).MustID(),

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -710,7 +710,7 @@ func RandBlock(blockBody iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iot
 
 		return &iotago.Block{
 			API: api,
-			BlockHeader: iotago.BlockHeader{
+			Header: iotago.BlockHeader{
 				ProtocolVersion:  TestAPI.Version(),
 				IssuingTime:      RandUTCTime(),
 				SlotCommitmentID: iotago.NewEmptyCommitment(api.ProtocolParameters().Version()).MustID(),
@@ -723,7 +723,7 @@ func RandBlock(blockBody iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iot
 
 	return &iotago.Block{
 		API: api,
-		BlockHeader: iotago.BlockHeader{
+		Header: iotago.BlockHeader{
 			ProtocolVersion:  TestAPI.Version(),
 			IssuingTime:      RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(api.ProtocolParameters().Version()).MustID(),
@@ -771,7 +771,7 @@ func RandBasicBlockWithIssuerAndRMC(api iotago.API, issuerID iotago.AccountID, r
 	basicBlock := RandBasicBlock(api, iotago.PayloadSignedTransaction)
 
 	block := RandBlock(basicBlock, TestAPI, rmc)
-	block.IssuerID = issuerID
+	block.Header.IssuerID = issuerID
 
 	return block
 }

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -735,7 +735,7 @@ func RandProtocolBlock(block iotago.Block, api iotago.API, rmc iotago.Mana) *iot
 }
 
 func RandBasicBlock(api iotago.API, withPayloadType iotago.PayloadType) *iotago.BasicBlock {
-	var payload iotago.BlockPayload
+	var payload iotago.ApplicationPayload
 
 	//nolint:exhaustive
 	switch withPayloadType {

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -699,16 +699,16 @@ func RandBlockID() iotago.BlockID {
 	return Rand36ByteArray()
 }
 
-// RandProtocolBlock returns a random block with the given inner payload.
-func RandProtocolBlock(block iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iotago.ProtocolBlock {
-	if basicBlock, isBasic := block.(*iotago.BasicBlock); isBasic {
+// RandBlock returns a random block with the given inner payload.
+func RandBlock(blockBody iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iotago.Block {
+	if basicBlock, isBasic := blockBody.(*iotago.BasicBlock); isBasic {
 		burnedMana, err := basicBlock.ManaCost(rmc, api.ProtocolParameters().WorkScoreParameters())
 		if err != nil {
 			panic(err)
 		}
 		basicBlock.MaxBurnedMana = burnedMana
 
-		return &iotago.ProtocolBlock{
+		return &iotago.Block{
 			API: api,
 			BlockHeader: iotago.BlockHeader{
 				ProtocolVersion:  TestAPI.Version(),
@@ -721,7 +721,7 @@ func RandProtocolBlock(block iotago.BlockBody, api iotago.API, rmc iotago.Mana) 
 		}
 	}
 
-	return &iotago.ProtocolBlock{
+	return &iotago.Block{
 		API: api,
 		BlockHeader: iotago.BlockHeader{
 			ProtocolVersion:  TestAPI.Version(),
@@ -729,7 +729,7 @@ func RandProtocolBlock(block iotago.BlockBody, api iotago.API, rmc iotago.Mana) 
 			SlotCommitmentID: iotago.NewEmptyCommitment(api.ProtocolParameters().Version()).MustID(),
 			IssuerID:         RandAccountID(),
 		},
-		Body:      block,
+		Body:      blockBody,
 		Signature: RandEd25519Signature(),
 	}
 }
@@ -767,10 +767,10 @@ func RandValidationBlock(api iotago.API) *iotago.ValidationBlock {
 	}
 }
 
-func RandBasicBlockWithIssuerAndRMC(api iotago.API, issuerID iotago.AccountID, rmc iotago.Mana) *iotago.ProtocolBlock {
+func RandBasicBlockWithIssuerAndRMC(api iotago.API, issuerID iotago.AccountID, rmc iotago.Mana) *iotago.Block {
 	basicBlock := RandBasicBlock(api, iotago.PayloadSignedTransaction)
 
-	block := RandProtocolBlock(basicBlock, TestAPI, rmc)
+	block := RandBlock(basicBlock, TestAPI, rmc)
 	block.IssuerID = issuerID
 
 	return block

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -700,7 +700,7 @@ func RandBlockID() iotago.BlockID {
 }
 
 // RandProtocolBlock returns a random block with the given inner payload.
-func RandProtocolBlock(block iotago.Block, api iotago.API, rmc iotago.Mana) *iotago.ProtocolBlock {
+func RandProtocolBlock(block iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iotago.ProtocolBlock {
 	if basicBlock, isBasic := block.(*iotago.BasicBlock); isBasic {
 		burnedMana, err := basicBlock.ManaCost(rmc, api.ProtocolParameters().WorkScoreParameters())
 		if err != nil {

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -701,7 +701,7 @@ func RandBlockID() iotago.BlockID {
 
 // RandBlock returns a random block with the given inner payload.
 func RandBlock(blockBody iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iotago.Block {
-	if basicBlock, isBasic := blockBody.(*iotago.BasicBlock); isBasic {
+	if basicBlock, isBasic := blockBody.(*iotago.BasicBlockBody); isBasic {
 		burnedMana, err := basicBlock.ManaCost(rmc, api.ProtocolParameters().WorkScoreParameters())
 		if err != nil {
 			panic(err)
@@ -734,7 +734,7 @@ func RandBlock(blockBody iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iot
 	}
 }
 
-func RandBasicBlock(api iotago.API, withPayloadType iotago.PayloadType) *iotago.BasicBlock {
+func RandBasicBlock(api iotago.API, withPayloadType iotago.PayloadType) *iotago.BasicBlockBody {
 	var payload iotago.ApplicationPayload
 
 	//nolint:exhaustive
@@ -747,7 +747,7 @@ func RandBasicBlock(api iotago.API, withPayloadType iotago.PayloadType) *iotago.
 		payload = &iotago.CandidacyAnnouncement{}
 	}
 
-	return &iotago.BasicBlock{
+	return &iotago.BasicBlockBody{
 		API:                api,
 		StrongParents:      SortedRandBlockIDs(1 + rand.Intn(iotago.BlockMaxParents)),
 		WeakParents:        iotago.BlockIDs{},
@@ -757,8 +757,8 @@ func RandBasicBlock(api iotago.API, withPayloadType iotago.PayloadType) *iotago.
 	}
 }
 
-func RandValidationBlock(api iotago.API) *iotago.ValidationBlock {
-	return &iotago.ValidationBlock{
+func RandValidationBlock(api iotago.API) *iotago.ValidationBlockBody {
+	return &iotago.ValidationBlockBody{
 		API:                     api,
 		StrongParents:           SortedRandBlockIDs(1 + rand.Intn(iotago.BlockTypeValidationMaxParents)),
 		WeakParents:             iotago.BlockIDs{},

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -716,7 +716,7 @@ func RandProtocolBlock(block iotago.BlockBody, api iotago.API, rmc iotago.Mana) 
 				SlotCommitmentID: iotago.NewEmptyCommitment(api.ProtocolParameters().Version()).MustID(),
 				IssuerID:         RandAccountID(),
 			},
-			Block:     basicBlock,
+			Body:      basicBlock,
 			Signature: RandEd25519Signature(),
 		}
 	}
@@ -729,7 +729,7 @@ func RandProtocolBlock(block iotago.BlockBody, api iotago.API, rmc iotago.Mana) 
 			SlotCommitmentID: iotago.NewEmptyCommitment(api.ProtocolParameters().Version()).MustID(),
 			IssuerID:         RandAccountID(),
 		},
-		Block:     block,
+		Body:      block,
 		Signature: RandEd25519Signature(),
 	}
 }


### PR DESCRIPTION
# Description of change

Add `Header` key in `Block`
Append `Body` to `{Basic,Validation}Block`
Rename `ProtocolBlock` -> `Block`
Rename `Block` in `ProtocolBlock` to `Body`
Rename `Block` -> `BlockBody`
Rename `BlockPayload` -> `ApplicationPayload`
Removes nesting from `BlockHeader`.
Remove `Block` prefixes in field names.

Also adapted most variable and function names where it made sense.

Implements iotaledger/iota-core#467.

## How the change has been tested

Existing tests pass.
