### PR TITLE
Set rmc increase and decrease to 1

### DIFF
--- a/api/core_test.go
+++ b/api/core_test.go
@@ -400,8 +400,8 @@ func Test_CoreAPIJSONSerialization(t *testing.T) {
 				"epochNearingThreshold": 60,
 				"congestionControlParameters": {
 					"minReferenceManaCost": "1",
-					"increase": "10",
-					"decrease": "10",
+					"increase": "1",
+					"decrease": "1",
 					"increaseThreshold": 400000000,
 					"decreaseThreshold": 250000000,
 					"schedulerRate": 50000000,

--- a/api_test.go
+++ b/api_test.go
@@ -100,8 +100,8 @@ func TestProtocolParametersJSONMarshalling(t *testing.T) {
 	"epochNearingThreshold": 60,
 	"congestionControlParameters": {
 		"minReferenceManaCost": "1",
-		"increase": "10",
-		"decrease": "10",
+		"increase": "1",
+		"decrease": "1",
 		"increaseThreshold": 400000000,
 		"decreaseThreshold": 250000000,
 		"schedulerRate": 50000000,

--- a/api_v3_protocol_parameters.go
+++ b/api_v3_protocol_parameters.go
@@ -233,7 +233,7 @@ func NewV3SnapshotProtocolParameters(opts ...options.Option[V3ProtocolParameters
 			WithTimeProviderOptions(0, time.Now().Unix(), 10, 13),
 			WithLivenessOptions(15, 30, 10, 20, 60),
 			WithSupplyOptions(1813620509061365, 63, 1, 17, 32, 21, 70),
-			WithCongestionControlOptions(1, 10, 10, 400_000_000, 250_000_000, 50_000_000, 1000, 100),
+			WithCongestionControlOptions(1, 1, 1, 400_000_000, 250_000_000, 50_000_000, 1000, 100),
 			WithStakingOptions(10, 10, 10),
 			WithVersionSignalingOptions(7, 5, 7),
 			WithRewardsOptions(8, 8, 11, 2, 1, 384),

--- a/tpkg/test_consts.go
+++ b/tpkg/test_consts.go
@@ -18,7 +18,7 @@ var ShimmerMainnetV3TestProtocolParameters = iotago.NewV3SnapshotProtocolParamet
 	iotago.WithTimeProviderOptions(0, time.Now().Unix(), 10, 13),
 	iotago.WithLivenessOptions(15, 30, 10, 20, 60),
 	iotago.WithSupplyOptions(1813620509061365, 63, 1, 17, 32, 21, 70),
-	iotago.WithCongestionControlOptions(1, 10, 10, 400_000_000, 250_000_000, 50_000_000, 1000, 100),
+	iotago.WithCongestionControlOptions(1, 1, 1, 400_000_000, 250_000_000, 50_000_000, 1000, 100),
 	iotago.WithStakingOptions(10, 10, 10),
 	iotago.WithVersionSignalingOptions(7, 5, 7),
 	iotago.WithRewardsOptions(8, 8, 11, 2, 1, 384),


### PR DESCRIPTION
Update RMC Increase and Decrease parameters to 1. 
This is in line with decisions made about minimum block costs. We have now set the WorkScore of a standard block to roughly 500,000 and RMCMin to 1, so this standard block will cost 0.5 Mana, and this cost will increase by 0.5 Mana each time RMC increases.

Decision discussed with and approved by @vekkiokonio 