### PR TITLE
Fix transaction output validation

### DIFF
--- a/output.go
+++ b/output.go
@@ -375,8 +375,6 @@ func OutputsSyntacticalDepositAmount(protoParams ProtocolParameters, storageScor
 			}
 		}
 
-		sum += amount
-
 		return nil
 	}
 }


### PR DESCRIPTION
Amount was added twice, once with safemath once without, which caused problems during syntactical validation of transactions with large outputs.