### PR TITLE
Fix usage of omitempty for all models

### DIFF
--- a/address_restricted.go
+++ b/address_restricted.go
@@ -13,7 +13,7 @@ import (
 
 type RestrictedAddress struct {
 	Address             Address                    `serix:""`
-	AllowedCapabilities AddressCapabilitiesBitMask `serix:""`
+	AllowedCapabilities AddressCapabilitiesBitMask `serix:",omitempty"`
 }
 
 func (addr *RestrictedAddress) Clone() Address {

--- a/block.go
+++ b/block.go
@@ -335,8 +335,8 @@ type BasicBlockBody struct {
 
 	// The parents the block references.
 	StrongParents      BlockIDs `serix:",lenPrefix=uint8,minLen=1,maxLen=8"`
-	WeakParents        BlockIDs `serix:",lenPrefix=uint8,minLen=0,maxLen=8"`
-	ShallowLikeParents BlockIDs `serix:",lenPrefix=uint8,minLen=0,maxLen=8"`
+	WeakParents        BlockIDs `serix:",lenPrefix=uint8,minLen=0,maxLen=8,omitempty"`
+	ShallowLikeParents BlockIDs `serix:",lenPrefix=uint8,minLen=0,maxLen=8,omitempty"`
 
 	// The inner payload of the block. Can be nil.
 	Payload ApplicationPayload `serix:",optional,omitempty"`
@@ -454,8 +454,8 @@ type ValidationBlockBody struct {
 	API API
 	// The parents the block references.
 	StrongParents      BlockIDs `serix:",lenPrefix=uint8,minLen=1,maxLen=50"`
-	WeakParents        BlockIDs `serix:",lenPrefix=uint8,minLen=0,maxLen=50"`
-	ShallowLikeParents BlockIDs `serix:",lenPrefix=uint8,minLen=0,maxLen=50"`
+	WeakParents        BlockIDs `serix:",lenPrefix=uint8,minLen=0,maxLen=50,omitempty"`
+	ShallowLikeParents BlockIDs `serix:",lenPrefix=uint8,minLen=0,maxLen=50,omitempty"`
 
 	HighestSupportedVersion Version `serix:""`
 	// ProtocolParametersHash is the hash of the protocol parameters for the HighestSupportedVersion.

--- a/block_test.go
+++ b/block_test.go
@@ -564,7 +564,7 @@ func TestBlockJSONMarshalling(t *testing.T) {
 		Signature: signature,
 	}
 
-	blockJSON := fmt.Sprintf(`{"header":{"protocolVersion":%d,"networkId":"%d","issuingTime":"%s","slotCommitmentId":"%s","latestFinalizedSlot":0,"issuerId":"%s"},"body":{"type":%d,"strongParents":["%s"],"weakParents":[],"shallowLikeParents":[],"highestSupportedVersion":%d,"protocolParametersHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"signature":{"type":%d,"publicKey":"%s","signature":"%s"}}`,
+	blockJSON := fmt.Sprintf(`{"header":{"protocolVersion":%d,"networkId":"%d","issuingTime":"%s","slotCommitmentId":"%s","latestFinalizedSlot":0,"issuerId":"%s"},"body":{"type":%d,"strongParents":["%s"],"highestSupportedVersion":%d,"protocolParametersHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},"signature":{"type":%d,"publicKey":"%s","signature":"%s"}}`,
 		tpkg.TestAPI.Version(),
 		networkID,
 		strconv.FormatUint(serializer.TimeToUint64(issuingTime), 10),

--- a/nodeclient/apimodels/core.go
+++ b/nodeclient/apimodels/core.go
@@ -243,9 +243,9 @@ type (
 		// StrongParents are the strong parents of the block.
 		StrongParents iotago.BlockIDs `serix:",lenPrefix=uint8"`
 		// WeakParents are the weak parents of the block.
-		WeakParents iotago.BlockIDs `serix:",lenPrefix=uint8"`
+		WeakParents iotago.BlockIDs `serix:",lenPrefix=uint8,omitempty"`
 		// ShallowLikeParents are the shallow like parents of the block.
-		ShallowLikeParents iotago.BlockIDs `serix:",lenPrefix=uint8"`
+		ShallowLikeParents iotago.BlockIDs `serix:",lenPrefix=uint8,omitempty"`
 		// LatestFinalizedSlot is the latest finalized slot.
 		LatestFinalizedSlot iotago.SlotIndex `serix:""`
 		// Commitment is the latest commitment of the node.

--- a/transaction_essence.go
+++ b/transaction_essence.go
@@ -38,13 +38,13 @@ type TransactionEssence struct {
 	// The slot index in which the transaction was created by the client.
 	CreationSlot SlotIndex `serix:""`
 	// The commitment references of this transaction.
-	ContextInputs TxEssenceContextInputs `serix:""`
+	ContextInputs TxEssenceContextInputs `serix:",omitempty"`
 	// The inputs of this transaction.
 	Inputs TxEssenceInputs `serix:""`
 	// The optional accounts map with corresponding allotment values.
-	Allotments TxEssenceAllotments `serix:""`
+	Allotments TxEssenceAllotments `serix:",omitempty"`
 	// The capabilities of the transaction.
-	Capabilities TransactionCapabilitiesBitMask `serix:""`
+	Capabilities TransactionCapabilitiesBitMask `serix:",omitempty"`
 	// The optional embedded payload.
 	Payload TxEssencePayload `serix:",optional"`
 }

--- a/unlock_cond_expiration.go
+++ b/unlock_cond_expiration.go
@@ -12,7 +12,7 @@ type ExpirationUnlockCondition struct {
 	// The identity who is allowed to use the output after the expiration has happened.
 	ReturnAddress Address `serix:""`
 	// The slot index at which the expiration happens.
-	Slot SlotIndex `serix:",omitempty"`
+	Slot SlotIndex `serix:""`
 }
 
 func (s *ExpirationUnlockCondition) Clone() UnlockCondition {

--- a/unlock_cond_timelock.go
+++ b/unlock_cond_timelock.go
@@ -9,7 +9,7 @@ import (
 //   - the output can only be consumed, if T is bigger than the one defined in the condition.
 type TimelockUnlockCondition struct {
 	// The slot index until which the timelock applies (inclusive).
-	Slot SlotIndex `serix:",omitempty"`
+	Slot SlotIndex `serix:""`
 }
 
 func (s *TimelockUnlockCondition) Clone() UnlockCondition {


### PR DESCRIPTION
This PR fixes some occurrences or missing `omitempty` for all protocol models or API models.