### PR TITLE
Add work score output offset for each output

### DIFF
--- a/output_account.go
+++ b/output_account.go
@@ -194,7 +194,7 @@ func (a *AccountOutput) WorkScore(workScoreParameters *WorkScoreParameters) (Wor
 		return 0, err
 	}
 
-	return workScoreConditions.Add(workScoreFeatures, workScoreImmutableFeatures)
+	return workScoreParameters.Output.Add(workScoreConditions, workScoreFeatures, workScoreImmutableFeatures)
 }
 
 func (a *AccountOutput) Ident() Address {

--- a/output_anchor.go
+++ b/output_anchor.go
@@ -189,7 +189,7 @@ func (a *AnchorOutput) WorkScore(workScoreParameters *WorkScoreParameters) (Work
 		return 0, err
 	}
 
-	return workScoreConditions.Add(workScoreFeatures, workScoreImmutableFeatures)
+	return workScoreParameters.Output.Add(workScoreConditions, workScoreFeatures, workScoreImmutableFeatures)
 }
 
 func (a *AnchorOutput) Ident(nextState TransDepIdentOutput) (Address, error) {

--- a/output_basic.go
+++ b/output_basic.go
@@ -88,7 +88,7 @@ func (e *BasicOutput) WorkScore(workScoreParameters *WorkScoreParameters) (WorkS
 		return 0, err
 	}
 
-	return workScoreConditions.Add(workScoreFeatures)
+	return workScoreParameters.Output.Add(workScoreConditions, workScoreFeatures)
 }
 
 func (e *BasicOutput) FeatureSet() FeatureSet {

--- a/output_delegation.go
+++ b/output_delegation.go
@@ -181,7 +181,12 @@ func (d *DelegationOutput) StorageScore(storageScoreStruct *StorageScoreStructur
 }
 
 func (d *DelegationOutput) WorkScore(workScoreParameters *WorkScoreParameters) (WorkScore, error) {
-	return d.UnlockConditions.WorkScore(workScoreParameters)
+	workScoreConditions, err := d.UnlockConditions.WorkScore(workScoreParameters)
+	if err != nil {
+		return 0, err
+	}
+
+	return workScoreParameters.Output.Add(workScoreConditions)
 }
 
 func (d *DelegationOutput) ChainID() ChainID {

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -208,7 +208,7 @@ func (f *FoundryOutput) WorkScore(workScoreParameters *WorkScoreParameters) (Wor
 		return 0, err
 	}
 
-	return workScoreTokenScheme.Add(workScoreConditions, workScoreFeatures, workScoreImmutableFeatures)
+	return workScoreParameters.Output.Add(workScoreTokenScheme, workScoreConditions, workScoreFeatures, workScoreImmutableFeatures)
 }
 
 func (f *FoundryOutput) ChainID() ChainID {

--- a/output_nft.go
+++ b/output_nft.go
@@ -185,7 +185,7 @@ func (n *NFTOutput) WorkScore(workScoreParameters *WorkScoreParameters) (WorkSco
 		return 0, err
 	}
 
-	return workScoreConditions.Add(workScoreFeatures, workScoreImmutableFeatures)
+	return workScoreParameters.Output.Add(workScoreConditions, workScoreFeatures, workScoreImmutableFeatures)
 }
 
 func (n *NFTOutput) ChainID() ChainID {

--- a/workscore_test.go
+++ b/workscore_test.go
@@ -86,6 +86,7 @@ func TestTransactionEssenceWorkScore(t *testing.T) {
 
 	// Calculate work score as defined in TIP-45 for verification.
 	expectedWorkScore := workScoreParameters.DataByte*iotago.WorkScore(tx.Size()) +
+		workScoreParameters.Output*2 +
 		workScoreParameters.Input*2 +
 		workScoreParameters.ContextInput*3 +
 		// Accounts for one Signature unlock.


### PR DESCRIPTION
# Description of change

Add work score output offset for each output which was previously missing.

Does not impact iota-core, so no companion PR needed.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Adapted the existing work score test.