### PR TITLE
Disallow non-printable ASCII characters in keys

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -345,7 +345,7 @@ func V3API(protoParams ProtocolParameters) API {
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte)),
 		)
 		must(api.RegisterValidators(MetadataFeatureEntriesKey(""), nil, func(ctx context.Context, key MetadataFeatureEntriesKey) error {
-			if err := checkASCIIString(string(key)); err != nil {
+			if err := checkPrintableASCIIString(string(key)); err != nil {
 				return ierrors.Join(ErrInvalidMetadataKey, err)
 			}
 
@@ -365,7 +365,7 @@ func V3API(protoParams ProtocolParameters) API {
 			serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsByte)),
 		)
 		must(api.RegisterValidators(StateMetadataFeatureEntriesKey(""), nil, func(ctx context.Context, key StateMetadataFeatureEntriesKey) error {
-			if err := checkASCIIString(string(key)); err != nil {
+			if err := checkPrintableASCIIString(string(key)); err != nil {
 				return ierrors.Join(ErrInvalidStateMetadataKey, err)
 			}
 

--- a/feat.go
+++ b/feat.go
@@ -3,7 +3,6 @@ package iotago
 import (
 	"fmt"
 	"sort"
-	"unicode"
 
 	"github.com/iotaledger/hive.go/constraints"
 	"github.com/iotaledger/hive.go/ierrors"
@@ -334,10 +333,13 @@ func FeatureUnchanged(featType FeatureType, inFeatSet FeatureSet, outFeatSet Fea
 	return nil
 }
 
-func checkASCIIString(s string) error {
+// checkPrintableASCIIString returns an error if the given string contains non-printable ASCII characters (including space).
+func checkPrintableASCIIString(s string) error {
 	for i := 0; i < len(s); i++ {
-		if s[i] > unicode.MaxASCII {
-			return ierrors.Errorf("string contains non-ASCII character at index %d", i)
+		if s[i] < 33 || s[i] > 126 {
+			return ierrors.Errorf(
+				"string contains non-printable ASCII character %d at index %d (allowed range 33 <= character <= 126)", s[i], i,
+			)
 		}
 	}
 

--- a/feat_test.go
+++ b/feat_test.go
@@ -119,6 +119,26 @@ func TestFeaturesMetadata(t *testing.T) {
 			seriErr: iotago.ErrInvalidStateMetadataKey,
 			target:  &iotago.StateMetadataFeature{},
 		},
+		{
+			name: "fail - StateMetadataFeature - space char in key",
+			source: &iotago.StateMetadataFeature{
+				Entries: iotago.StateMetadataFeatureEntries{
+					"space-> ": []byte("world"),
+				},
+			},
+			seriErr: iotago.ErrInvalidStateMetadataKey,
+			target:  &iotago.StateMetadataFeature{},
+		},
+		{
+			name: "fail - StateMetadataFeature - ASCII control-character in key",
+			source: &iotago.StateMetadataFeature{
+				Entries: iotago.StateMetadataFeatureEntries{
+					"\x07": []byte("world"),
+				},
+			},
+			seriErr: iotago.ErrInvalidStateMetadataKey,
+			target:  &iotago.StateMetadataFeature{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description of change

Disallow non-printable ASCII characters in the keys of the metadata and state metadata feature.
This is so we can always print the keys and they have a solid human-readable representation, which, for example, is useful for the explorer.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Adapted tests.