### PR TITLE
Block failure reason improvements

### DIFF
--- a/api/core.go
+++ b/api/core.go
@@ -256,66 +256,65 @@ const (
 
 	TxFailureMultiAddressLengthUnlockLengthMismatch TransactionFailureReason = 20
 	TxFailureMultiAddressUnlockThresholdNotReached  TransactionFailureReason = 21
-	TxFailureNestedMultiUnlock                      TransactionFailureReason = 22
 
-	TxFailureSenderFeatureNotUnlocked TransactionFailureReason = 23
+	TxFailureSenderFeatureNotUnlocked TransactionFailureReason = 22
 
-	TxFailureIssuerFeatureNotUnlocked TransactionFailureReason = 24
+	TxFailureIssuerFeatureNotUnlocked TransactionFailureReason = 23
 
-	TxFailureStakingRewardInputMissing             TransactionFailureReason = 25
-	TxFailureStakingBlockIssuerFeatureMissing      TransactionFailureReason = 26
-	TxFailureStakingCommitmentInputMissing         TransactionFailureReason = 27
-	TxFailureStakingRewardClaimingInvalid          TransactionFailureReason = 28
-	TxFailureStakingFeatureRemovedBeforeUnbonding  TransactionFailureReason = 29
-	TxFailureStakingFeatureModifiedBeforeUnbonding TransactionFailureReason = 30
-	TxFailureStakingStartEpochInvalid              TransactionFailureReason = 31
-	TxFailureStakingEndEpochTooEarly               TransactionFailureReason = 32
+	TxFailureStakingRewardInputMissing             TransactionFailureReason = 24
+	TxFailureStakingBlockIssuerFeatureMissing      TransactionFailureReason = 25
+	TxFailureStakingCommitmentInputMissing         TransactionFailureReason = 26
+	TxFailureStakingRewardClaimingInvalid          TransactionFailureReason = 27
+	TxFailureStakingFeatureRemovedBeforeUnbonding  TransactionFailureReason = 28
+	TxFailureStakingFeatureModifiedBeforeUnbonding TransactionFailureReason = 29
+	TxFailureStakingStartEpochInvalid              TransactionFailureReason = 30
+	TxFailureStakingEndEpochTooEarly               TransactionFailureReason = 31
 
-	TxFailureBlockIssuerCommitmentInputMissing TransactionFailureReason = 33
-	TxFailureBlockIssuanceCreditInputMissing   TransactionFailureReason = 34
-	TxFailureBlockIssuerNotExpired             TransactionFailureReason = 35
-	TxFailureBlockIssuerExpiryTooEarly         TransactionFailureReason = 36
-	TxFailureManaMovedOffBlockIssuerAccount    TransactionFailureReason = 37
-	TxFailureAccountLocked                     TransactionFailureReason = 38
+	TxFailureBlockIssuerCommitmentInputMissing TransactionFailureReason = 32
+	TxFailureBlockIssuanceCreditInputMissing   TransactionFailureReason = 33
+	TxFailureBlockIssuerNotExpired             TransactionFailureReason = 34
+	TxFailureBlockIssuerExpiryTooEarly         TransactionFailureReason = 35
+	TxFailureManaMovedOffBlockIssuerAccount    TransactionFailureReason = 36
+	TxFailureAccountLocked                     TransactionFailureReason = 37
 
-	TxFailureTimelockCommitmentInputMissing TransactionFailureReason = 39
-	TxFailureTimelockNotExpired             TransactionFailureReason = 40
+	TxFailureTimelockCommitmentInputMissing TransactionFailureReason = 38
+	TxFailureTimelockNotExpired             TransactionFailureReason = 39
 
-	TxFailureExpirationCommitmentInputMissing TransactionFailureReason = 41
-	TxFailureExpirationNotUnlockable          TransactionFailureReason = 42
+	TxFailureExpirationCommitmentInputMissing TransactionFailureReason = 40
+	TxFailureExpirationNotUnlockable          TransactionFailureReason = 41
 
-	TxFailureReturnAmountNotFulFilled TransactionFailureReason = 43
+	TxFailureReturnAmountNotFulFilled TransactionFailureReason = 42
 
-	TxFailureNewChainOutputHasNonZeroedID        TransactionFailureReason = 44
-	TxFailureChainOutputImmutableFeaturesChanged TransactionFailureReason = 45
+	TxFailureNewChainOutputHasNonZeroedID        TransactionFailureReason = 43
+	TxFailureChainOutputImmutableFeaturesChanged TransactionFailureReason = 44
 
-	TxFailureImplicitAccountDestructionDisallowed     TransactionFailureReason = 46
-	TxFailureMultipleImplicitAccountCreationAddresses TransactionFailureReason = 47
+	TxFailureImplicitAccountDestructionDisallowed     TransactionFailureReason = 45
+	TxFailureMultipleImplicitAccountCreationAddresses TransactionFailureReason = 46
 
-	TxFailureAccountInvalidFoundryCounter TransactionFailureReason = 48
+	TxFailureAccountInvalidFoundryCounter TransactionFailureReason = 47
 
-	TxFailureAnchorInvalidStateTransition      TransactionFailureReason = 49
-	TxFailureAnchorInvalidGovernanceTransition TransactionFailureReason = 50
+	TxFailureAnchorInvalidStateTransition      TransactionFailureReason = 48
+	TxFailureAnchorInvalidGovernanceTransition TransactionFailureReason = 49
 
-	TxFailureFoundryTransitionWithoutAccount TransactionFailureReason = 51
-	TxFailureFoundrySerialInvalid            TransactionFailureReason = 52
+	TxFailureFoundryTransitionWithoutAccount TransactionFailureReason = 50
+	TxFailureFoundrySerialInvalid            TransactionFailureReason = 51
 
-	TxFailureDelegationCommitmentInputMissing  TransactionFailureReason = 53
-	TxFailureDelegationRewardInputMissing      TransactionFailureReason = 54
-	TxFailureDelegationRewardsClaimingInvalid  TransactionFailureReason = 55
-	TxFailureDelegationOutputTransitionedTwice TransactionFailureReason = 56
-	TxFailureDelegationModified                TransactionFailureReason = 57
-	TxFailureDelegationStartEpochInvalid       TransactionFailureReason = 58
-	TxFailureDelegationAmountMismatch          TransactionFailureReason = 59
-	TxFailureDelegationEndEpochNotZero         TransactionFailureReason = 60
-	TxFailureDelegationEndEpochInvalid         TransactionFailureReason = 61
+	TxFailureDelegationCommitmentInputMissing  TransactionFailureReason = 52
+	TxFailureDelegationRewardInputMissing      TransactionFailureReason = 53
+	TxFailureDelegationRewardsClaimingInvalid  TransactionFailureReason = 54
+	TxFailureDelegationOutputTransitionedTwice TransactionFailureReason = 55
+	TxFailureDelegationModified                TransactionFailureReason = 56
+	TxFailureDelegationStartEpochInvalid       TransactionFailureReason = 57
+	TxFailureDelegationAmountMismatch          TransactionFailureReason = 58
+	TxFailureDelegationEndEpochNotZero         TransactionFailureReason = 59
+	TxFailureDelegationEndEpochInvalid         TransactionFailureReason = 60
 
-	TxFailureCapabilitiesNativeTokenBurningNotAllowed TransactionFailureReason = 62
-	TxFailureCapabilitiesManaBurningNotAllowed        TransactionFailureReason = 63
-	TxFailureCapabilitiesAccountDestructionNotAllowed TransactionFailureReason = 64
-	TxFailureCapabilitiesAnchorDestructionNotAllowed  TransactionFailureReason = 65
-	TxFailureCapabilitiesFoundryDestructionNotAllowed TransactionFailureReason = 66
-	TxFailureCapabilitiesNFTDestructionNotAllowed     TransactionFailureReason = 67
+	TxFailureCapabilitiesNativeTokenBurningNotAllowed TransactionFailureReason = 61
+	TxFailureCapabilitiesManaBurningNotAllowed        TransactionFailureReason = 62
+	TxFailureCapabilitiesAccountDestructionNotAllowed TransactionFailureReason = 63
+	TxFailureCapabilitiesAnchorDestructionNotAllowed  TransactionFailureReason = 64
+	TxFailureCapabilitiesFoundryDestructionNotAllowed TransactionFailureReason = 65
+	TxFailureCapabilitiesNFTDestructionNotAllowed     TransactionFailureReason = 66
 
 	TxFailureSemanticValidationFailed TransactionFailureReason = 255
 )
@@ -366,7 +365,6 @@ var txErrorsFailureReasonMap = map[error]TransactionFailureReason{
 
 	// multi address
 	iotago.ErrMultiAddressLengthUnlockLengthMismatch: TxFailureMultiAddressLengthUnlockLengthMismatch,
-	iotago.ErrNestedMultiUnlock:                      TxFailureNestedMultiUnlock,
 	iotago.ErrMultiAddressUnlockThresholdNotReached:  TxFailureMultiAddressUnlockThresholdNotReached,
 
 	// sender feature

--- a/api/core.go
+++ b/api/core.go
@@ -3,8 +3,6 @@ package api
 import (
 	"time"
 
-	"github.com/samber/lo"
-
 	"github.com/iotaledger/hive.go/ierrors"
 	"github.com/iotaledger/hive.go/serializer/v2"
 	iotago "github.com/iotaledger/iota.go/v4"
@@ -461,9 +459,10 @@ func unwrapErrors(err error, errList []error) []error {
 	//nolint:errorlint // false positive: we're not switching on a specific error type.
 	switch x := err.(type) {
 	case interface{ Unwrap() []error }:
-		// Reverse, so we walk the tree in post-order.
-		reversedErrors := lo.Reverse(x.Unwrap())
-		for _, err := range reversedErrors {
+		errors := x.Unwrap()
+		// Iterate the errors in reverse, so we walk the tree in post-order.
+		for i := len(errors) - 1; i >= 0; i-- {
+			err := errors[i]
 			if err != nil {
 				errList = unwrapErrors(err, errList)
 				errList = append(errList, err)

--- a/api/core_test.go
+++ b/api/core_test.go
@@ -524,7 +524,7 @@ func Test_CoreAPIJSONSerialization(t *testing.T) {
 	"transactionMetadata": {
 		"transactionId": "0x010000000000000000000000000000000000000000000000000000000000000000000000",
 		"transactionState": "failed",
-		"transactionFailureReason": 55
+		"transactionFailureReason": 54
 	}
 }`,
 		},

--- a/error.go
+++ b/error.go
@@ -16,14 +16,10 @@ var (
 	ErrIssuerAccountNotFound = ierrors.New("could not retrieve account information for block issuer")
 	// ErrBurnedInsufficientMana gets returned when the issuer account burned insufficient Mana for a block.
 	ErrBurnedInsufficientMana = ierrors.New("block issuer account burned insufficient Mana")
-	// ErrBlockVersionInvalid gets returned when the block version is invalid to retrieve API.
-	ErrBlockVersionInvalid = ierrors.New("could not retrieve API for block version")
 	// ErrRMCNotFound gets returned when the RMC could not be found from the slot commitment.
 	ErrRMCNotFound = ierrors.New("could not retrieve RMC for slot commitment")
 	// ErrFailedToCalculateManaCost gets returned when the Mana cost could not be calculated.
 	ErrFailedToCalculateManaCost = ierrors.New("could not calculate Mana cost for block")
-	// ErrNegativeBIC gets returned when the BIC of the issuer account is negative.
-	ErrNegativeBIC = ierrors.New("negative BIC")
 	// ErrAccountExpired gets returned when the account is expired.
 	ErrAccountExpired = ierrors.New("account expired")
 	// ErrInvalidSignature gets returned when the signature is invalid.

--- a/vm/nova/stvf_test.go
+++ b/vm/nova/stvf_test.go
@@ -3126,7 +3126,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 					},
 				},
 			},
-			wantErr: &iotago.ChainTransitionError{},
+			wantErr: iotago.ErrChainOutputImmutableFeaturesChanged,
 		},
 	}
 
@@ -3141,8 +3141,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 
 					err := novaVM.ChainSTVF(tt.svCtx, tt.transType, tt.input, cpy)
 					if tt.wantErr != nil {
-						//nolint:gosec // false positive
-						require.ErrorAs(t, err, &tt.wantErr)
+						require.ErrorIs(t, err, tt.wantErr)
 						return
 					}
 					require.NoError(t, err)
@@ -3156,8 +3155,7 @@ func TestNFTOutput_ValidateStateTransition(t *testing.T) {
 
 			err := novaVM.ChainSTVF(tt.svCtx, tt.transType, tt.input, tt.next)
 			if tt.wantErr != nil {
-				//nolint:gosec // false positive
-				require.ErrorAs(t, err, &tt.wantErr)
+				require.ErrorIs(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
# Description of change

fixes #679 

Also implements the reverse iteration over the errors in `unwrapErrors` with a read-only for loop instead of the writing `lo.Reverse` which caused a race condition in iota-core.
