### PR TITLE
Cleanup API and field order

### DIFF
--- a/api/core.go
+++ b/api/core.go
@@ -248,8 +248,8 @@ type (
 		ShallowLikeParents iotago.BlockIDs `serix:",lenPrefix=uint8,omitempty"`
 		// LatestFinalizedSlot is the latest finalized slot.
 		LatestFinalizedSlot iotago.SlotIndex `serix:""`
-		// Commitment is the latest commitment of the node.
-		Commitment *iotago.Commitment `serix:""`
+		// LatestCommitment is the latest commitment of the node.
+		LatestCommitment *iotago.Commitment `serix:""`
 	}
 
 	// BlockCreatedResponse defines the response of a POST blocks REST API call.
@@ -266,10 +266,8 @@ type (
 		BlockState string `serix:""`
 		// BlockFailureReason if applicable indicates the error that occurred during the block processing.
 		BlockFailureReason BlockFailureReason `serix:",omitempty"`
-		// TransactionState might be pending, conflicting, confirmed, finalized, rejected.
-		TransactionState string `serix:",omitempty"`
-		// TransactionFailureReason if applicable indicates the error that occurred during the transaction processing.
-		TransactionFailureReason TransactionFailureReason `serix:",omitempty"`
+		// TransactionMetadata is the metadata of the transaction that is contained in the block.
+		TransactionMetadata *TransactionMetadataResponse `serix:",omitempty"`
 	}
 
 	// BlockWithMetadataResponse defines the response of a GET full block REST API call.
@@ -294,22 +292,34 @@ type (
 		OutputIDProof *iotago.OutputIDProof  `serix:""`
 	}
 
-	// OutputMetadata defines the response of a GET outputs metadata REST API call.
-	OutputMetadata struct {
-		// BlockID is the block ID that contains the output.
-		BlockID iotago.BlockID `serix:""`
+	OutputInclusionMetadata struct {
+		// Slot is the slot in which the output was included.
+		Slot iotago.SlotIndex `serix:""`
 		// TransactionID is the transaction ID that creates the output.
 		TransactionID iotago.TransactionID `serix:""`
-		// OutputIndex is the index of the output.
-		OutputIndex uint16 `serix:""`
-		// IncludedCommitmentID is the commitment ID that includes the output.
-		IncludedCommitmentID iotago.CommitmentID `serix:",omitempty"`
-		// IsSpent indicates whether the output is spent or not.
-		IsSpent bool `serix:""`
-		// CommitmentIDSpent is the commitment ID that includes the spent output.
-		CommitmentIDSpent iotago.CommitmentID `serix:",omitempty"`
-		// TransactionIDSpent is the transaction ID that spends the output.
-		TransactionIDSpent iotago.TransactionID `serix:",omitempty"`
+		// CommitmentID is the commitment ID that includes the creation of the output.
+		CommitmentID iotago.CommitmentID `serix:",omitempty"`
+	}
+
+	OutputConsumptionMetadata struct {
+		// Slot is the slot in which the output was spent.
+		Slot iotago.SlotIndex `serix:""`
+		// TransactionID is the transaction ID that spends the output.
+		TransactionID iotago.TransactionID `serix:""`
+		// CommitmentID is the commitment ID that includes the spending of the output.
+		CommitmentID iotago.CommitmentID `serix:",omitempty"`
+	}
+
+	// OutputMetadata defines the response of a GET outputs metadata REST API call.
+	OutputMetadata struct {
+		// OutputID is the hex encoded output ID.
+		OutputID iotago.OutputID `serix:""`
+		// BlockID is the block ID that contains the output.
+		BlockID iotago.BlockID `serix:""`
+		// Included is the metadata of the output if it is included in the ledger.
+		Included *OutputInclusionMetadata `serix:""`
+		// Spent is the metadata of the output if it is marked as spent in the ledger.
+		Spent *OutputConsumptionMetadata `serix:",omitempty"`
 		// LatestCommitmentID is the latest commitment ID of a node.
 		LatestCommitmentID iotago.CommitmentID `serix:""`
 	}
@@ -333,7 +343,7 @@ type (
 
 	// CongestionResponse defines the response for the congestion REST API call.
 	CongestionResponse struct {
-		// Slot is the slot for which the estimate is provided
+		// Slot is the slot for which the estimate is provided.
 		Slot iotago.SlotIndex `serix:""`
 		// Ready indicates if a node is ready to issue a block in a current congestion or should wait.
 		Ready bool `serix:""`
@@ -348,8 +358,8 @@ type (
 	ValidatorResponse struct {
 		// AddressBech32 is the account address of the validator.
 		AddressBech32 string `serix:"address,lenPrefix=uint8"`
-		// StakingEpochEnd is the epoch until which the validator registered to stake.
-		StakingEpochEnd iotago.EpochIndex `serix:""`
+		// StakingEndEpoch is the epoch until which the validator registered to stake.
+		StakingEndEpoch iotago.EpochIndex `serix:""`
 		// PoolStake is the sum of tokens delegated to the pool and the validator stake.
 		PoolStake iotago.BaseToken `serix:""`
 		// ValidatorStake is the stake of the validator.
@@ -373,10 +383,10 @@ type (
 
 	// ManaRewardsResponse defines the response for the mana rewards REST API call.
 	ManaRewardsResponse struct {
-		// EpochStart is the starting epoch for the range for which the mana rewards are returned.
-		EpochStart iotago.EpochIndex `serix:""`
-		// EpochEnd is the ending epoch for the range for which the mana rewards are returned, also the decay is only applied up to this point.
-		EpochEnd iotago.EpochIndex `serix:""`
+		// StartEpoch is the starting epoch for the range for which the mana rewards are returned.
+		StartEpoch iotago.EpochIndex `serix:""`
+		// EndEpoch is the ending epoch for the range for which the mana rewards are returned, also the decay is only applied up to this point.
+		EndEpoch iotago.EpochIndex `serix:""`
 		// The amount of totally available rewards the requested output may claim, decayed up to EpochEnd (including).
 		Rewards iotago.Mana `serix:""`
 	}

--- a/api/core.go
+++ b/api/core.go
@@ -319,7 +319,7 @@ type (
 		// Included is the metadata of the output if it is included in the ledger.
 		Included *OutputInclusionMetadata `serix:""`
 		// Spent is the metadata of the output if it is marked as spent in the ledger.
-		Spent *OutputConsumptionMetadata `serix:",omitempty"`
+		Spent *OutputConsumptionMetadata `serix:",optional,omitempty"`
 		// LatestCommitmentID is the latest commitment ID of a node.
 		LatestCommitmentID iotago.CommitmentID `serix:""`
 	}

--- a/api/core.go
+++ b/api/core.go
@@ -295,7 +295,7 @@ type (
 	OutputInclusionMetadata struct {
 		// Slot is the slot in which the output was included.
 		Slot iotago.SlotIndex `serix:""`
-		// TransactionID is the transaction ID that creates the output.
+		// TransactionID is the transaction ID that created the output.
 		TransactionID iotago.TransactionID `serix:""`
 		// CommitmentID is the commitment ID that includes the creation of the output.
 		CommitmentID iotago.CommitmentID `serix:",omitempty"`
@@ -304,7 +304,7 @@ type (
 	OutputConsumptionMetadata struct {
 		// Slot is the slot in which the output was spent.
 		Slot iotago.SlotIndex `serix:""`
-		// TransactionID is the transaction ID that spends the output.
+		// TransactionID is the transaction ID that spent the output.
 		TransactionID iotago.TransactionID `serix:""`
 		// CommitmentID is the commitment ID that includes the spending of the output.
 		CommitmentID iotago.CommitmentID `serix:",omitempty"`

--- a/api/core_test.go
+++ b/api/core_test.go
@@ -105,7 +105,7 @@ func Test_IssuanceBlockHeaderResponse(t *testing.T) {
 			iotago.BlockID{0x7},
 		},
 		LatestFinalizedSlot: 14,
-		Commitment: &iotago.Commitment{
+		LatestCommitment: &iotago.Commitment{
 			ProtocolVersion:      testAPI.Version(),
 			Slot:                 18,
 			PreviousCommitmentID: iotago.CommitmentID{0x1},
@@ -118,7 +118,7 @@ func Test_IssuanceBlockHeaderResponse(t *testing.T) {
 	jsonResponse, err := testAPI.JSONEncode(response)
 	require.NoError(t, err)
 
-	expected := "{\"strongParents\":[\"0x090000000000000000000000000000000000000000000000000000000000000000000000\"],\"weakParents\":[\"0x080000000000000000000000000000000000000000000000000000000000000000000000\"],\"shallowLikeParents\":[\"0x070000000000000000000000000000000000000000000000000000000000000000000000\"],\"latestFinalizedSlot\":14,\"commitment\":{\"protocolVersion\":3,\"slot\":18,\"previousCommitmentId\":\"0x010000000000000000000000000000000000000000000000000000000000000000000000\",\"rootsId\":\"0x0200000000000000000000000000000000000000000000000000000000000000\",\"cumulativeWeight\":\"89\",\"referenceManaCost\":\"123\"}}"
+	expected := "{\"strongParents\":[\"0x090000000000000000000000000000000000000000000000000000000000000000000000\"],\"weakParents\":[\"0x080000000000000000000000000000000000000000000000000000000000000000000000\"],\"shallowLikeParents\":[\"0x070000000000000000000000000000000000000000000000000000000000000000000000\"],\"latestFinalizedSlot\":14,\"latestCommitment\":{\"protocolVersion\":3,\"slot\":18,\"previousCommitmentId\":\"0x010000000000000000000000000000000000000000000000000000000000000000000000\",\"rootsId\":\"0x0200000000000000000000000000000000000000000000000000000000000000\",\"cumulativeWeight\":\"89\",\"referenceManaCost\":\"123\"}}"
 	require.Equal(t, expected, string(jsonResponse))
 
 	decoded := new(api.IssuanceBlockHeaderResponse)
@@ -149,17 +149,20 @@ func Test_BlockMetadataResponse(t *testing.T) {
 
 	{
 		response := &api.BlockMetadataResponse{
-			BlockID:                  iotago.BlockID{0x9},
-			BlockState:               api.BlockStateFailed.String(),
-			BlockFailureReason:       api.BlockFailureParentNotFound,
-			TransactionState:         api.TransactionStateFailed.String(),
-			TransactionFailureReason: api.TxFailureFailedToClaimDelegationReward,
+			BlockID:            iotago.BlockID{0x9},
+			BlockState:         api.BlockStateFailed.String(),
+			BlockFailureReason: api.BlockFailureParentNotFound,
+			TransactionMetadata: &api.TransactionMetadataResponse{
+				TransactionID:            iotago.TransactionID{0x1},
+				TransactionState:         api.TransactionStateFailed.String(),
+				TransactionFailureReason: api.TxFailureFailedToClaimDelegationReward,
+			},
 		}
 
 		jsonResponse, err := testAPI.JSONEncode(response)
 		require.NoError(t, err)
 
-		expected := "{\"blockId\":\"0x090000000000000000000000000000000000000000000000000000000000000000000000\",\"blockState\":\"failed\",\"blockFailureReason\":3,\"transactionState\":\"failed\",\"transactionFailureReason\":20}"
+		expected := "{\"blockId\":\"0x090000000000000000000000000000000000000000000000000000000000000000000000\",\"blockState\":\"failed\",\"blockFailureReason\":3,\"transactionMetadata\":{\"transactionId\":\"0x010000000000000000000000000000000000000000000000000000000000000000000000\",\"transactionState\":\"failed\",\"transactionFailureReason\":20}}"
 		require.Equal(t, expected, string(jsonResponse))
 
 		decoded := new(api.BlockMetadataResponse)
@@ -191,20 +194,25 @@ func Test_OutputMetadataResponse(t *testing.T) {
 
 	{
 		response := &api.OutputMetadata{
-			BlockID:              iotago.BlockID{0x8},
-			TransactionID:        iotago.TransactionID{0x9},
-			OutputIndex:          3,
-			IncludedCommitmentID: iotago.CommitmentID{0x3},
-			IsSpent:              true,
-			CommitmentIDSpent:    iotago.CommitmentID{0x6},
-			TransactionIDSpent:   iotago.TransactionID{0x1},
-			LatestCommitmentID:   iotago.CommitmentID{0x2},
+			OutputID: iotago.OutputID{0x01},
+			BlockID:  iotago.BlockID{0x02},
+			Included: &api.OutputInclusionMetadata{
+				Slot:          3,
+				TransactionID: iotago.TransactionID{0x4},
+				CommitmentID:  iotago.CommitmentID{0x5},
+			},
+			Spent: &api.OutputConsumptionMetadata{
+				Slot:          6,
+				TransactionID: iotago.TransactionID{0x7},
+				CommitmentID:  iotago.CommitmentID{0x8},
+			},
+			LatestCommitmentID: iotago.CommitmentID{0x9},
 		}
 
 		jsonResponse, err := testAPI.JSONEncode(response)
 		require.NoError(t, err)
 
-		expected := "{\"blockId\":\"0x080000000000000000000000000000000000000000000000000000000000000000000000\",\"transactionId\":\"0x090000000000000000000000000000000000000000000000000000000000000000000000\",\"outputIndex\":3,\"includedCommitmentId\":\"0x030000000000000000000000000000000000000000000000000000000000000000000000\",\"isSpent\":true,\"commitmentIdSpent\":\"0x060000000000000000000000000000000000000000000000000000000000000000000000\",\"transactionIdSpent\":\"0x010000000000000000000000000000000000000000000000000000000000000000000000\",\"latestCommitmentId\":\"0x020000000000000000000000000000000000000000000000000000000000000000000000\"}"
+		expected := "{\"outputId\":\"0x0100000000000000000000000000000000000000000000000000000000000000000000000000\",\"blockId\":\"0x020000000000000000000000000000000000000000000000000000000000000000000000\",\"included\":{\"slot\":3,\"transactionId\":\"0x040000000000000000000000000000000000000000000000000000000000000000000000\",\"commitmentId\":\"0x050000000000000000000000000000000000000000000000000000000000000000000000\"},\"spent\":{\"slot\":6,\"transactionId\":\"0x070000000000000000000000000000000000000000000000000000000000000000000000\",\"commitmentId\":\"0x080000000000000000000000000000000000000000000000000000000000000000000000\"},\"latestCommitmentId\":\"0x090000000000000000000000000000000000000000000000000000000000000000000000\"}"
 		require.Equal(t, expected, string(jsonResponse))
 
 		decoded := new(api.OutputMetadata)
@@ -215,17 +223,21 @@ func Test_OutputMetadataResponse(t *testing.T) {
 	// Test omitempty
 	{
 		response := &api.OutputMetadata{
-			BlockID:            iotago.BlockID{0x8},
-			TransactionID:      iotago.TransactionID{0x9},
-			OutputIndex:        3,
-			IsSpent:            false,
-			LatestCommitmentID: iotago.CommitmentID{0x2},
+			OutputID: iotago.OutputID{0x01},
+			BlockID:  iotago.BlockID{0x02},
+			Included: &api.OutputInclusionMetadata{
+				Slot:          3,
+				TransactionID: iotago.TransactionID{0x4},
+				// CommitmentID is omitted
+			},
+			// Spent is omitted
+			LatestCommitmentID: iotago.CommitmentID{0x9},
 		}
 
 		jsonResponse, err := testAPI.JSONEncode(response)
 		require.NoError(t, err)
 
-		expected := "{\"blockId\":\"0x080000000000000000000000000000000000000000000000000000000000000000000000\",\"transactionId\":\"0x090000000000000000000000000000000000000000000000000000000000000000000000\",\"outputIndex\":3,\"isSpent\":false,\"latestCommitmentId\":\"0x020000000000000000000000000000000000000000000000000000000000000000000000\"}"
+		expected := "{\"outputId\":\"0x0100000000000000000000000000000000000000000000000000000000000000000000000000\",\"blockId\":\"0x020000000000000000000000000000000000000000000000000000000000000000000000\",\"included\":{\"slot\":3,\"transactionId\":\"0x040000000000000000000000000000000000000000000000000000000000000000000000\"},\"latestCommitmentId\":\"0x090000000000000000000000000000000000000000000000000000000000000000000000\"}"
 		require.Equal(t, expected, string(jsonResponse))
 
 		decoded := new(api.OutputMetadata)
@@ -288,7 +300,7 @@ func Test_AccountStakingListResponse(t *testing.T) {
 		Validators: []*api.ValidatorResponse{
 			{
 				AddressBech32:                  iotago.AccountID{0xFF}.ToAddress().Bech32(iotago.PrefixTestnet),
-				StakingEpochEnd:                0,
+				StakingEndEpoch:                0,
 				PoolStake:                      123,
 				ValidatorStake:                 456,
 				FixedCost:                      69,
@@ -302,7 +314,7 @@ func Test_AccountStakingListResponse(t *testing.T) {
 
 	jsonResponse, err := testAPI.JSONEncode(response)
 	require.NoError(t, err)
-	expected := "{\"stakers\":[{\"address\":\"rms1prlsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqcyz9fx\",\"stakingEpochEnd\":0,\"poolStake\":\"123\",\"validatorStake\":\"456\",\"fixedCost\":\"69\",\"active\":true,\"latestSupportedProtocolVersion\":9,\"latestSupportedProtocolHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}],\"pageSize\":50,\"cursor\":\"0,1\"}"
+	expected := "{\"stakers\":[{\"address\":\"rms1prlsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqcyz9fx\",\"stakingEndEpoch\":0,\"poolStake\":\"123\",\"validatorStake\":\"456\",\"fixedCost\":\"69\",\"active\":true,\"latestSupportedProtocolVersion\":9,\"latestSupportedProtocolHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}],\"pageSize\":50,\"cursor\":\"0,1\"}"
 	require.Equal(t, expected, string(jsonResponse))
 
 	decoded := new(api.ValidatorsResponse)
@@ -314,15 +326,15 @@ func Test_ManaRewardsResponse(t *testing.T) {
 	testAPI := testAPI()
 
 	response := &api.ManaRewardsResponse{
-		EpochStart: 123,
-		EpochEnd:   133,
+		StartEpoch: 123,
+		EndEpoch:   133,
 		Rewards:    456,
 	}
 
 	jsonResponse, err := testAPI.JSONEncode(response)
 	require.NoError(t, err)
 
-	expected := "{\"epochStart\":123,\"epochEnd\":133,\"rewards\":\"456\"}"
+	expected := "{\"startEpoch\":123,\"endEpoch\":133,\"rewards\":\"456\"}"
 	require.Equal(t, expected, string(jsonResponse))
 
 	decoded := new(api.ManaRewardsResponse)

--- a/feat_blockissuer.go
+++ b/feat_blockissuer.go
@@ -14,12 +14,15 @@ const (
 // BlockIssuerFeature is a feature which indicates that this account can issue blocks.
 // The feature includes a block issuer address as well as an expiry slot.
 type BlockIssuerFeature struct {
-	BlockIssuerKeys BlockIssuerKeys `serix:",lenPrefix=uint8"`
 	ExpirySlot      SlotIndex       `serix:""`
+	BlockIssuerKeys BlockIssuerKeys `serix:",lenPrefix=uint8"`
 }
 
 func (s *BlockIssuerFeature) Clone() Feature {
-	return &BlockIssuerFeature{BlockIssuerKeys: s.BlockIssuerKeys, ExpirySlot: s.ExpirySlot}
+	return &BlockIssuerFeature{
+		ExpirySlot:      s.ExpirySlot,
+		BlockIssuerKeys: s.BlockIssuerKeys,
+	}
 }
 
 func (s *BlockIssuerFeature) StorageScore(storageScoreStruct *StorageScoreStructure, _ StorageScoreFunc) StorageScore {
@@ -36,6 +39,11 @@ func (s *BlockIssuerFeature) Equal(other Feature) bool {
 	if !is {
 		return false
 	}
+
+	if s.ExpirySlot != otherFeat.ExpirySlot {
+		return false
+	}
+
 	if len(s.BlockIssuerKeys) != len(otherFeat.BlockIssuerKeys) {
 		return false
 	}
@@ -45,7 +53,7 @@ func (s *BlockIssuerFeature) Equal(other Feature) bool {
 		}
 	}
 
-	return s.ExpirySlot == otherFeat.ExpirySlot
+	return true
 }
 
 func (s *BlockIssuerFeature) Type() FeatureType {
@@ -53,6 +61,6 @@ func (s *BlockIssuerFeature) Type() FeatureType {
 }
 
 func (s *BlockIssuerFeature) Size() int {
-	// FeatureType + BlockIssuerKeys + ExpirySlot
-	return serializer.SmallTypeDenotationByteSize + s.BlockIssuerKeys.Size() + SlotIndexLength
+	// FeatureType + ExpirySlot + BlockIssuerKeys
+	return serializer.SmallTypeDenotationByteSize + SlotIndexLength + s.BlockIssuerKeys.Size()
 }

--- a/nodeclient/blockissuer_client.go
+++ b/nodeclient/blockissuer_client.go
@@ -121,11 +121,11 @@ func (client *blockIssuerClient) SendPayloadWithTransactionBuilder(ctx context.C
 
 	// set the commitment slot as the creation slot of the transaction if no slot was set yet.
 	if builder.CreationSlot() == 0 {
-		builder.SetCreationSlot(blockIssuance.Commitment.Slot)
+		builder.SetCreationSlot(blockIssuance.LatestCommitment.Slot)
 	}
 
 	// allot the required mana to the block issuer
-	builder.AllotRequiredManaAndStoreRemainingManaInOutput(builder.CreationSlot(), blockIssuance.Commitment.ReferenceManaCost, blockIssuerAccountAddress.AccountID(), storedManaOutputIndex)
+	builder.AllotRequiredManaAndStoreRemainingManaInOutput(builder.CreationSlot(), blockIssuance.LatestCommitment.ReferenceManaCost, blockIssuerAccountAddress.AccountID(), storedManaOutputIndex)
 
 	// sign the transaction
 	payload, err := builder.Build(signer)
@@ -134,7 +134,7 @@ func (client *blockIssuerClient) SendPayloadWithTransactionBuilder(ctx context.C
 	}
 
 	//nolint:contextcheck // false positive
-	commitmentID, err := blockIssuance.Commitment.ID()
+	commitmentID, err := blockIssuance.LatestCommitment.ID()
 	if err != nil {
 		return nil, nil, ierrors.Wrap(err, "failed to calculate the commitment ID")
 	}


### PR DESCRIPTION
There was a wrong order in the blockissuer feature which cause the serialization not to be aligned with the TIPs.

The PR also cleans up the CORE API to have a consistent naming scheme.
Some responses were also simplified like the output metadata response.