### PR TITLE
Fix BIC check when Account ID is zeroed

### DIFF
--- a/vm/nova/stvf_test.go
+++ b/vm/nova/stvf_test.go
@@ -394,6 +394,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "ok - valid staking transition",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -452,6 +453,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "ok - adding staking feature in account state transition",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -502,6 +504,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - adding staking feature in account state transition with start epoch set too early",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -553,6 +556,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - negative BIC during account state transition",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -602,6 +606,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - removing staking feature before end epoch",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -655,6 +660,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - changing staking feature's staked amount",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -714,6 +720,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - reducing staking feature's end epoch by more than the unbonding period",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -773,6 +780,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - account removes block issuer feature while having a staking feature",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(1000, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -834,6 +842,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - expired staking feature removed without specifying reward input",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(1000, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -887,6 +896,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - changing an expired staking feature without claiming",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(1000, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1037,6 +1047,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - destroy block issuer account with negative BIC",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1154,6 +1165,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "ok - expired block issuer destroy transition",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1196,6 +1208,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "failed - remove non-expired block issuer feature transition",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1245,6 +1258,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "ok - remove expired block issuer feature transition",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1372,6 +1386,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "ok - update expired block issuer feature without extending expiration after MCA",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1476,6 +1491,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - update expired block issuer feature with extending expiration before MCA",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1533,6 +1549,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - update expired block issuer feature with extending expiration to the past before MCA",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1590,6 +1607,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - update block issuer account with negative BIC",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1702,6 +1720,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "ok - update block issuer feature expiration to earlier slot",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1759,6 +1778,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "ok - non-expired block issuer replace key",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,

--- a/vm/nova/stvf_test.go
+++ b/vm/nova/stvf_test.go
@@ -1089,7 +1089,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - destroy block issuer account no BIC provided",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
-				ChainID: exampleAccountID,
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1667,7 +1667,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - update block issuer account without BIC provided",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
-				ChainID: exampleAccountID,
+				ChainID:  exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,

--- a/vm/nova/stvf_test.go
+++ b/vm/nova/stvf_test.go
@@ -1089,6 +1089,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - destroy block issuer account no BIC provided",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID: exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,
@@ -1666,6 +1667,7 @@ func TestAccountOutput_ValidateStateTransition(t *testing.T) {
 			name: "fail - update block issuer account without BIC provided",
 			input: &vm.ChainOutputWithIDs{
 				OutputID: tpkg.RandOutputIDWithCreationSlot(0, 0),
+				ChainID: exampleAccountID,
 				Output: &iotago.AccountOutput{
 					Amount:    100,
 					AccountID: exampleAccountID,

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -298,7 +298,12 @@ func accountStateChangeValid(vmParams *vm.Params, input *vm.ChainOutputWithIDs, 
 	// If a Block Issuer Feature is present on the input side of the transaction,
 	// and the BIC is negative, the account is locked.
 	if current.FeatureSet().BlockIssuer() != nil {
-		if bic, exists := vmParams.WorkingSet.BIC[current.AccountID]; exists {
+		accountID, is := input.ChainID.(iotago.AccountID)
+		if !is {
+			return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID to account ID")
+		}
+
+		if bic, exists := vmParams.WorkingSet.BIC[accountID]; exists {
 			if bic < 0 {
 				return ierrors.Wrap(iotago.ErrAccountLocked, "negative block issuer credit")
 			}
@@ -623,7 +628,12 @@ func accountDestructionValid(vmParams *vm.Params, input *vm.ChainOutputWithIDs) 
 		if blockIssuerFeat.ExpirySlot >= vmParams.WorkingSet.Commitment.Slot {
 			return ierrors.Wrap(iotago.ErrInvalidBlockIssuerTransition, "cannot destroy output until the block issuer feature expires")
 		}
-		if bic, exists := vmParams.WorkingSet.BIC[outputToDestroy.AccountID]; exists {
+		accountID, is := input.ChainID.(iotago.AccountID)
+		if !is {
+			return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID to account ID")
+		}
+
+		if bic, exists := vmParams.WorkingSet.BIC[accountID]; exists {
 			if bic < 0 {
 				return ierrors.Wrap(iotago.ErrAccountLocked, "cannot destroy locked account")
 			}

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -300,7 +300,8 @@ func accountStateChangeValid(vmParams *vm.Params, input *vm.ChainOutputWithIDs, 
 	if current.FeatureSet().BlockIssuer() != nil {
 		accountID, is := input.ChainID.(iotago.AccountID)
 		if !is {
-			return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID to account ID")
+			return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID %s to account ID",
+				input.ChainID.ToHex())
 		}
 
 		if bic, exists := vmParams.WorkingSet.BIC[accountID]; exists {
@@ -630,7 +631,8 @@ func accountDestructionValid(vmParams *vm.Params, input *vm.ChainOutputWithIDs) 
 		}
 		accountID, is := input.ChainID.(iotago.AccountID)
 		if !is {
-			return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID to account ID")
+			return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID %s to account ID",
+				input.ChainID.ToHex())
 		}
 
 		if bic, exists := vmParams.WorkingSet.BIC[accountID]; exists {

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -298,18 +298,8 @@ func accountStateChangeValid(vmParams *vm.Params, input *vm.ChainOutputWithIDs, 
 	// If a Block Issuer Feature is present on the input side of the transaction,
 	// and the BIC is negative, the account is locked.
 	if current.FeatureSet().BlockIssuer() != nil {
-		accountID, is := input.ChainID.(iotago.AccountID)
-		if !is {
-			return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID %s to account ID",
-				input.ChainID.ToHex())
-		}
-
-		if bic, exists := vmParams.WorkingSet.BIC[accountID]; exists {
-			if bic < 0 {
-				return ierrors.Wrap(iotago.ErrAccountLocked, "negative block issuer credit")
-			}
-		} else {
-			return iotago.ErrBlockIssuanceCreditInputRequired
+		if err := accountBlockIssuanceCreditLocked(input, vmParams.WorkingSet.BIC); err != nil {
+			return err
 		}
 	}
 
@@ -629,18 +619,9 @@ func accountDestructionValid(vmParams *vm.Params, input *vm.ChainOutputWithIDs) 
 		if blockIssuerFeat.ExpirySlot >= vmParams.WorkingSet.Commitment.Slot {
 			return ierrors.Wrap(iotago.ErrInvalidBlockIssuerTransition, "cannot destroy output until the block issuer feature expires")
 		}
-		accountID, is := input.ChainID.(iotago.AccountID)
-		if !is {
-			return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID %s to account ID",
-				input.ChainID.ToHex())
-		}
 
-		if bic, exists := vmParams.WorkingSet.BIC[accountID]; exists {
-			if bic < 0 {
-				return ierrors.Wrap(iotago.ErrAccountLocked, "cannot destroy locked account")
-			}
-		} else {
-			return iotago.ErrBlockIssuanceCreditInputRequired
+		if err := accountBlockIssuanceCreditLocked(input, vmParams.WorkingSet.BIC); err != nil {
+			return err
 		}
 	}
 
@@ -665,6 +646,22 @@ func accountDestructionValid(vmParams *vm.Params, input *vm.ChainOutputWithIDs) 
 		if !isClaiming {
 			return ierrors.Wrapf(iotago.ErrInvalidAccountStateTransition, "%w: cannot destroy account with a staking feature without reward input", iotago.ErrInvalidStakingRewardInputRequired)
 		}
+	}
+
+	return nil
+}
+
+func accountBlockIssuanceCreditLocked(input *vm.ChainOutputWithIDs, bicSet vm.BlockIssuanceCreditInputSet) error {
+	accountID, is := input.ChainID.(iotago.AccountID)
+	if !is {
+		return ierrors.Wrapf(iotago.ErrBlockIssuanceCreditInputRequired, "cannot convert chain ID %s to account ID",
+			input.ChainID.ToHex())
+	}
+
+	if bic, exists := bicSet[accountID]; !exists {
+		return iotago.ErrBlockIssuanceCreditInputRequired
+	} else if bic < 0 {
+		return ierrors.Wrapf(iotago.ErrAccountLocked, "cannot destroy locked account with ID %s", accountID.ToHex())
 	}
 
 	return nil

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -1096,6 +1096,86 @@ func TestNovaTransactionExecution(t *testing.T) {
 			}
 		}(),
 
+		// ok - remove expired block issuer feature from new account
+		func() *test {
+			_, ident1, ident1AddressKeys := tpkg.RandEd25519Identity()
+
+			creationSlot := iotago.SlotIndex(110)
+			inputIDs := tpkg.RandOutputIDs(1)
+			accountID := iotago.AccountIDFromOutputID(inputIDs[0])
+
+			inputs := vm.InputSet{
+				inputIDs[0]: &iotago.AccountOutput{
+					Amount:    100,
+					AccountID: iotago.EmptyAccountID,
+					Features: iotago.AccountOutputFeatures{
+						&iotago.BlockIssuerFeature{
+							BlockIssuerKeys: iotago.NewBlockIssuerKeys(),
+							ExpirySlot:      100,
+						},
+					},
+					UnlockConditions: iotago.AccountOutputUnlockConditions{
+						&iotago.AddressUnlockCondition{Address: ident1},
+					},
+				},
+			}
+
+			transaction := &iotago.Transaction{
+				API: testAPI,
+				TransactionEssence: &iotago.TransactionEssence{
+					CreationSlot: creationSlot,
+					ContextInputs: iotago.TxEssenceContextInputs{
+						&iotago.BlockIssuanceCreditInput{
+							AccountID: accountID,
+						},
+					},
+					Inputs:       inputIDs.UTXOInputs(),
+					Capabilities: iotago.TransactionCapabilitiesBitMaskWithCapabilities(iotago.WithTransactionCanDoAnything()),
+				},
+				Outputs: iotago.TxEssenceOutputs{
+					&iotago.AccountOutput{
+						Amount:    100,
+						AccountID: accountID,
+						Features:  iotago.AccountOutputFeatures{},
+						UnlockConditions: iotago.AccountOutputUnlockConditions{
+							&iotago.AddressUnlockCondition{Address: ident1},
+						},
+					},
+				},
+			}
+
+			bicInputs := vm.BlockIssuanceCreditInputSet{
+				accountID: 0,
+			}
+
+			commitmentInput := &iotago.Commitment{
+				Slot: creationSlot,
+			}
+
+			sigs, err := transaction.Sign(ident1AddressKeys)
+			require.NoError(t, err)
+
+			return &test{
+				name: "ok - remove expired block issuer feature from new account",
+				vmParams: &vm.Params{
+					API: testAPI,
+				},
+				resolvedInputs: vm.ResolvedInputs{
+					InputSet:                    inputs,
+					BlockIssuanceCreditInputSet: bicInputs,
+					CommitmentInput:             commitmentInput,
+				},
+				tx: &iotago.SignedTransaction{
+					API:         testAPI,
+					Transaction: transaction,
+					Unlocks: iotago.Unlocks{
+						&iotago.SignatureUnlock{Signature: sigs[0]},
+					},
+				},
+				wantErr: nil,
+			}
+		}(),
+
 		// fail - destroy block issuer account with expiry at slot with max value
 		func() *test {
 			accountAddr1 := tpkg.RandAccountAddress()

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -1173,16 +1173,16 @@ func TestNovaTransactionExecution(t *testing.T) {
 
 		// ok - destroy block issuer account
 		func() *test {
-			accountAddr1 := tpkg.RandAccountAddress()
-
 			_, ident1, ident1AddressKeys := tpkg.RandEd25519Identity()
 
 			inputIDs := tpkg.RandOutputIDs(1)
+			// Simulate the scenario where the input account's ID is unset.
+			accountID := iotago.AccountIDFromOutputID(inputIDs[0])
 
 			inputs := vm.InputSet{
 				inputIDs[0]: &iotago.AccountOutput{
 					Amount:    100,
-					AccountID: accountAddr1.AccountID(),
+					AccountID: iotago.EmptyAccountID,
 					Features: iotago.AccountOutputFeatures{
 						&iotago.BlockIssuerFeature{
 							BlockIssuerKeys: iotago.NewBlockIssuerKeys(),
@@ -1201,7 +1201,7 @@ func TestNovaTransactionExecution(t *testing.T) {
 					CreationSlot: 110,
 					ContextInputs: iotago.TxEssenceContextInputs{
 						&iotago.BlockIssuanceCreditInput{
-							AccountID: accountAddr1.AccountID(),
+							AccountID: accountID,
 						},
 					},
 					Inputs:       inputIDs.UTXOInputs(),
@@ -1218,7 +1218,7 @@ func TestNovaTransactionExecution(t *testing.T) {
 			}
 
 			bicInputs := vm.BlockIssuanceCreditInputSet{
-				accountAddr1.AccountID(): 0,
+				accountID: 0,
 			}
 
 			commitment := &iotago.Commitment{


### PR DESCRIPTION
# Description of change

Fix BIC check when Account ID is zeroed by always using the pre-calculated chain ID of the input rather than the `AccountID` field of the input which may be zero.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Adapted tests and added a new one so both modified code paths are covered.