### PR TITLE
Remove SenderFeature from AnchorOutput

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -90,7 +90,7 @@ var (
 
 	anchorOutputV3FeatBlocksArrRules = &serix.ArrayRules{
 		Min: 0, // Min: -
-		Max: 3, // Max: SenderFeature, MetadataFeature, StateMetadataFeature
+		Max: 2, // Max: MetadataFeature, StateMetadataFeature
 		ValidationMode: serializer.ArrayValidationModeNoDuplicates |
 			serializer.ArrayValidationModeLexicalOrdering |
 			serializer.ArrayValidationModeAtMostOneOfEachTypeByte,
@@ -533,7 +533,6 @@ func V3API(protoParams ProtocolParameters) API {
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte).WithArrayRules(anchorOutputV3FeatBlocksArrRules),
 		))
 
-		must(api.RegisterInterfaceObjects((*anchorOutputFeature)(nil), (*SenderFeature)(nil)))
 		must(api.RegisterInterfaceObjects((*anchorOutputFeature)(nil), (*MetadataFeature)(nil)))
 		must(api.RegisterInterfaceObjects((*anchorOutputFeature)(nil), (*StateMetadataFeature)(nil)))
 


### PR DESCRIPTION
I removed the `SenderFeature` from the `AnchorOutput`, because I think it actually makes no sense.

The only reason to have the `SenderFeature` would be to signal who was the last owner of the output before an output transition, but the governor is not allowed to "unlock the chain" to use it as a sender, but the governor is the only one allowed to change the ownership, so this is impossible.