### PR TITLE
rename max parents

### DIFF
--- a/block.go
+++ b/block.go
@@ -19,10 +19,10 @@ import (
 const (
 	// MaxBlockSize defines the maximum size of a block.
 	MaxBlockSize = 32768
-	// BlockMaxParents defines the maximum amount of parents in a block.
-	BlockMaxParents = 8
-	// BlockTypeValidationMaxParents defines the maximum amount of parents in a ValidationBlock. TODO: replace number with committee size.
-	BlockTypeValidationMaxParents = BlockMaxParents + 42
+	// BasicBlockMaxParents defines the maximum number of parents in a basic block.
+	BasicBlockMaxParents = 8
+	// ValidationBlockMaxParents defines the maximum number of parents in a ValidationBlock.
+	ValidationBlockMaxParents = 50
 
 	// block type + strong parents count + weak parents count + shallow like parents count + payload type + mana.
 	BasicBlockSizeEmptyParentsAndEmptyPayload = serializer.OneByte + serializer.OneByte + serializer.OneByte + serializer.OneByte + serializer.TypeDenotationByteSize + ManaSize

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -749,7 +749,7 @@ func RandBasicBlock(api iotago.API, withPayloadType iotago.PayloadType) *iotago.
 
 	return &iotago.BasicBlockBody{
 		API:                api,
-		StrongParents:      SortedRandBlockIDs(1 + rand.Intn(iotago.BlockMaxParents)),
+		StrongParents:      SortedRandBlockIDs(1 + rand.Intn(iotago.BasicBlockMaxParents)),
 		WeakParents:        iotago.BlockIDs{},
 		ShallowLikeParents: iotago.BlockIDs{},
 		Payload:            payload,
@@ -760,7 +760,7 @@ func RandBasicBlock(api iotago.API, withPayloadType iotago.PayloadType) *iotago.
 func RandValidationBlock(api iotago.API) *iotago.ValidationBlockBody {
 	return &iotago.ValidationBlockBody{
 		API:                     api,
-		StrongParents:           SortedRandBlockIDs(1 + rand.Intn(iotago.BlockTypeValidationMaxParents)),
+		StrongParents:           SortedRandBlockIDs(1 + rand.Intn(iotago.ValidationBlockMaxParents)),
 		WeakParents:             iotago.BlockIDs{},
 		ShallowLikeParents:      iotago.BlockIDs{},
 		HighestSupportedVersion: TestAPI.Version() + 1,


### PR DESCRIPTION
renames the max parents for basic blocks and validation blocks. 

BlockMaxParents -> BasicBlockMaxParents
BlockTypeValidationMaxParents -> ValidationBlockMaxParents