### PR TITLE
Unify syntactic output checks & make address restriction checks syntactic

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -456,9 +456,6 @@ func V3API(protoParams ProtocolParameters) API {
 
 	{
 		must(api.RegisterTypeSettings(AccountOutput{}, serix.TypeSettings{}.WithObjectType(uint8(OutputAccount))))
-		must(api.RegisterValidators(AccountOutput{}, nil, func(ctx context.Context, account AccountOutput) error {
-			return account.syntacticallyValidate()
-		}))
 
 		must(api.RegisterTypeSettings(AccountOutputUnlockConditions{},
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte).WithArrayRules(accountOutputV3UnlockCondArrRules),
@@ -485,9 +482,6 @@ func V3API(protoParams ProtocolParameters) API {
 
 	{
 		must(api.RegisterTypeSettings(AnchorOutput{}, serix.TypeSettings{}.WithObjectType(uint8(OutputAnchor))))
-		must(api.RegisterValidators(AnchorOutput{}, nil, func(ctx context.Context, anchor AnchorOutput) error {
-			return anchor.syntacticallyValidate()
-		}))
 
 		must(api.RegisterTypeSettings(AnchorOutputUnlockConditions{},
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte).WithArrayRules(anchorOutputV3UnlockCondArrRules),
@@ -515,10 +509,6 @@ func V3API(protoParams ProtocolParameters) API {
 		must(api.RegisterTypeSettings(FoundryOutput{},
 			serix.TypeSettings{}.WithObjectType(uint8(OutputFoundry))),
 		)
-		must(api.RegisterValidators(FoundryOutput{}, nil, func(ctx context.Context, foundry FoundryOutput) error {
-			//nolint:contextcheck
-			return foundry.syntacticallyValidate()
-		}))
 
 		must(api.RegisterTypeSettings(FoundryOutputUnlockConditions{},
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte).WithArrayRules(foundryOutputV3UnlockCondArrRules),
@@ -547,9 +537,6 @@ func V3API(protoParams ProtocolParameters) API {
 		must(api.RegisterTypeSettings(NFTOutput{},
 			serix.TypeSettings{}.WithObjectType(uint8(OutputNFT))),
 		)
-		must(api.RegisterValidators(NFTOutput{}, nil, func(ctx context.Context, nft NFTOutput) error {
-			return nft.syntacticallyValidate()
-		}))
 
 		must(api.RegisterTypeSettings(NFTOutputUnlockConditions{},
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte).WithArrayRules(nftOutputV3UnlockCondArrRules),
@@ -578,9 +565,6 @@ func V3API(protoParams ProtocolParameters) API {
 
 	{
 		must(api.RegisterTypeSettings(DelegationOutput{}, serix.TypeSettings{}.WithObjectType(uint8(OutputDelegation))))
-		must(api.RegisterValidators(DelegationOutput{}, nil, func(ctx context.Context, delegation DelegationOutput) error {
-			return delegation.syntacticallyValidate()
-		}))
 
 		must(api.RegisterTypeSettings(DelegationOutputUnlockConditions{},
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte).WithArrayRules(delegationOutputV3UnlockCondArrRules),

--- a/feat_native_token_test.go
+++ b/feat_native_token_test.go
@@ -74,6 +74,9 @@ func TestNativeToken_SyntacticalValidation(t *testing.T) {
 			}
 
 			foundryBytes, err := tpkg.TestAPI.Encode(foundryIn, serix.WithValidation())
+			if err == nil {
+				err = iotago.OutputsSyntacticalFoundry()(0, foundryIn)
+			}
 			if test.wantErr != nil {
 				require.ErrorIs(t, err, test.wantErr)
 				return

--- a/output.go
+++ b/output.go
@@ -592,8 +592,7 @@ func checkAddressRestrictions(output TxEssenceOutput, address Address) error {
 	return nil
 }
 
-// OutputsSyntacticalAddressRestrictions returns a func that checks the capability flag restrictions on addresses, and checks that
-// no more than one Implicit Account Creation Address is on the input side of a transaction.
+// OutputsSyntacticalAddressRestrictions returns a func that checks the capability flag restrictions on addresses.
 //
 // Does not validate the Return Address in StorageDepositReturnUnlockCondition because such a Return Address
 // already is as restricted as the most restricted address.

--- a/output_account.go
+++ b/output_account.go
@@ -178,15 +178,6 @@ func (a *AccountOutput) StorageScore(storageScoreStruct *StorageScoreStructure, 
 		a.ImmutableFeatures.StorageScore(storageScoreStruct, nil)
 }
 
-func (a *AccountOutput) syntacticallyValidate() error {
-	// Address should never be nil.
-	if a.Conditions.MustSet().Address().Address.Type() == AddressImplicitAccountCreation {
-		return ErrImplicitAccountCreationAddressInInvalidOutput
-	}
-
-	return nil
-}
-
 func (a *AccountOutput) WorkScore(workScoreParameters *WorkScoreParameters) (WorkScore, error) {
 	workScoreConditions, err := a.Conditions.WorkScore(workScoreParameters)
 	if err != nil {

--- a/output_anchor.go
+++ b/output_anchor.go
@@ -183,18 +183,6 @@ func (a *AnchorOutput) StorageScore(storageScoreStruct *StorageScoreStructure, _
 		a.ImmutableFeatures.StorageScore(storageScoreStruct, nil)
 }
 
-func (a *AnchorOutput) syntacticallyValidate() error {
-	// Address should never be nil.
-	stateControllerAddress := a.Conditions.MustSet().StateControllerAddress().Address
-	governorAddress := a.Conditions.MustSet().GovernorAddress().Address
-
-	if (stateControllerAddress.Type() == AddressImplicitAccountCreation) || (governorAddress.Type() == AddressImplicitAccountCreation) {
-		return ErrImplicitAccountCreationAddressInInvalidOutput
-	}
-
-	return nil
-}
-
 func (a *AnchorOutput) WorkScore(workScoreParameters *WorkScoreParameters) (WorkScore, error) {
 	workScoreConditions, err := a.Conditions.WorkScore(workScoreParameters)
 	if err != nil {

--- a/output_delegation.go
+++ b/output_delegation.go
@@ -180,21 +180,6 @@ func (d *DelegationOutput) StorageScore(storageScoreStruct *StorageScoreStructur
 		d.Conditions.StorageScore(storageScoreStruct, nil)
 }
 
-func (d *DelegationOutput) syntacticallyValidate() error {
-	if d.ValidatorAddress.AccountID().Empty() {
-		return ErrDelegationValidatorAddressEmpty
-	}
-
-	// Address should never be nil.
-	address := d.Conditions.MustSet().Address().Address
-
-	if address.Type() == AddressImplicitAccountCreation {
-		return ErrImplicitAccountCreationAddressInInvalidOutput
-	}
-
-	return nil
-}
-
 func (d *DelegationOutput) WorkScore(workScoreParameters *WorkScoreParameters) (WorkScore, error) {
 	return d.Conditions.WorkScore(workScoreParameters)
 }

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -211,25 +211,6 @@ func (f *FoundryOutput) WorkScore(workScoreParameters *WorkScoreParameters) (Wor
 	return workScoreTokenScheme.Add(workScoreConditions, workScoreFeatures, workScoreImmutableFeatures)
 }
 
-func (f *FoundryOutput) syntacticallyValidate() error {
-	nativeTokenFeature := f.FeatureSet().NativeToken()
-	if nativeTokenFeature == nil {
-		return nil
-	}
-
-	foundryID, err := f.FoundryID()
-	if err != nil {
-		return err
-	}
-
-	// NativeTokenFeature ID should have the same ID as the foundry
-	if !foundryID.Matches(nativeTokenFeature.ID) {
-		return ierrors.Wrapf(ErrFoundryIDNativeTokenIDMismatch, "FoundryID: %s, NativeTokenID: %s", foundryID, nativeTokenFeature.ID)
-	}
-
-	return nil
-}
-
 func (f *FoundryOutput) ChainID() ChainID {
 	foundryID, err := f.FoundryID()
 	if err != nil {

--- a/output_nft.go
+++ b/output_nft.go
@@ -188,17 +188,6 @@ func (n *NFTOutput) WorkScore(workScoreParameters *WorkScoreParameters) (WorkSco
 	return workScoreConditions.Add(workScoreFeatures, workScoreImmutableFeatures)
 }
 
-func (n *NFTOutput) syntacticallyValidate() error {
-	// Address should never be nil.
-	address := n.Conditions.MustSet().Address().Address
-
-	if address.Type() == AddressImplicitAccountCreation {
-		return ErrImplicitAccountCreationAddressInInvalidOutput
-	}
-
-	return nil
-}
-
 func (n *NFTOutput) ChainID() ChainID {
 	return n.NFTID
 }

--- a/output_test.go
+++ b/output_test.go
@@ -857,7 +857,7 @@ func TestOutputsSyntacticaDelegation(t *testing.T) {
 			},
 		},
 		{
-			name: "fail - validator id zeroed",
+			name: "fail - Delegation Output contains empty validator address",
 			outputs: iotago.Outputs[iotago.Output]{
 				&iotago.DelegationOutput{
 					Amount:           OneIOTA,

--- a/signed_transaction.go
+++ b/signed_transaction.go
@@ -103,7 +103,7 @@ func (t *SignedTransaction) syntacticallyValidate() error {
 		return ierrors.Errorf("unlock block count must match inputs in transaction, %d vs. %d", len(t.Unlocks), len(inputs))
 	}
 
-	if err := t.Transaction.syntacticallyValidate(t.API); err != nil {
+	if err := t.Transaction.SyntacticallyValidate(t.API); err != nil {
 		return ierrors.Errorf("transaction is invalid: %w", err)
 	}
 

--- a/transaction.go
+++ b/transaction.go
@@ -44,8 +44,6 @@ var (
 	ErrAnchorOutputCyclicAddress = ierrors.New("anchor output's AnchorID corresponds to state and/or governance controller")
 	// ErrNFTOutputCyclicAddress gets returned if an NFTOutput's NFTID results into the same address as the address field within the output.
 	ErrNFTOutputCyclicAddress = ierrors.New("NFT output's ID corresponds to address field")
-	// ErrDelegationValidatorAddressZeroed gets returned if a Delegation Output's Validator address is zeroed out.
-	ErrDelegationValidatorAddressZeroed = ierrors.New("delegation output's validator address is zeroed")
 	// ErrOutputsSumExceedsTotalSupply gets returned if the sum of the output deposits exceeds the total supply of tokens.
 	ErrOutputsSumExceedsTotalSupply = ierrors.New("accumulated output balance exceeds total supply")
 	// ErrOutputAmountMoreThanTotalSupply gets returned if an output base token amount is more than the total supply.

--- a/transaction.go
+++ b/transaction.go
@@ -269,6 +269,7 @@ func (t *Transaction) SyntacticallyValidate(api API) error {
 		OutputsSyntacticalNFT(),
 		OutputsSyntacticalDelegation(),
 		OutputsSyntacticalAddressRestrictions(),
+		OutputsSyntacticalImplicitAccountCreationAddress(),
 	)
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -268,6 +268,7 @@ func (t *Transaction) syntacticallyValidate(api API) error {
 		OutputsSyntacticalAnchor(),
 		OutputsSyntacticalNFT(),
 		OutputsSyntacticalDelegation(),
+		OutputsSyntacticalAddressRestrictions(),
 	)
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -251,10 +251,10 @@ func (t *Transaction) Size() int {
 
 // syntacticallyValidate checks whether the transaction essence is syntactically valid.
 // The function does not syntactically validate the input or outputs themselves.
-func (t *Transaction) syntacticallyValidate(api API) error {
+func (t *Transaction) SyntacticallyValidate(api API) error {
 	protoParams := api.ProtocolParameters()
 
-	if err := t.TransactionEssence.SyntacticallyValidate(api); err != nil {
+	if err := t.TransactionEssence.syntacticallyValidateEssence(api); err != nil {
 		return err
 	}
 

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -108,7 +108,10 @@ func (u *TransactionEssence) WorkScore(workScoreParameters *WorkScoreParameters)
 
 // SyntacticallyValidate checks whether the transaction essence is syntactically valid.
 // The function does not syntactically validate the input or outputs themselves.
-func (u *TransactionEssence) SyntacticallyValidate(api API) error {
+//
+// This function includes "essence" in its name to disambiguate it from the "SyntacticallyValidate" function on the Transaction,
+// and since the essence is embedded in the Transaction a similar name could easily lead to confusion.
+func (u *TransactionEssence) syntacticallyValidateEssence(api API) error {
 	if err := BitMaskNonTrailingZeroBytesValidatorFunc(u.Capabilities); err != nil {
 		return ierrors.Wrapf(ErrTxEssenceCapabilitiesInvalid, "invalid capabilities bitmask: %w", err)
 	}

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -20,7 +20,7 @@ func NewVirtualMachine() vm.VirtualMachine {
 			vm.ExecFuncBalancedNativeTokens(),
 			vm.ExecFuncChainTransitions(),
 			vm.ExecFuncBalancedMana(),
-			vm.ExecFuncAddressRestrictions(),
+			vm.ExecFuncAtMostOneImplicitAccountCreationAddress(),
 		},
 	}
 }

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -7850,7 +7850,13 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 		resolvedInputs.CommitmentInput = &tests[idx].resolvedCommitmentInput
 
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateAndExecuteSignedTransaction(tx, resolvedInputs)
+			var err error
+			// Some constraints are implicitly tested as part of the address restrictions, which are syntactic checks.
+			err = tx.Transaction.SyntacticallyValidate(tx.API)
+			if err == nil {
+				err = validateAndExecuteSignedTransaction(tx, resolvedInputs)
+			}
+
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 				return

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -7358,7 +7358,7 @@ func TestTxSemanticAddressRestrictions(t *testing.T) {
 					},
 				}
 
-				_, err := novaVM.Execute(tx.Transaction, resolvedInputs, make(vm.UnlockedIdentities), vm.ExecFuncAddressRestrictions())
+				_, err := novaVM.Execute(tx.Transaction, resolvedInputs, make(vm.UnlockedIdentities), vm.ExecFuncAtMostOneImplicitAccountCreationAddress())
 				if testInput.wantErr != nil {
 					require.ErrorIs(t, err, testInput.wantErr)
 					return


### PR DESCRIPTION
# Description of change

Unifies the syntactic checks for outputs. Some were executed at (de)serialization time, some were run as part of syntactic transaction validation. Now they are all run in the latter since that is the more established pattern.

Also makes the address restriction checks syntactic (rather than semantic) and introduces a dedicated function for the semantic check that only one input in a given transaction may contain an address of type implicit account creation address.

Finally, this PR makes `SyntacticallyValidate` on `TransactionEssence` private, renames it and makes `syntacticallyValidate` on the `Transaction` public. Since the essence is embedded in the transaction it was easy to accidentally call `transaction.SyntacticallyValidate` which would only validate the inner essence instead of the whole transaction. That was already the case in the signed transaction where `t.Transaction.syntacticallyValidate(t.API)` was called.

## How the change has been tested

Some tests had to be adapted because they relied on serix validation. The previous deserialization tests for implicit account creation address checks were moved to a dedicated test.