### PR TITLE
Fix `MinRequiredAllotedMana` by including the block signature in the calculation

### DIFF
--- a/address_signer.go
+++ b/address_signer.go
@@ -66,6 +66,22 @@ func NewInMemoryAddressSigner(addrKeys ...AddressKeys) AddressSigner {
 	return ss
 }
 
+// NewInMemoryAddressSignerFromEd25519PrivateKey creates a new InMemoryAddressSigner
+// for the Ed25519Address derived from the public key of the given private key
+// as well as the related ImplicitAccountCreationAddress.
+func NewInMemoryAddressSignerFromEd25519PrivateKey(privKey ed25519.PrivateKey) AddressSigner {
+	pubKey := privKey.Public().(ed25519.PublicKey)
+
+	ed25519Address := Ed25519AddressFromPubKey(pubKey)
+	ed25519AddressKey := NewAddressKeysForEd25519Address(ed25519Address, privKey)
+
+	implicitAccountCreationAddress := ImplicitAccountCreationAddressFromPubKey(pubKey)
+	implicitAccountCreationAddressKey := NewAddressKeysForImplicitAccountCreationAddress(implicitAccountCreationAddress, privKey)
+
+	// add both address types for simplicity
+	return NewInMemoryAddressSigner(ed25519AddressKey, implicitAccountCreationAddressKey)
+}
+
 // InMemoryAddressSigner implements AddressSigner by holding keys simply in-memory.
 type InMemoryAddressSigner struct {
 	addrKeys map[string]interface{}

--- a/address_signer.go
+++ b/address_signer.go
@@ -70,6 +70,7 @@ func NewInMemoryAddressSigner(addrKeys ...AddressKeys) AddressSigner {
 // for the Ed25519Address derived from the public key of the given private key
 // as well as the related ImplicitAccountCreationAddress.
 func NewInMemoryAddressSignerFromEd25519PrivateKey(privKey ed25519.PrivateKey) AddressSigner {
+	//nolint:forcetypeassert // we can safely assume that this is an ed25519.PublicKey
 	pubKey := privKey.Public().(ed25519.PublicKey)
 
 	ed25519Address := Ed25519AddressFromPubKey(pubKey)

--- a/block.go
+++ b/block.go
@@ -147,17 +147,14 @@ func blockSigningMessage(headerHash Identifier, blockHash Identifier) []byte {
 	return byteutils.ConcatBytes(headerHash[:], blockHash[:])
 }
 
-// Sign produces signatures signing the essence for every given AddressKeys.
-// The produced signatures are in the same order as the AddressKeys.
-func (b *Block) Sign(addrKey AddressKeys) (Signature, error) {
+// Sign produces a signature by signing the signing message of the block.
+func (b *Block) Sign(signer AddressSigner, addr Address) (Signature, error) {
 	signMsg, err := b.SigningMessage()
 	if err != nil {
 		return nil, err
 	}
 
-	signer := NewInMemoryAddressSigner(addrKey)
-
-	return signer.Sign(addrKey.Address, signMsg)
+	return signer.Sign(addr, signMsg)
 }
 
 // VerifySignature verifies the Signature of the block.

--- a/block.go
+++ b/block.go
@@ -271,10 +271,15 @@ func (b *Block) Size() int {
 func (b *Block) ManaCost(rmc Mana) (Mana, error) {
 	workScore, err := b.WorkScore()
 	if err != nil {
-		return 0, err
+		return 0, ierrors.Errorf("failed to calculate block workscore: %w", err)
 	}
 
-	return ManaCost(rmc, workScore)
+	manaCost, err := ManaCost(rmc, workScore)
+	if err != nil {
+		return 0, ierrors.Errorf("failed to calculate mana cost: %w", err)
+	}
+
+	return manaCost, nil
 }
 
 // syntacticallyValidate syntactically validates the Block.

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -100,14 +100,25 @@ func (b *BasicBlockBuilder) LatestFinalizedSlot(slot iotago.SlotIndex) *BasicBlo
 	return b
 }
 
-func (b *BasicBlockBuilder) Sign(accountID iotago.AccountID, prvKey ed25519.PrivateKey) *BasicBlockBuilder {
+func (b *BasicBlockBuilder) Sign(accountID iotago.AccountID, privKey ed25519.PrivateKey) *BasicBlockBuilder {
+	pubKey := privKey.Public().(ed25519.PublicKey)
+	ed25519Address := iotago.Ed25519AddressFromPubKey(pubKey)
+
+	signer := iotago.NewInMemoryAddressSigner(
+		iotago.NewAddressKeysForEd25519Address(ed25519Address, privKey),
+	)
+
+	return b.SignWithSigner(accountID, signer, ed25519Address)
+}
+
+func (b *BasicBlockBuilder) SignWithSigner(accountID iotago.AccountID, signer iotago.AddressSigner, addr iotago.Address) *BasicBlockBuilder {
 	if b.err != nil {
 		return b
 	}
 
 	b.protocolBlock.Header.IssuerID = accountID
 
-	signature, err := b.protocolBlock.Sign(iotago.NewAddressKeysForEd25519Address(iotago.Ed25519AddressFromPubKey(prvKey.Public().(ed25519.PublicKey)), prvKey))
+	signature, err := b.protocolBlock.Sign(signer, addr)
 	if err != nil {
 		b.err = ierrors.Errorf("error signing block: %w", err)
 
@@ -302,14 +313,25 @@ func (v *ValidationBlockBuilder) LatestFinalizedSlot(slot iotago.SlotIndex) *Val
 	return v
 }
 
-func (v *ValidationBlockBuilder) Sign(accountID iotago.AccountID, prvKey ed25519.PrivateKey) *ValidationBlockBuilder {
+func (v *ValidationBlockBuilder) Sign(accountID iotago.AccountID, privKey ed25519.PrivateKey) *ValidationBlockBuilder {
+	pubKey := privKey.Public().(ed25519.PublicKey)
+	ed25519Address := iotago.Ed25519AddressFromPubKey(pubKey)
+
+	signer := iotago.NewInMemoryAddressSigner(
+		iotago.NewAddressKeysForEd25519Address(ed25519Address, privKey),
+	)
+
+	return v.SignWithSigner(accountID, signer, ed25519Address)
+}
+
+func (v *ValidationBlockBuilder) SignWithSigner(accountID iotago.AccountID, signer iotago.AddressSigner, addr iotago.Address) *ValidationBlockBuilder {
 	if v.err != nil {
 		return v
 	}
 
 	v.protocolBlock.Header.IssuerID = accountID
 
-	signature, err := v.protocolBlock.Sign(iotago.NewAddressKeysForEd25519Address(iotago.Ed25519AddressFromPubKey(prvKey.Public().(ed25519.PublicKey)), prvKey))
+	signature, err := v.protocolBlock.Sign(signer, addr)
 	if err != nil {
 		v.err = ierrors.Errorf("error signing block: %w", err)
 

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -205,15 +205,9 @@ func (b *BasicBlockBuilder) CalculateAndSetMaxBurnedMana(rmc iotago.Mana) *Basic
 		return b
 	}
 
-	blockWorkScore, err := b.protocolBlock.WorkScore()
+	burnedMana, err := b.protocolBlock.ManaCost(rmc)
 	if err != nil {
-		b.err = ierrors.Errorf("error calculating block workscore: %w", err)
-		return b
-	}
-
-	burnedMana, err := iotago.ManaCost(rmc, blockWorkScore)
-	if err != nil {
-		b.err = ierrors.Errorf("error calculating mana cost: %w", err)
+		b.err = ierrors.Wrap(err, "error calculating mana cost")
 		return b
 	}
 

--- a/builder/block_builder.go
+++ b/builder/block_builder.go
@@ -101,6 +101,7 @@ func (b *BasicBlockBuilder) LatestFinalizedSlot(slot iotago.SlotIndex) *BasicBlo
 }
 
 func (b *BasicBlockBuilder) Sign(accountID iotago.AccountID, privKey ed25519.PrivateKey) *BasicBlockBuilder {
+	//nolint:forcetypeassert // we can safely assume that this is an ed25519.PublicKey
 	pubKey := privKey.Public().(ed25519.PublicKey)
 	ed25519Address := iotago.Ed25519AddressFromPubKey(pubKey)
 
@@ -308,6 +309,7 @@ func (v *ValidationBlockBuilder) LatestFinalizedSlot(slot iotago.SlotIndex) *Val
 }
 
 func (v *ValidationBlockBuilder) Sign(accountID iotago.AccountID, privKey ed25519.PrivateKey) *ValidationBlockBuilder {
+	//nolint:forcetypeassert // we can safely assume that this is an ed25519.PublicKey
 	pubKey := privKey.Public().(ed25519.PublicKey)
 	ed25519Address := iotago.Ed25519AddressFromPubKey(pubKey)
 

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -157,7 +157,10 @@ func (b *TransactionBuilder) AddTaggedDataPayload(payload *iotago.TaggedData) *T
 // TransactionFunc is a function which receives a SignedTransaction as its parameter.
 type TransactionFunc func(tx *iotago.SignedTransaction)
 
-func (b *TransactionBuilder) StoreRemainingManaInOutput(targetSlot iotago.SlotIndex, blockIssuerAccountID iotago.AccountID, storedManaOutputIndex int) *TransactionBuilder {
+// StoreRemainingManaInOutput moves the remaining mana to stored mana on the specified output index.
+// The given "ignoreMana" is not considered for the calculation of the remaining mana.
+// It will throw an error if the given "ignoreMana" is less than the available mana.
+func (b *TransactionBuilder) StoreRemainingManaInOutput(targetSlot iotago.SlotIndex, accountID iotago.AccountID, ignoreMana iotago.Mana, storedManaOutputIndex int) *TransactionBuilder {
 	setBuildError := func(err error) *TransactionBuilder {
 		b.occurredBuildErr = err
 		return b
@@ -167,7 +170,7 @@ func (b *TransactionBuilder) StoreRemainingManaInOutput(targetSlot iotago.SlotIn
 		return setBuildError(ierrors.Errorf("given storedManaOutputIndex does not exist: %d", storedManaOutputIndex))
 	}
 
-	unboundManaInputsLeftoverBalance, err := b.calculateAvailableManaLeftover(targetSlot, 0, blockIssuerAccountID)
+	unboundManaInputsLeftoverBalance, err := b.calculateAvailableManaLeftover(targetSlot, ignoreMana, accountID)
 	if err != nil {
 		return setBuildError(err)
 	}

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -198,7 +198,7 @@ func (b *TransactionBuilder) AllotRequiredManaAndStoreRemainingManaInOutput(targ
 	}
 
 	// calculate the minimum required mana to issue the block
-	minRequiredMana, err := b.MinRequiredAllotedMana(b.api.ProtocolParameters().WorkScoreParameters(), rmc, blockIssuerAccountID)
+	minRequiredMana, err := b.MinRequiredAllotedMana(rmc, blockIssuerAccountID)
 	if err != nil {
 		return setBuildError(ierrors.Wrap(err, "failed to calculate the minimum required mana to issue the block"))
 	}
@@ -513,7 +513,7 @@ func (b *TransactionBuilder) CalculateAvailableMana(targetSlot iotago.SlotIndex)
 // MinRequiredAllotedMana returns the minimum alloted mana required to issue a Block
 // with the transaction payload from the builder and 1 allotment for the block issuer
 // and a Ed25519 block signature.
-func (b *TransactionBuilder) MinRequiredAllotedMana(workScoreParameters *iotago.WorkScoreParameters, rmc iotago.Mana, blockIssuerAccountID iotago.AccountID) (iotago.Mana, error) {
+func (b *TransactionBuilder) MinRequiredAllotedMana(rmc iotago.Mana, blockIssuerAccountID iotago.AccountID) (iotago.Mana, error) {
 	// clone the essence allotments to not modify the original transaction
 	allotmentsCpy := b.transaction.Allotments.Clone()
 

--- a/wallet/keymanager.go
+++ b/wallet/keymanager.go
@@ -92,15 +92,9 @@ func (k *KeyManager) Mnemonic() bip39.Mnemonic {
 
 // AddressSigner returns an address signer.
 func (k *KeyManager) AddressSigner() iotago.AddressSigner {
-	privKey, pubKey := k.KeyPair()
+	privKey, _ := k.KeyPair()
 
-	// add both address types for simplicity in tests
-	ed25519Address := iotago.Ed25519AddressFromPubKey(pubKey)
-	ed25519AddressKey := iotago.NewAddressKeysForEd25519Address(ed25519Address, privKey)
-	implicitAccountCreationAddress := iotago.ImplicitAccountCreationAddressFromPubKey(pubKey)
-	implicitAccountCreationAddressKey := iotago.NewAddressKeysForImplicitAccountCreationAddress(implicitAccountCreationAddress, privKey)
-
-	return iotago.NewInMemoryAddressSigner(ed25519AddressKey, implicitAccountCreationAddressKey)
+	return iotago.NewInMemoryAddressSignerFromEd25519PrivateKey(privKey)
 }
 
 // Address calculates an address of the specified type.


### PR DESCRIPTION
We didn't take the costs for the block signature into consideration, when calculating the minimum required alloted mana to issue a block in the transaction builder.

That's the reason for the faucet not alloting enough mana to the block issuer.