### PR TITLE
Make staked amount check syntactical

### DIFF
--- a/feat_staking.go
+++ b/feat_staking.go
@@ -12,9 +12,6 @@ var (
 	// ErrInvalidStakingEndEpochTooEarly gets returned when a new Staking Feature's end epoch
 	// is not at least set to the transaction epoch plus the unbonding period.
 	ErrInvalidStakingEndEpochTooEarly = ierrors.New("staking end epoch must be set to the transaction epoch plus the unbonding period")
-	// ErrInvalidStakingAmountMismatch gets returned when a new Staking Feature's Staked Amount
-	// is not less or equal to the account's amount.
-	ErrInvalidStakingAmountMismatch = ierrors.New("staking amount must be less or equal to the amount on the account")
 	// ErrInvalidStakingBlockIssuerRequired gets returned when an account contains a Staking Feature
 	// but no Block Issuer Feature.
 	ErrInvalidStakingBlockIssuerRequired = ierrors.New("staking feature requires a block issuer feature")

--- a/output.go
+++ b/output.go
@@ -268,7 +268,7 @@ func (outputSet OutputSet) NewAccounts() AccountOutputsSet {
 	set := make(AccountOutputsSet)
 	for utxoInputID, output := range outputSet {
 		accountOutput, is := output.(*AccountOutput)
-		if !is || !accountOutput.AccountEmpty() {
+		if !is || !accountOutput.AccountID.Empty() {
 			continue
 		}
 		set[AccountIDFromOutputID(utxoInputID)] = accountOutput
@@ -450,7 +450,7 @@ func OutputsSyntacticalAccount() OutputsSyntacticalValidationFunc {
 			return nil
 		}
 
-		if accountOutput.AccountEmpty() {
+		if accountOutput.AccountID.Empty() {
 			if accountOutput.FoundryCounter != 0 {
 				return ierrors.Wrapf(ErrAccountOutputNonEmptyState, "output %d, foundry counter not zero", index)
 			}
@@ -477,7 +477,7 @@ func OutputsSyntacticalAnchor() OutputsSyntacticalValidationFunc {
 			return nil
 		}
 
-		if anchorOutput.AnchorEmpty() {
+		if anchorOutput.AnchorID.Empty() {
 			if anchorOutput.StateIndex != 0 {
 				return ierrors.Wrapf(ErrAnchorOutputNonEmptyState, "output %d, state index not zero", index)
 			}

--- a/output_account.go
+++ b/output_account.go
@@ -205,10 +205,6 @@ func (a *AccountOutput) ChainID() ChainID {
 	return a.AccountID
 }
 
-func (a *AccountOutput) AccountEmpty() bool {
-	return a.AccountID == EmptyAccountID
-}
-
 func (a *AccountOutput) FeatureSet() FeatureSet {
 	return a.Features.MustSet()
 }

--- a/output_anchor.go
+++ b/output_anchor.go
@@ -215,10 +215,6 @@ func (a *AnchorOutput) ChainID() ChainID {
 	return a.AnchorID
 }
 
-func (a *AnchorOutput) AnchorEmpty() bool {
-	return a.AnchorID == EmptyAnchorID
-}
-
 func (a *AnchorOutput) FeatureSet() FeatureSet {
 	return a.Features.MustSet()
 }

--- a/output_test.go
+++ b/output_test.go
@@ -540,6 +540,57 @@ func TestOutputsSyntacticalAccount(t *testing.T) {
 			},
 			wantErr: iotago.ErrAccountOutputCyclicAddress,
 		},
+		{
+			name: "ok - staked amount equal to amount",
+			outputs: iotago.Outputs[iotago.Output]{
+				&iotago.AccountOutput{
+					Amount:         OneIOTA,
+					AccountID:      tpkg.Rand32ByteArray(),
+					FoundryCounter: 1337,
+					UnlockConditions: iotago.AccountOutputUnlockConditions{
+						&iotago.AddressUnlockCondition{Address: tpkg.RandAccountAddress()},
+					},
+					Features: iotago.AccountOutputFeatures{
+						&iotago.StakingFeature{StakedAmount: OneIOTA},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ok - staked amount less than amount",
+			outputs: iotago.Outputs[iotago.Output]{
+				&iotago.AccountOutput{
+					Amount:         OneIOTA + 1,
+					AccountID:      tpkg.Rand32ByteArray(),
+					FoundryCounter: 1337,
+					UnlockConditions: iotago.AccountOutputUnlockConditions{
+						&iotago.AddressUnlockCondition{Address: tpkg.RandAccountAddress()},
+					},
+					Features: iotago.AccountOutputFeatures{
+						&iotago.StakingFeature{StakedAmount: OneIOTA},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "fail - staked amount greater than amount",
+			outputs: iotago.Outputs[iotago.Output]{
+				&iotago.AccountOutput{
+					Amount:         OneIOTA,
+					AccountID:      tpkg.Rand32ByteArray(),
+					FoundryCounter: 1337,
+					UnlockConditions: iotago.AccountOutputUnlockConditions{
+						&iotago.AddressUnlockCondition{Address: tpkg.RandAccountAddress()},
+					},
+					Features: iotago.AccountOutputFeatures{
+						&iotago.StakingFeature{StakedAmount: OneIOTA + 1},
+					},
+				},
+			},
+			wantErr: iotago.ErrAccountOutputAmountLessThanStakedAmount,
+		},
 	}
 	valFunc := iotago.OutputsSyntacticalAccount()
 	for _, tt := range tests {

--- a/transaction.go
+++ b/transaction.go
@@ -39,6 +39,8 @@ var (
 	ErrAccountOutputNonEmptyState = ierrors.New("account output is not empty state")
 	// ErrAccountOutputCyclicAddress gets returned if an AccountOutput's AccountID results into the same address as the address field within the output.
 	ErrAccountOutputCyclicAddress = ierrors.New("account output's ID corresponds to address field")
+	// ErrAccountOutputAmountLessThanStakedAmount gets returned if an AccountOutput's amount is less than the StakedAmount field of its staking feature.
+	ErrAccountOutputAmountLessThanStakedAmount = ierrors.New("account output's amount is less than the staked amount")
 	// ErrAnchorOutputNonEmptyState gets returned if an AnchorOutput with zeroed AnchorID contains state (counters non-zero etc.).
 	ErrAnchorOutputNonEmptyState = ierrors.New("anchor output is not empty state")
 	// ErrAnchorOutputCyclicAddress gets returned if an AnchorOutput's AnchorID results into the same address as the State/Governance controller.

--- a/vm/nova/stvf_test.go
+++ b/vm/nova/stvf_test.go
@@ -351,47 +351,6 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			wantErr: iotago.ErrInvalidStakingEndEpochTooEarly,
 		},
 		{
-			name: "fail - staking genesis staked amount higher than amount",
-			next: &iotago.AccountOutput{
-				Amount:    100,
-				AccountID: iotago.AccountID{},
-				UnlockConditions: iotago.AccountOutputUnlockConditions{
-					&iotago.AddressUnlockCondition{Address: tpkg.RandEd25519Address()},
-				},
-				Features: iotago.AccountOutputFeatures{
-					&iotago.StakingFeature{
-						StakedAmount: 500,
-						FixedCost:    5,
-						StartEpoch:   currentEpoch,
-						EndEpoch:     currentEpoch + tpkg.TestAPI.ProtocolParameters().StakingUnbondingPeriod(),
-					},
-					exampleBlockIssuerFeature,
-				},
-			},
-			input:     nil,
-			transType: iotago.ChainTransitionTypeGenesis,
-			svCtx: &vm.Params{
-				API: tpkg.TestAPI,
-				WorkingSet: &vm.WorkingSet{
-					Commitment: &iotago.Commitment{
-						Slot: currentSlot,
-					},
-					UnlockedIdents: vm.UnlockedIdentities{
-						exampleIssuer.Key(): {UnlockedAt: 0},
-					},
-					Tx: &iotago.Transaction{
-						API: tpkg.TestAPI,
-						TransactionEssence: &iotago.TransactionEssence{
-							CreationSlot: currentSlot,
-							Capabilities: iotago.TransactionCapabilitiesBitMaskWithCapabilities(iotago.WithTransactionCanDoAnything()),
-						},
-					},
-					BIC: exampleBIC,
-				},
-			},
-			wantErr: iotago.ErrInvalidStakingAmountMismatch,
-		},
-		{
 			name: "fail - staking feature without block issuer feature",
 			next: &iotago.AccountOutput{
 				Amount:    100,

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -476,10 +476,6 @@ func accountStakingSTVF(vmParams *vm.Params, chainID iotago.ChainID, current *io
 // or one which was effectively removed and added within the same transaction.
 // This is allowed as long as the epoch range of the old and new feature are disjoint.
 func accountStakingGenesisValidation(vmParams *vm.Params, next *iotago.AccountOutput, stakingFeat *iotago.StakingFeature) error {
-	if next.Amount < stakingFeat.StakedAmount {
-		return iotago.ErrInvalidStakingAmountMismatch
-	}
-
 	// It should already never be nil here, but for 100% safety, we'll check again.
 	commitment := vmParams.WorkingSet.Commitment
 	if commitment == nil {


### PR DESCRIPTION
Makes the check for StakedAmount <= Amount syntactical.

Previously, this check was also only done in the genesis checks for accounts, now it will be done for any account output.

Also cleaned up checks for empty account/anchor IDs.