### PR TITLE
Add Stored Mana and Allotments do not exceed Max Mana check

### DIFF
--- a/output.go
+++ b/output.go
@@ -406,7 +406,7 @@ func OutputsSyntacticalStoredMana(maxManaValue Mana) OutputsSyntacticalValidatio
 		var err error
 		sum, err = safemath.SafeAdd(sum, storedMana)
 		if err != nil {
-			return ierrors.Errorf("%w: %w: stored mana sum calculation failed at output %d", ErrMaxManaExceeded, err, index)
+			return ierrors.Wrapf(ErrMaxManaExceeded, "%w: stored mana sum calculation failed at output %d", err, index)
 		}
 
 		if sum > maxManaValue {

--- a/output_test.go
+++ b/output_test.go
@@ -297,7 +297,7 @@ func TestOutputsSyntacticalDepositAmount(t *testing.T) {
 					},
 				},
 			},
-			wantErr: iotago.ErrOutputAmountMoreThanTotalSupply,
+			wantErr: iotago.ErrOutputsSumExceedsTotalSupply,
 		},
 		{
 			name:        "fail - sum more than total supply over multiple outputs",

--- a/transaction.go
+++ b/transaction.go
@@ -277,7 +277,9 @@ func (t *Transaction) SyntacticallyValidate(api API) error {
 	}
 
 	var maxManaValue Mana = (1 << protoParams.ManaParameters().BitsCount) - 1
-	t.allotmentSyntacticValidation(maxManaValue)
+	if err := t.allotmentSyntacticValidation(maxManaValue); err != nil {
+		return err
+	}
 
 	return SyntacticallyValidateOutputs(t.Outputs,
 		OutputsSyntacticalDepositAmount(protoParams, api.StorageScoreStructure()),

--- a/transaction.go
+++ b/transaction.go
@@ -47,8 +47,6 @@ var (
 	ErrNFTOutputCyclicAddress = ierrors.New("NFT output's ID corresponds to address field")
 	// ErrOutputsSumExceedsTotalSupply gets returned if the sum of the output deposits exceeds the total supply of tokens.
 	ErrOutputsSumExceedsTotalSupply = ierrors.New("accumulated output balance exceeds total supply")
-	// ErrOutputAmountMoreThanTotalSupply gets returned if an output base token amount is more than the total supply.
-	ErrOutputAmountMoreThanTotalSupply = ierrors.New("an output's base token amount cannot exceed the total supply")
 	// ErrStorageDepositLessThanMinReturnOutputStorageDeposit gets returned when the storage deposit condition's amount is less than the min storage deposit for the return output.
 	ErrStorageDepositLessThanMinReturnOutputStorageDeposit = ierrors.New("storage deposit return amount is less than the min storage deposit needed for the return output")
 	// ErrStorageDepositExceedsTargetOutputAmount gets returned when the storage deposit condition's amount exceeds the target output's base token amount.

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -371,7 +371,7 @@ func TestTransactionSyntacticMaxMana(t *testing.T) {
 					tx.Allotments = iotago.Allotments{allotmentWithMana(maxManaValue + 1)}
 				},
 			),
-			wantErr: nil,
+			wantErr: iotago.ErrMaxManaExceeded,
 		},
 		{
 			name: "fail - sum of allotted mana exceeds max value",
@@ -380,7 +380,7 @@ func TestTransactionSyntacticMaxMana(t *testing.T) {
 					tx.Allotments = iotago.Allotments{allotmentWithMana(maxManaValue - 1), allotmentWithMana(maxManaValue - 1)}
 				},
 			),
-			wantErr: nil,
+			wantErr: iotago.ErrMaxManaExceeded,
 		},
 	}
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -299,3 +299,100 @@ func TestTransactionEssenceCapabilitiesBitMask(t *testing.T) {
 		})
 	}
 }
+
+func TestTransactionSyntacticMaxMana(t *testing.T) {
+	type test struct {
+		name    string
+		tx      *iotago.Transaction
+		wantErr error
+	}
+
+	basicOutputWithMana := func(mana iotago.Mana) *iotago.BasicOutput {
+		return &iotago.BasicOutput{
+			Amount: OneIOTA,
+			Mana:   mana,
+			Conditions: iotago.BasicOutputUnlockConditions{
+				&iotago.AddressUnlockCondition{
+					Address: tpkg.RandEd25519Address(),
+				},
+			},
+		}
+	}
+
+	allotmentWithMana := func(mana iotago.Mana) *iotago.Allotment {
+		return &iotago.Allotment{
+			Mana:      mana,
+			AccountID: tpkg.RandAccountID(),
+		}
+	}
+
+	var maxManaValue iotago.Mana = (1 << tpkg.TestAPI.ProtocolParameters().ManaParameters().BitsCount) - 1
+	tests := []*test{
+		{
+			name: "ok - stored mana sum below max value",
+			tx: tpkg.RandTransactionWithOptions(tpkg.TestAPI,
+				func(tx *iotago.Transaction) {
+					tx.Outputs = iotago.TxEssenceOutputs{basicOutputWithMana(1), basicOutputWithMana(maxManaValue - 1)}
+				},
+			),
+			wantErr: nil,
+		},
+		{
+			name: "fail - one output's stored mana exceeds max mana value",
+			tx: tpkg.RandTransactionWithOptions(tpkg.TestAPI,
+				func(tx *iotago.Transaction) {
+					tx.Outputs = iotago.TxEssenceOutputs{basicOutputWithMana(maxManaValue + 1)}
+				},
+			),
+			wantErr: iotago.ErrMaxManaExceeded,
+		},
+		{
+			name: "fail - sum of stored mana exceeds max mana value",
+			tx: tpkg.RandTransactionWithOptions(tpkg.TestAPI,
+				func(tx *iotago.Transaction) {
+					tx.Outputs = iotago.TxEssenceOutputs{basicOutputWithMana(maxManaValue - 1), basicOutputWithMana(maxManaValue - 1)}
+				},
+			),
+			wantErr: iotago.ErrMaxManaExceeded,
+		},
+		{
+			name: "ok - allotted mana sum below max value",
+			tx: tpkg.RandTransactionWithOptions(tpkg.TestAPI,
+				func(tx *iotago.Transaction) {
+					tx.Allotments = iotago.Allotments{allotmentWithMana(1), allotmentWithMana(maxManaValue - 1)}
+				},
+			),
+			wantErr: nil,
+		},
+		{
+			name: "fail - one allotment's mana exceeds max value",
+			tx: tpkg.RandTransactionWithOptions(tpkg.TestAPI,
+				func(tx *iotago.Transaction) {
+					tx.Allotments = iotago.Allotments{allotmentWithMana(maxManaValue + 1)}
+				},
+			),
+			wantErr: nil,
+		},
+		{
+			name: "fail - sum of allotted mana exceeds max value",
+			tx: tpkg.RandTransactionWithOptions(tpkg.TestAPI,
+				func(tx *iotago.Transaction) {
+					tx.Allotments = iotago.Allotments{allotmentWithMana(maxManaValue - 1), allotmentWithMana(maxManaValue - 1)}
+				},
+			),
+			wantErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.tx.SyntacticallyValidate(tpkg.TestAPI)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
# Description of change

Adds a check that the sum of stored mana or the sum of allotments does not exceed the maximum possible mana value (<code>2<sup>Mana Parameters::Bits Count</sup> - 1</code>). Note that this does not check that the sum of all stored mana plus the sum of all allotments does not exceed this max value. It's debatable whether we should do that, but since the semantic validation of Mana does take care of that part, we do not absolutely have to do it at the syntactic check already.

Also removes the explicit check that an output cannot exceed max base token supply, because that check is included in the "the sum of all base tokens cannot exceed max token supply" check implicitly. I believe this was done as an overflow safeguard, but by using safemath, we can avoid this extra check.

## How the change has been tested

Added tests for the new checks.