### PR TITLE
Handle null `input` in account STVF & increase min unlocks count in Multi Unlock to 2

### DIFF
--- a/tpkg/rand_unlock.go
+++ b/tpkg/rand_unlock.go
@@ -61,7 +61,8 @@ func RandNFTUnlock() *iotago.NFTUnlock {
 
 // RandMultiUnlock returns a random multi unlock.
 func RandMultiUnlock() *iotago.MultiUnlock {
-	unlockCnt := RandInt(10) + 1
+	// at least 2 unlocks but max 10 unlocks
+	unlockCnt := RandInt(9) + 2
 	unlocks := make([]iotago.Unlock, 0, unlockCnt)
 
 	for i := 0; i < unlockCnt; i++ {

--- a/unlock_multi.go
+++ b/unlock_multi.go
@@ -8,7 +8,7 @@ import (
 // MultiUnlock is an Unlock which holds a list of unlocks for a multi address.
 type MultiUnlock struct {
 	// The unlocks for this MultiUnlock.
-	Unlocks []Unlock `serix:",lenPrefix=uint8,minLen=1,maxLen=10"`
+	Unlocks []Unlock `serix:",lenPrefix=uint8,minLen=2,maxLen=10"`
 }
 
 func (u *MultiUnlock) Clone() Unlock {

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -240,7 +240,7 @@ func implicitAccountSTVF(vmParams *vm.Params, implicitAccount *vm.ImplicitAccoun
 func accountSTVF(vmParams *vm.Params, input *vm.ChainOutputWithIDs, transType iotago.ChainTransitionType, next *iotago.AccountOutput) error {
 	// Whether the transaction is claiming Mana rewards for this account.
 	isClaimingRewards := false
-	if vmParams.WorkingSet.Rewards != nil {
+	if vmParams.WorkingSet.Rewards != nil && input != nil {
 		_, isClaimingRewards = vmParams.WorkingSet.Rewards[input.ChainID]
 	}
 


### PR DESCRIPTION
# Description of change

Handle null `input` in account STVF. Wasn't correctly handled in #645.

Also increases the Multi Unlock min count to 2 following #647.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.