### PR TITLE
Fix checks for registered feature interface objects

### DIFF
--- a/api_v3.go
+++ b/api_v3.go
@@ -393,14 +393,6 @@ func V3API(protoParams ProtocolParameters) API {
 		must(api.RegisterTypeSettings(StakingFeature{},
 			serix.TypeSettings{}.WithObjectType(uint8(FeatureStaking))),
 		)
-		must(api.RegisterInterfaceObjects((*Feature)(nil), (*SenderFeature)(nil)))
-		must(api.RegisterInterfaceObjects((*Feature)(nil), (*IssuerFeature)(nil)))
-		must(api.RegisterInterfaceObjects((*Feature)(nil), (*MetadataFeature)(nil)))
-		must(api.RegisterInterfaceObjects((*Feature)(nil), (*StateMetadataFeature)(nil)))
-		must(api.RegisterInterfaceObjects((*Feature)(nil), (*TagFeature)(nil)))
-		must(api.RegisterInterfaceObjects((*Feature)(nil), (*NativeTokenFeature)(nil)))
-		must(api.RegisterInterfaceObjects((*Feature)(nil), (*BlockIssuerFeature)(nil)))
-		must(api.RegisterInterfaceObjects((*Feature)(nil), (*StakingFeature)(nil)))
 	}
 
 	{
@@ -445,13 +437,6 @@ func V3API(protoParams ProtocolParameters) API {
 		must(api.RegisterTypeSettings(ImmutableAccountUnlockCondition{},
 			serix.TypeSettings{}.WithObjectType(uint8(UnlockConditionImmutableAccount))),
 		)
-		must(api.RegisterInterfaceObjects((*UnlockCondition)(nil), (*AddressUnlockCondition)(nil)))
-		must(api.RegisterInterfaceObjects((*UnlockCondition)(nil), (*StorageDepositReturnUnlockCondition)(nil)))
-		must(api.RegisterInterfaceObjects((*UnlockCondition)(nil), (*TimelockUnlockCondition)(nil)))
-		must(api.RegisterInterfaceObjects((*UnlockCondition)(nil), (*ExpirationUnlockCondition)(nil)))
-		must(api.RegisterInterfaceObjects((*UnlockCondition)(nil), (*StateControllerAddressUnlockCondition)(nil)))
-		must(api.RegisterInterfaceObjects((*UnlockCondition)(nil), (*GovernorAddressUnlockCondition)(nil)))
-		must(api.RegisterInterfaceObjects((*UnlockCondition)(nil), (*ImmutableAccountUnlockCondition)(nil)))
 	}
 
 	{

--- a/feat.go
+++ b/feat.go
@@ -75,11 +75,17 @@ var featNames = [FeatureStaking + 1]string{
 }
 
 // Features is a slice of Feature(s).
-type Features[T Feature] []Feature
+type Features[T Feature] []T
 
 // Clone clones the Features.
 func (f Features[T]) Clone() Features[T] {
-	return lo.CloneSlice(f)
+	cpy := make(Features[T], len(f))
+	for i, v := range f {
+		//nolint:forcetypeassert // we can safely assume that this is of type T
+		cpy[i] = v.Clone().(T)
+	}
+
+	return cpy
 }
 
 func (f Features[T]) StorageScore(storageScoreStruct *StorageScoreStructure, _ StorageScoreFunc) StorageScore {

--- a/output_test.go
+++ b/output_test.go
@@ -70,9 +70,20 @@ func TestOutputsDeSerialize(t *testing.T) {
 				Features: iotago.AccountOutputFeatures{
 					&iotago.SenderFeature{Address: tpkg.RandEd25519Address()},
 					&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": tpkg.RandBytes(100)}},
+					&iotago.BlockIssuerFeature{
+						ExpirySlot:      1337,
+						BlockIssuerKeys: tpkg.RandBlockIssuerKeys(),
+					},
+					&iotago.StakingFeature{
+						StakedAmount: 1337,
+						FixedCost:    10,
+						StartEpoch:   1,
+						EndEpoch:     2,
+					},
 				},
 				ImmutableFeatures: iotago.AccountOutputImmFeatures{
 					&iotago.IssuerFeature{Address: tpkg.RandEd25519Address()},
+					&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"immutable": tpkg.RandBytes(100)}},
 				},
 			},
 			target: &iotago.AccountOutput{},
@@ -89,11 +100,12 @@ func TestOutputsDeSerialize(t *testing.T) {
 					&iotago.GovernorAddressUnlockCondition{Address: tpkg.RandEd25519Address()},
 				},
 				Features: iotago.AnchorOutputFeatures{
-					&iotago.SenderFeature{Address: tpkg.RandEd25519Address()},
+					&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": tpkg.RandBytes(100)}},
 					&iotago.StateMetadataFeature{Entries: iotago.StateMetadataFeatureEntries{"data": tpkg.RandBytes(100)}},
 				},
 				ImmutableFeatures: iotago.AnchorOutputImmFeatures{
 					&iotago.IssuerFeature{Address: tpkg.RandEd25519Address()},
+					&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": tpkg.RandBytes(100)}},
 				},
 			},
 			target: &iotago.AnchorOutput{},
@@ -113,8 +125,11 @@ func TestOutputsDeSerialize(t *testing.T) {
 				},
 				Features: iotago.FoundryOutputFeatures{
 					&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": tpkg.RandBytes(100)}},
+					tpkg.RandNativeTokenFeature(),
 				},
-				ImmutableFeatures: iotago.FoundryOutputImmFeatures{},
+				ImmutableFeatures: iotago.FoundryOutputImmFeatures{
+					&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"immutable": tpkg.RandBytes(100)}},
+				},
 			},
 			target: &iotago.FoundryOutput{},
 		},
@@ -143,7 +158,7 @@ func TestOutputsDeSerialize(t *testing.T) {
 				},
 				ImmutableFeatures: iotago.NFTOutputImmFeatures{
 					&iotago.IssuerFeature{Address: tpkg.RandEd25519Address()},
-					&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": tpkg.RandBytes(10)}},
+					&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"immutable": tpkg.RandBytes(10)}},
 				},
 			},
 			target: &iotago.NFTOutput{},

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -451,10 +451,9 @@ func TestNovaTransactionExecution(t *testing.T) {
 					UnlockConditions: iotago.NFTOutputUnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident3},
 					},
-					Features: iotago.NFTOutputFeatures{
-						&iotago.IssuerFeature{Address: ident3},
-					},
+					Features: iotago.NFTOutputFeatures{},
 					ImmutableFeatures: iotago.NFTOutputImmFeatures{
+						&iotago.IssuerFeature{Address: ident3},
 						&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("transfer to 4")}},
 					},
 				},
@@ -467,10 +466,9 @@ func TestNovaTransactionExecution(t *testing.T) {
 					UnlockConditions: iotago.NFTOutputUnlockConditions{
 						&iotago.AddressUnlockCondition{Address: ident4},
 					},
-					Features: iotago.NFTOutputFeatures{
-						&iotago.IssuerFeature{Address: ident3},
-					},
+					Features: iotago.NFTOutputFeatures{},
 					ImmutableFeatures: iotago.NFTOutputImmFeatures{
+						&iotago.IssuerFeature{Address: ident3},
 						&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("going to be destroyed")}},
 					},
 				},
@@ -750,10 +748,9 @@ func TestNovaTransactionExecution(t *testing.T) {
 						UnlockConditions: iotago.NFTOutputUnlockConditions{
 							&iotago.AddressUnlockCondition{Address: ident4},
 						},
-						Features: iotago.NFTOutputFeatures{
-							&iotago.IssuerFeature{Address: ident3},
-						},
+						Features: iotago.NFTOutputFeatures{},
 						ImmutableFeatures: iotago.NFTOutputImmFeatures{
+							&iotago.IssuerFeature{Address: ident3},
 							&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("transfer to 4")}},
 						},
 					},
@@ -1770,10 +1767,9 @@ func TestNovaTransactionExecution_RestrictedAddress(t *testing.T) {
 								UnlockConditions: iotago.NFTOutputUnlockConditions{
 									&iotago.AddressUnlockCondition{Address: ed25519Addresses[0]},
 								},
-								Features: iotago.NFTOutputFeatures{
-									&iotago.IssuerFeature{Address: ed25519Addresses[1]},
-								},
+								Features: iotago.NFTOutputFeatures{},
 								ImmutableFeatures: iotago.NFTOutputImmFeatures{
+									&iotago.IssuerFeature{Address: ed25519Addresses[1]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("immutable")}},
 								},
 							},
@@ -1795,10 +1791,10 @@ func TestNovaTransactionExecution_RestrictedAddress(t *testing.T) {
 									&iotago.AddressUnlockCondition{Address: ed25519Addresses[0]},
 								},
 								Features: iotago.NFTOutputFeatures{
-									&iotago.IssuerFeature{Address: ed25519Addresses[1]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("some new metadata")}},
 								},
 								ImmutableFeatures: iotago.NFTOutputImmFeatures{
+									&iotago.IssuerFeature{Address: ed25519Addresses[1]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("immutable")}},
 								},
 							},
@@ -1858,10 +1854,9 @@ func TestNovaTransactionExecution_RestrictedAddress(t *testing.T) {
 								UnlockConditions: iotago.NFTOutputUnlockConditions{
 									&iotago.AddressUnlockCondition{Address: ed25519Addresses[0]},
 								},
-								Features: iotago.NFTOutputFeatures{
-									&iotago.IssuerFeature{Address: ed25519Addresses[0]},
-								},
+								Features: iotago.NFTOutputFeatures{},
 								ImmutableFeatures: iotago.NFTOutputImmFeatures{
+									&iotago.IssuerFeature{Address: ed25519Addresses[0]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("immutable")}},
 								},
 							},
@@ -1883,10 +1878,10 @@ func TestNovaTransactionExecution_RestrictedAddress(t *testing.T) {
 									&iotago.AddressUnlockCondition{Address: ed25519Addresses[0]},
 								},
 								Features: iotago.NFTOutputFeatures{
-									&iotago.IssuerFeature{Address: ed25519Addresses[0]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("some new metadata")}},
 								},
 								ImmutableFeatures: iotago.NFTOutputImmFeatures{
+									&iotago.IssuerFeature{Address: ed25519Addresses[0]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("immutable")}},
 								},
 							},
@@ -2740,10 +2735,9 @@ func TestNovaTransactionExecution_MultiAddress(t *testing.T) {
 								UnlockConditions: iotago.NFTOutputUnlockConditions{
 									&iotago.AddressUnlockCondition{Address: ed25519Addresses[0]},
 								},
-								Features: iotago.NFTOutputFeatures{
-									&iotago.IssuerFeature{Address: ed25519Addresses[1]},
-								},
+								Features: iotago.NFTOutputFeatures{},
 								ImmutableFeatures: iotago.NFTOutputImmFeatures{
+									&iotago.IssuerFeature{Address: ed25519Addresses[1]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("immutable")}},
 								},
 							},
@@ -2771,10 +2765,10 @@ func TestNovaTransactionExecution_MultiAddress(t *testing.T) {
 									&iotago.AddressUnlockCondition{Address: ed25519Addresses[0]},
 								},
 								Features: iotago.NFTOutputFeatures{
-									&iotago.IssuerFeature{Address: ed25519Addresses[1]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("some new metadata")}},
 								},
 								ImmutableFeatures: iotago.NFTOutputImmFeatures{
+									&iotago.IssuerFeature{Address: ed25519Addresses[1]},
 									&iotago.MetadataFeature{Entries: iotago.MetadataFeatureEntries{"data": []byte("immutable")}},
 								},
 							},
@@ -5597,17 +5591,6 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 							},
 						})
 
-						outputs = append(outputs, &iotago.AnchorOutput{
-							Amount: 1337,
-							UnlockConditions: iotago.AnchorOutputUnlockConditions{
-								&iotago.StateControllerAddressUnlockCondition{Address: ident1},
-								&iotago.GovernorAddressUnlockCondition{Address: ident1},
-							},
-							Features: iotago.AnchorOutputFeatures{
-								&iotago.SenderFeature{Address: sender},
-							},
-						})
-
 						outputs = append(outputs, &iotago.NFTOutput{
 							Amount: 1337,
 							UnlockConditions: iotago.NFTOutputUnlockConditions{
@@ -5721,13 +5704,21 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 				},
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.AnchorOutput{
-						Amount:   100,
+						Amount:   50,
 						AnchorID: anchorID,
 						UnlockConditions: iotago.AnchorOutputUnlockConditions{
 							&iotago.StateControllerAddressUnlockCondition{Address: stateController},
 							&iotago.GovernorAddressUnlockCondition{Address: governor},
 						},
-						Features: iotago.AnchorOutputFeatures{
+						Features: iotago.AnchorOutputFeatures{},
+					},
+					&iotago.BasicOutput{
+						Amount: 50,
+						Mana:   0,
+						UnlockConditions: iotago.BasicOutputUnlockConditions{
+							&iotago.AddressUnlockCondition{Address: anchorAddr},
+						},
+						Features: iotago.BasicOutputFeatures{
 							&iotago.SenderFeature{Address: anchorAddr},
 						},
 					},
@@ -5781,14 +5772,22 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 				},
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.AnchorOutput{
-						Amount:     100,
+						Amount:     50,
 						AnchorID:   anchorID,
 						StateIndex: currentStateIndex + 1,
 						UnlockConditions: iotago.AnchorOutputUnlockConditions{
 							&iotago.StateControllerAddressUnlockCondition{Address: stateController},
 							&iotago.GovernorAddressUnlockCondition{Address: governor},
 						},
-						Features: iotago.AnchorOutputFeatures{
+						Features: iotago.AnchorOutputFeatures{},
+					},
+					&iotago.BasicOutput{
+						Amount: 50,
+						Mana:   0,
+						UnlockConditions: iotago.BasicOutputUnlockConditions{
+							&iotago.AddressUnlockCondition{Address: anchorAddr},
+						},
+						Features: iotago.BasicOutputFeatures{
 							&iotago.SenderFeature{Address: anchorAddr},
 						},
 					},
@@ -5840,13 +5839,21 @@ func TestTxSemanticOutputsSender(t *testing.T) {
 				},
 				Outputs: iotago.TxEssenceOutputs{
 					&iotago.AnchorOutput{
-						Amount:   100,
+						Amount:   50,
 						AnchorID: anchorID,
 						UnlockConditions: iotago.AnchorOutputUnlockConditions{
 							&iotago.StateControllerAddressUnlockCondition{Address: stateController},
 							&iotago.GovernorAddressUnlockCondition{Address: governor},
 						},
-						Features: iotago.AnchorOutputFeatures{
+						Features: iotago.AnchorOutputFeatures{},
+					},
+					&iotago.BasicOutput{
+						Amount: 50,
+						Mana:   0,
+						UnlockConditions: iotago.BasicOutputUnlockConditions{
+							&iotago.AddressUnlockCondition{Address: anchorAddr},
+						},
+						Features: iotago.BasicOutputFeatures{
 							&iotago.SenderFeature{Address: governor},
 						},
 					},
@@ -7656,8 +7663,19 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
+				// a basic output will hold the native tokens
+				&iotago.BasicOutput{
+					Amount: 21200,
+					Mana:   0,
+					UnlockConditions: iotago.BasicOutputUnlockConditions{
+						&iotago.AddressUnlockCondition{Address: edIdent},
+					},
+					Features: iotago.BasicOutputFeatures{
+						exampleNativeTokenFeature,
+					},
+				},
 				&iotago.AccountOutput{
-					Amount:    exampleAmount,
+					Amount:    exampleAmount - 21200,
 					Mana:      exampleMana,
 					AccountID: accountID1,
 					UnlockConditions: iotago.AccountOutputUnlockConditions{
@@ -7674,7 +7692,6 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 								iotago.Ed25519PublicKeyBlockIssuerKeyFromPublicKey(tpkg.Rand32ByteArray()),
 							),
 						},
-						exampleNativeTokenFeature,
 					},
 				},
 			},

--- a/workscore_test.go
+++ b/workscore_test.go
@@ -46,7 +46,6 @@ func TestTransactionEssenceWorkScore(t *testing.T) {
 				StakedAmount: 500_00,
 				FixedCost:    500,
 			},
-			tpkg.RandNativeTokenFeature(),
 		},
 	}
 
@@ -92,7 +91,7 @@ func TestTransactionEssenceWorkScore(t *testing.T) {
 		workScoreParameters.SignatureEd25519 +
 		workScoreParameters.BlockIssuer +
 		workScoreParameters.Staking +
-		workScoreParameters.NativeToken*2 +
+		workScoreParameters.NativeToken*1 +
 		workScoreParameters.Allotment*2
 
 	require.Equal(t, expectedWorkScore, workScore, "work score expected: %d, actual: %d", expectedWorkScore, workScore)


### PR DESCRIPTION
The `Features[T Feature]` type erased the actual `T` type, and therefore `serix` was unable to correctly detect if the features were allowed in that specific output. This is fixed by this PR.