### PR TITLE
Add Block Network ID check

### DIFF
--- a/block.go
+++ b/block.go
@@ -37,6 +37,7 @@ var (
 	ErrCommitmentInputTooRecent           = ierrors.New("a block cannot contain a commitment input with index more recent than the block's slot minus minCommittableAge")
 	ErrInvalidBlockVersion                = ierrors.New("block has invalid protocol version")
 	ErrCommitmentInputNewerThanCommitment = ierrors.New("a block cannot contain a commitment input with index newer than the commitment index")
+	ErrBlockNetworkIDInvalid              = ierrors.New("invalid network ID in block header")
 )
 
 // BlockBodyType denotes a type of Block Body.
@@ -273,6 +274,11 @@ func (b *Block) Size() int {
 func (b *Block) syntacticallyValidate() error {
 	if b.API.ProtocolParameters().Version() != b.Header.ProtocolVersion {
 		return ierrors.Wrapf(ErrInvalidBlockVersion, "mismatched protocol version: wanted %d, got %d in block", b.API.ProtocolParameters().Version(), b.Header.ProtocolVersion)
+	}
+
+	expectedNetworkID := b.API.ProtocolParameters().NetworkID()
+	if b.Header.NetworkID != expectedNetworkID {
+		return ierrors.Wrapf(ErrBlockNetworkIDInvalid, "got %v, want %v (%s)", b.Header.NetworkID, expectedNetworkID, b.API.ProtocolParameters().NetworkName())
 	}
 
 	block := b.Body

--- a/block_test.go
+++ b/block_test.go
@@ -440,6 +440,7 @@ func TestBasicBlock_MinSize(t *testing.T) {
 		API: tpkg.TestAPI,
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
+			NetworkID:        tpkg.TestAPI.ProtocolParameters().NetworkID(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI).MustID(),
 		},
@@ -468,6 +469,7 @@ func TestValidationBlock_MinSize(t *testing.T) {
 		API: tpkg.TestAPI,
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
+			NetworkID:        tpkg.TestAPI.ProtocolParameters().NetworkID(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI).MustID(),
 		},
@@ -496,6 +498,7 @@ func TestValidationBlock_HighestSupportedVersion(t *testing.T) {
 		API: tpkg.TestAPI,
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  tpkg.TestAPI.Version(),
+			NetworkID:        tpkg.TestAPI.ProtocolParameters().NetworkID(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(tpkg.TestAPI).MustID(),
 		},

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -23,6 +23,7 @@ func NewBasicBlockBuilder(api iotago.API) *BasicBlockBuilder {
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  api.ProtocolParameters().Version(),
 			SlotCommitmentID: iotago.EmptyCommitmentID,
+			NetworkID:        api.ProtocolParameters().NetworkID(),
 			IssuingTime:      time.Now().UTC(),
 		},
 		Signature: &iotago.Ed25519Signature{},
@@ -205,6 +206,7 @@ func NewValidationBlockBuilder(api iotago.API) *ValidationBlockBuilder {
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  api.ProtocolParameters().Version(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(api).MustID(),
+			NetworkID:        api.ProtocolParameters().NetworkID(),
 			IssuingTime:      time.Now().UTC(),
 		},
 		Signature: &iotago.Ed25519Signature{},

--- a/nodeclient/http_api_client_test.go
+++ b/nodeclient/http_api_client_test.go
@@ -323,6 +323,7 @@ func TestClient_SubmitBlock(t *testing.T) {
 		API: mockAPI,
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),
+			NetworkID:        mockAPI.ProtocolParameters().NetworkID(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI).MustID(),
 		},
 		Signature: &iotago.Ed25519Signature{},
@@ -380,6 +381,7 @@ func TestClient_BlockByBlockID(t *testing.T) {
 		API: mockAPI,
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),
+			NetworkID:        mockAPI.ProtocolParameters().NetworkID(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI).MustID(),
 		},
@@ -410,6 +412,7 @@ func TestClient_TransactionIncludedBlock(t *testing.T) {
 		API: mockAPI,
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  mockAPI.Version(),
+			NetworkID:        mockAPI.ProtocolParameters().NetworkID(),
 			IssuingTime:      tpkg.RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(mockAPI).MustID(),
 		},

--- a/tpkg/util.go
+++ b/tpkg/util.go
@@ -712,6 +712,7 @@ func RandBlock(blockBody iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iot
 			API: api,
 			Header: iotago.BlockHeader{
 				ProtocolVersion:  TestAPI.Version(),
+				NetworkID:        api.ProtocolParameters().NetworkID(),
 				IssuingTime:      RandUTCTime(),
 				SlotCommitmentID: iotago.NewEmptyCommitment(api).MustID(),
 				IssuerID:         RandAccountID(),
@@ -725,6 +726,7 @@ func RandBlock(blockBody iotago.BlockBody, api iotago.API, rmc iotago.Mana) *iot
 		API: api,
 		Header: iotago.BlockHeader{
 			ProtocolVersion:  TestAPI.Version(),
+			NetworkID:        api.ProtocolParameters().NetworkID(),
 			IssuingTime:      RandUTCTime(),
 			SlotCommitmentID: iotago.NewEmptyCommitment(api).MustID(),
 			IssuerID:         RandAccountID(),


### PR DESCRIPTION
# Description of change

Add Block Network ID check analogous to the check in the transaction essence.
Block Builders set the Network ID by default to the one provided by the passed API.

iota-core tests run fine with this PR, so no companion PR needed.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Existing tests were adapted and the Network ID added were it was missing.
