### PR TITLE
Fix Mana Rewards Decay Epoch

### DIFF
--- a/api.go
+++ b/api.go
@@ -67,9 +67,9 @@ type API interface {
 	// MaxBlockWork returns the maximum block work score.
 	MaxBlockWork() WorkScore
 	// ComputedInitialReward returns the initial reward calculated from the parameters.
-	ComputedInitialReward() uint64
+	ComputedInitialReward() Mana
 	// ComputedFinalReward returns the final reward calculated from the parameters.
-	ComputedFinalReward() uint64
+	ComputedFinalReward() Mana
 }
 
 func LatestProtocolVersion() Version {

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -473,7 +473,7 @@ func (b *TransactionBuilder) CalculateAvailableMana(targetSlot iotago.SlotIndex)
 		}
 
 		// calculate the decayed stored mana of the input
-		inputStoredMana, err := b.api.ManaDecayProvider().ManaWithDecay(input.StoredMana(), inputID.CreationSlot(), targetSlot)
+		inputStoredMana, err := b.api.ManaDecayProvider().DecayManaBySlots(input.StoredMana(), inputID.CreationSlot(), targetSlot)
 		if err != nil {
 			return nil, ierrors.Wrap(err, "failed to calculate stored mana decay")
 		}

--- a/mana.go
+++ b/mana.go
@@ -63,7 +63,7 @@ func (r RewardsParameters) TargetReward(epoch EpochIndex, api API) (Mana, error)
 	}
 
 	// Rewards start at epoch 0.
-	decayedInitialReward, err := api.ManaDecayProvider().RewardsWithDecay(Mana(api.ComputedInitialReward()), 0, epoch)
+	decayedInitialReward, err := api.ManaDecayProvider().RewardsWithDecay(api.ComputedInitialReward(), 0, epoch)
 	if err != nil {
 		return 0, ierrors.Errorf("failed to calculate decayed initial reward: %w", err)
 	}

--- a/mana.go
+++ b/mana.go
@@ -59,11 +59,11 @@ func (r RewardsParameters) Equals(other RewardsParameters) bool {
 
 func (r RewardsParameters) TargetReward(epoch EpochIndex, api API) (Mana, error) {
 	if epoch > r.BootstrappingDuration {
-		return Mana(api.ComputedFinalReward()), nil
+		return api.ComputedFinalReward(), nil
 	}
 
 	// Rewards start at epoch 0.
-	decayedInitialReward, err := api.ManaDecayProvider().RewardsWithDecay(api.ComputedInitialReward(), 0, epoch)
+	decayedInitialReward, err := api.ManaDecayProvider().DecayManaByEpochs(api.ComputedInitialReward(), 0, epoch)
 	if err != nil {
 		return 0, ierrors.Errorf("failed to calculate decayed initial reward: %w", err)
 	}

--- a/mana.go
+++ b/mana.go
@@ -62,8 +62,8 @@ func (r RewardsParameters) TargetReward(epoch EpochIndex, api API) (Mana, error)
 		return Mana(api.ComputedFinalReward()), nil
 	}
 
-	// rewards start at epoch 1
-	decayedInitialReward, err := api.ManaDecayProvider().RewardsWithDecay(Mana(api.ComputedInitialReward()), 1, epoch)
+	// Rewards start at epoch 0.
+	decayedInitialReward, err := api.ManaDecayProvider().RewardsWithDecay(Mana(api.ComputedInitialReward()), 0, epoch)
 	if err != nil {
 		return 0, ierrors.Errorf("failed to calculate decayed initial reward: %w", err)
 	}

--- a/mana_decay_provider.go
+++ b/mana_decay_provider.go
@@ -162,22 +162,27 @@ func (p *ManaDecayProvider) generateMana(value BaseToken, slotDiff SlotIndex) (M
 	return Mana(result), nil
 }
 
-// ManaWithDecay applies the decay to the given mana.
-func (p *ManaDecayProvider) ManaWithDecay(storedMana Mana, creationSlot SlotIndex, targetSlot SlotIndex) (Mana, error) {
+// DecayManaBySlots applies the decay between the epochs corresponding to the creation and target slots to the given mana.
+func (p *ManaDecayProvider) DecayManaBySlots(mana Mana, creationSlot SlotIndex, targetSlot SlotIndex) (Mana, error) {
 	creationEpoch := p.timeProvider.EpochFromSlot(creationSlot)
 	targetEpoch := p.timeProvider.EpochFromSlot(targetSlot)
 
-	if creationEpoch > targetEpoch {
-		return 0, ierrors.Wrapf(ErrWrongEpochIndex, "the created epoch was bigger than the target epoch: %d > %d", creationEpoch, targetEpoch)
-	}
-
-	return p.decay(storedMana, targetEpoch-creationEpoch)
+	return p.DecayManaByEpochs(mana, creationEpoch, targetEpoch)
 }
 
-// ManaGenerationWithDecay calculates the generated mana and applies the decay to the result.
-func (p *ManaDecayProvider) ManaGenerationWithDecay(amount BaseToken, creationSlot SlotIndex, targetSlot SlotIndex) (Mana, error) {
+// DecayManaByEpochs applies the decay between the creation and target epochs to the given mana.
+func (p *ManaDecayProvider) DecayManaByEpochs(mana Mana, creationEpoch EpochIndex, targetEpoch EpochIndex) (Mana, error) {
+	if creationEpoch > targetEpoch {
+		return 0, ierrors.Wrapf(ErrWrongEpochIndex, "the creation epoch was greater than the target epoch: %d > %d", creationEpoch, targetEpoch)
+	}
+
+	return p.decay(mana, targetEpoch-creationEpoch)
+}
+
+// GenerateManaAndDecayBySlots generates mana from the given base token amount and returns the decayed result.
+func (p *ManaDecayProvider) GenerateManaAndDecayBySlots(amount BaseToken, creationSlot SlotIndex, targetSlot SlotIndex) (Mana, error) {
 	if creationSlot > targetSlot {
-		return 0, ierrors.Wrapf(ErrWrongEpochIndex, "the created slot was bigger than the target slot: %d > %d", creationSlot, targetSlot)
+		return 0, ierrors.Wrapf(ErrWrongEpochIndex, "the creation slot was greater than the target slot: %d > %d", creationSlot, targetSlot)
 	}
 
 	creationEpoch := p.timeProvider.EpochFromSlot(creationSlot)
@@ -272,13 +277,4 @@ func (p *ManaDecayProvider) ManaGenerationWithDecay(amount BaseToken, creationSl
 
 		return result, nil
 	}
-}
-
-// RewardsWithDecay applies the decay to the given stored mana.
-func (p *ManaDecayProvider) RewardsWithDecay(rewards Mana, rewardEpoch EpochIndex, claimedEpoch EpochIndex) (Mana, error) {
-	if rewardEpoch > claimedEpoch {
-		return 0, ierrors.Wrapf(ErrWrongEpochIndex, "the reward epoch was bigger than the claiming epoch: %d > %d", rewardEpoch, claimedEpoch)
-	}
-
-	return p.decay(rewards, claimedEpoch-rewardEpoch)
 }

--- a/mana_decay_provider_test.go
+++ b/mana_decay_provider_test.go
@@ -66,7 +66,7 @@ func BenchmarkManaWithDecay_Single(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		benchmarkResult, _ = testManaDecayProvider.ManaWithDecay(iotago.MaxMana, 0, endSlot)
+		benchmarkResult, _ = testManaDecayProvider.DecayManaBySlots(iotago.MaxMana, 0, endSlot)
 	}
 }
 
@@ -76,7 +76,7 @@ func BenchmarkManaWithDecay_Range(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		value := iotago.MaxMana
 		for epoch := 1; epoch <= 5*len(testManaDecayFactors); epoch++ {
-			value, _ = testManaDecayProvider.ManaWithDecay(value, 0, iotago.SlotIndex(epoch)<<slotsPerEpochExponent)
+			value, _ = testManaDecayProvider.DecayManaBySlots(value, 0, iotago.SlotIndex(epoch)<<slotsPerEpochExponent)
 		}
 		benchmarkResult = value
 	}
@@ -88,7 +88,7 @@ func BenchmarkManaGenerationWithDecay_Single(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		benchmarkResult, _ = testManaDecayProvider.ManaGenerationWithDecay(iotago.MaxBaseToken, 0, endIndex)
+		benchmarkResult, _ = testManaDecayProvider.GenerateManaAndDecayBySlots(iotago.MaxBaseToken, 0, endIndex)
 	}
 }
 
@@ -98,7 +98,7 @@ func BenchmarkManaGenerationWithDecay_Range(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var value iotago.Mana
 		for epoch := 1; epoch <= 5*len(testManaDecayFactors); epoch++ {
-			value, _ = testManaDecayProvider.ManaGenerationWithDecay(iotago.MaxBaseToken, 0, iotago.SlotIndex(epoch)<<slotsPerEpochExponent)
+			value, _ = testManaDecayProvider.GenerateManaAndDecayBySlots(iotago.MaxBaseToken, 0, iotago.SlotIndex(epoch)<<slotsPerEpochExponent)
 		}
 		benchmarkResult = value
 	}
@@ -117,14 +117,14 @@ func TestManaDecay_NoFactorsGiven(t *testing.T) {
 	manaDecayProvider := iotago.NewManaDecayProvider(testTimeProvider, slotsPerEpochExponent, manaStruct)
 
 	// no mana decay if no decay parameters are given
-	value, err := manaDecayProvider.ManaWithDecay(100, testTimeProvider.EpochStart(1), testTimeProvider.EpochStart(100))
+	value, err := manaDecayProvider.DecayManaBySlots(100, testTimeProvider.EpochStart(1), testTimeProvider.EpochStart(100))
 	require.NoError(t, err)
 	require.Equal(t, iotago.Mana(100), value)
 }
 
 func TestManaDecay_NoEpochIndexDiff(t *testing.T) {
 	// no decay in the same epoch
-	value, err := testManaDecayProvider.ManaWithDecay(100, testTimeProvider.EpochStart(1), testTimeProvider.EpochEnd(1))
+	value, err := testManaDecayProvider.DecayManaBySlots(100, testTimeProvider.EpochStart(1), testTimeProvider.EpochEnd(1))
 	require.NoError(t, err)
 	require.Equal(t, iotago.Mana(100), value)
 }
@@ -192,7 +192,7 @@ func TestManaDecay_StoredMana(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := testManaDecayProvider.ManaWithDecay(tt.storedMana, tt.createdSlot, tt.targetSlot)
+			result, err := testManaDecayProvider.DecayManaBySlots(tt.storedMana, tt.createdSlot, tt.targetSlot)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 
@@ -291,7 +291,7 @@ func TestManaDecay_PotentialMana(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// calculate the result
-			result, err := testManaDecayProvider.ManaGenerationWithDecay(tt.amount, tt.createdSlot, tt.targetSlot)
+			result, err := testManaDecayProvider.GenerateManaAndDecayBySlots(tt.amount, tt.createdSlot, tt.targetSlot)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 				return
@@ -380,7 +380,7 @@ func TestManaDecay_Rewards(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := testManaDecayProvider.RewardsWithDecay(tt.rewards, tt.rewardEpoch, tt.claimedEpoch)
+			result, err := testManaDecayProvider.DecayManaByEpochs(tt.rewards, tt.rewardEpoch, tt.claimedEpoch)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 

--- a/output.go
+++ b/output.go
@@ -318,7 +318,7 @@ func PotentialMana(manaDecayProvider *ManaDecayProvider, storageScoreStructure *
 		return 0, nil
 	}
 
-	return manaDecayProvider.ManaGenerationWithDecay(excessBaseTokens, creationSlot, targetSlot)
+	return manaDecayProvider.GenerateManaAndDecayBySlots(excessBaseTokens, creationSlot, targetSlot)
 }
 
 // TransIndepIdentOutput is a type of Output where the identity to unlock is independent

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -369,7 +369,7 @@ func accountBlockIssuerSTVF(vmParams *vm.Params, input *vm.ChainOutputWithIDs, c
 	manaOut := vmParams.WorkingSet.TotalManaOut
 
 	// AccountInStored
-	manaStoredAccount, err := manaDecayProvider.ManaWithDecay(current.StoredMana(), input.OutputID.CreationSlot(), vmParams.WorkingSet.Tx.CreationSlot)
+	manaStoredAccount, err := manaDecayProvider.DecayManaBySlots(current.StoredMana(), input.OutputID.CreationSlot(), vmParams.WorkingSet.Tx.CreationSlot)
 	if err != nil {
 		return ierrors.Wrapf(err, "account %s stored mana calculation failed", next.AccountID)
 	}

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -6594,7 +6594,7 @@ func TestTxSemanticMana(t *testing.T) {
 							potentialMana, err := iotago.PotentialMana(testAPI.ManaDecayProvider(), storageScoreStructure, input, creationSlot, targetSlot)
 							require.NoError(t, err)
 
-							storedMana, err := testAPI.ManaDecayProvider().ManaWithDecay(iotago.MaxMana, creationSlot, targetSlot)
+							storedMana, err := testAPI.ManaDecayProvider().DecayManaBySlots(iotago.MaxMana, creationSlot, targetSlot)
 							require.NoError(t, err)
 
 							return potentialMana + storedMana
@@ -6661,7 +6661,7 @@ func TestTxSemanticMana(t *testing.T) {
 							potentialMana, err := iotago.PotentialMana(testAPI.ManaDecayProvider(), storageScoreStructure, input, creationSlot, targetSlot)
 							require.NoError(t, err)
 
-							storedMana, err := testAPI.ManaDecayProvider().ManaWithDecay(iotago.MaxMana, creationSlot, targetSlot)
+							storedMana, err := testAPI.ManaDecayProvider().DecayManaBySlots(iotago.MaxMana, creationSlot, targetSlot)
 							require.NoError(t, err)
 
 							// generated mana + decay - allotment
@@ -6975,7 +6975,7 @@ func TestManaRewardsClaimingStaking(t *testing.T) {
 		Outputs: iotago.TxEssenceOutputs{
 			&iotago.AccountOutput{
 				Amount:         OneIOTA * 5,
-				Mana:           lo.PanicOnErr(testAPI.ManaDecayProvider().ManaGenerationWithDecay(balance-inputMinDeposit, creationSlot, currentSlot)),
+				Mana:           lo.PanicOnErr(testAPI.ManaDecayProvider().GenerateManaAndDecayBySlots(balance-inputMinDeposit, creationSlot, currentSlot)),
 				AccountID:      accountID,
 				FoundryCounter: 0,
 				UnlockConditions: iotago.AccountOutputUnlockConditions{

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -76,7 +76,7 @@ func TotalManaIn(manaDecayProvider *iotago.ManaDecayProvider, storageScoreStruct
 
 	for outputID, input := range inputSet {
 		// stored Mana
-		manaStored, err := manaDecayProvider.ManaWithDecay(input.StoredMana(), outputID.CreationSlot(), txCreationSlot)
+		manaStored, err := manaDecayProvider.DecayManaBySlots(input.StoredMana(), outputID.CreationSlot(), txCreationSlot)
 		if err != nil {
 			return 0, ierrors.Wrapf(err, "input %s stored mana calculation failed", outputID)
 		}


### PR DESCRIPTION
# Description of change

Fix the epoch against which the mana rewards are decayed which has to be the first epoch. This was assumed to be epoch 1 but epoch 0 is the actual first epoch, so this PR changes that.

The PR also renames the Mana Decay Provider functions to provide a clearer API. `ManaWithDecay` and `RewardsWithDecay` previously did the same thing (on slot and epoch level, respectively), but their names suggest they do different things entirely.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Existing tests pass.