### PR TITLE
Add `PotentialMana` helper function

### DIFF
--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -463,21 +463,9 @@ func (b *TransactionBuilder) CalculateAvailableMana(targetSlot iotago.SlotIndex)
 		// calculate the potential mana of the input
 		var inputPotentialMana iotago.Mana
 
-		// we need to ignore the storage deposit, because it doesn't generate mana
-		minDeposit, err := b.api.StorageScoreStructure().MinDeposit(input)
+		inputPotentialMana, err := iotago.PotentialMana(b.api.ManaDecayProvider(), b.api.StorageScoreStructure(), input, inputID.CreationSlot(), targetSlot)
 		if err != nil {
-			return nil, ierrors.Wrap(err, "failed to calculate min deposit")
-		}
-		if input.BaseTokenAmount() > minDeposit {
-			excessBaseTokens, err := safemath.SafeSub(input.BaseTokenAmount(), minDeposit)
-			if err != nil {
-				return nil, ierrors.Wrap(err, "failed to calculate excessBaseTokens of the input")
-			}
-
-			inputPotentialMana, err = b.api.ManaDecayProvider().ManaGenerationWithDecay(excessBaseTokens, inputID.CreationSlot(), targetSlot)
-			if err != nil {
-				return nil, ierrors.Wrap(err, "failed to calculate potential mana generation and decay")
-			}
+			return nil, ierrors.Wrap(err, "failed to calculate potential mana")
 		}
 
 		if err := result.AddPotentialMana(inputPotentialMana); err != nil {

--- a/output.go
+++ b/output.go
@@ -313,8 +313,8 @@ func PotentialMana(manaDecayProvider *ManaDecayProvider, storageScoreStructure *
 	}
 
 	excessBaseTokens, err := safemath.SafeSub(output.BaseTokenAmount(), minDeposit)
-	// An underflow means no potential mana is generated and hence no error is returned.
 	if err != nil {
+		// nolint:nilerr // An underflow means no potential mana is generated and hence no error is returned.
 		return 0, nil
 	}
 

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -379,19 +379,8 @@ func accountBlockIssuerSTVF(vmParams *vm.Params, input *vm.ChainOutputWithIDs, c
 	}
 
 	// AccountInPotential - the potential mana from the input side of the account in question
-	// the storage deposit does not generate potential mana, so we only use the excess base tokens to calculate the potential mana
-	minDeposit, err := storageScoreStructure.MinDeposit(current)
-	if err != nil {
-		return err
-	}
+	manaPotentialAccount, err := iotago.PotentialMana(manaDecayProvider, storageScoreStructure, input.Output, input.OutputID.CreationSlot(), vmParams.WorkingSet.Tx.CreationSlot)
 
-	excessBaseTokensAccount, err := safemath.SafeSub(current.BaseTokenAmount(), minDeposit)
-	if err != nil {
-		// an error means there was an underflow, which means the account has less than the minimum deposit
-		excessBaseTokensAccount = 0
-	}
-
-	manaPotentialAccount, err := manaDecayProvider.ManaGenerationWithDecay(excessBaseTokensAccount, input.OutputID.CreationSlot(), vmParams.WorkingSet.Tx.CreationSlot)
 	if err != nil {
 		return ierrors.Wrapf(err, "account %s potential mana calculation failed", next.AccountID)
 	}

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotaledger/hive.go/core/safemath"
 	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/serializer/v2/serix"
 	iotago "github.com/iotaledger/iota.go/v4"
@@ -6592,11 +6591,7 @@ func TestTxSemanticMana(t *testing.T) {
 
 							input := inputs[inputIDs[0]]
 							storageScoreStructure := iotago.NewStorageScoreStructure(testProtoParams.StorageScoreParameters())
-							minDeposit, err := storageScoreStructure.MinDeposit(input)
-							require.NoError(t, err)
-							excessBaseTokens, err := safemath.SafeSub(input.BaseTokenAmount(), minDeposit)
-							require.NoError(t, err)
-							potentialMana, err := testAPI.ManaDecayProvider().ManaGenerationWithDecay(excessBaseTokens, creationSlot, targetSlot)
+							potentialMana, err := iotago.PotentialMana(testAPI.ManaDecayProvider(), storageScoreStructure, input, creationSlot, targetSlot)
 							require.NoError(t, err)
 
 							storedMana, err := testAPI.ManaDecayProvider().ManaWithDecay(iotago.MaxMana, creationSlot, targetSlot)
@@ -6658,19 +6653,15 @@ func TestTxSemanticMana(t *testing.T) {
 					&iotago.BasicOutput{
 						Amount: OneIOTA,
 						Mana: func() iotago.Mana {
-							var createdSlot iotago.SlotIndex = 10
+							var creationSlot iotago.SlotIndex = 10
 							targetSlot := 10 + 100*testProtoParams.ParamEpochDurationInSlots()
 
 							input := inputs[inputIDs[0]]
 							storageScoreStructure := iotago.NewStorageScoreStructure(testProtoParams.StorageScoreParameters())
-							minDeposit, err := storageScoreStructure.MinDeposit(input)
-							require.NoError(t, err)
-							excessBaseTokens, err := safemath.SafeSub(input.BaseTokenAmount(), minDeposit)
-							require.NoError(t, err)
-							potentialMana, err := testAPI.ManaDecayProvider().ManaGenerationWithDecay(excessBaseTokens, createdSlot, targetSlot)
+							potentialMana, err := iotago.PotentialMana(testAPI.ManaDecayProvider(), storageScoreStructure, input, creationSlot, targetSlot)
 							require.NoError(t, err)
 
-							storedMana, err := testAPI.ManaDecayProvider().ManaWithDecay(iotago.MaxMana, createdSlot, targetSlot)
+							storedMana, err := testAPI.ManaDecayProvider().ManaWithDecay(iotago.MaxMana, creationSlot, targetSlot)
 							require.NoError(t, err)
 
 							// generated mana + decay - allotment

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -84,17 +84,7 @@ func TotalManaIn(manaDecayProvider *iotago.ManaDecayProvider, storageScoreStruct
 		if err != nil {
 			return 0, ierrors.Wrapf(iotago.ErrManaOverflow, "%w", err)
 		}
-		// potential Mana
-		// the storage deposit does not generate potential mana, so we only use the excess base tokens to calculate the potential mana
-		minDeposit, err := storageScoreStructure.MinDeposit(input)
-		if err != nil {
-			return 0, ierrors.Wrapf(err, "input %s min deposit calculation failed", outputID)
-		}
-		excessBaseTokens, err := safemath.SafeSub(input.BaseTokenAmount(), minDeposit)
-		if err != nil {
-			continue
-		}
-		manaPotential, err := manaDecayProvider.ManaGenerationWithDecay(excessBaseTokens, outputID.CreationSlot(), txCreationSlot)
+		manaPotential, err := iotago.PotentialMana(manaDecayProvider, storageScoreStructure, input, outputID.CreationSlot(), txCreationSlot)
 		if err != nil {
 			return 0, ierrors.Wrapf(err, "input %s potential mana calculation failed", outputID)
 		}


### PR DESCRIPTION
# Description of change

Add `PotentialMana` helper function that deduplicates a few occurences of the logic to calculate the potential mana of an output. Since the storage deposit does not generate Mana the excess base token calculation was duplicated in a few different places and hence this PR removes more lines than it adds :ok_hand:. In iota-core there are also places where this would be nice to have and other users of the iota.go library are most likely also happy to have this.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Existing tests using potential mana pass.