### PR TITLE
Derive Target Rewards

### DIFF
--- a/api.go
+++ b/api.go
@@ -66,10 +66,6 @@ type API interface {
 	ManaDecayProvider() *ManaDecayProvider
 	// MaxBlockWork returns the maximum block work score.
 	MaxBlockWork() WorkScore
-	// ComputedInitialReward returns the initial reward calculated from the parameters.
-	ComputedInitialReward() Mana
-	// ComputedFinalReward returns the final reward calculated from the parameters.
-	ComputedFinalReward() Mana
 }
 
 func LatestProtocolVersion() Version {

--- a/api/core_test.go
+++ b/api/core_test.go
@@ -416,9 +416,9 @@ func Test_CoreAPIJSONSerialization(t *testing.T) {
 				"rewardsParameters": {
 					"profitMarginExponent": 8,
 					"bootstrappingDuration": 1079,
-					"manaShareCoefficient": "2",
-					"decayBalancingConstantExponent": 8,
-					"decayBalancingConstant": "1",
+					"rewardToGenerationRatio": "2",
+					"initialRewardsRate": 1,
+					"finalRewardsRate": 1,
 					"poolCoefficientExponent": 11,
 					"retentionPeriod": 384
 				},

--- a/api/core_test.go
+++ b/api/core_test.go
@@ -416,9 +416,9 @@ func Test_CoreAPIJSONSerialization(t *testing.T) {
 				"rewardsParameters": {
 					"profitMarginExponent": 8,
 					"bootstrappingDuration": 1079,
-					"rewardToGenerationRatio": "2",
-					"initialRewardsRate": 1,
-					"finalRewardsRate": 1,
+					"rewardToGenerationRatio": 2,
+					"initialTargetRewardsRate": "616067521149261",
+					"finalTargetRewardsRate": "226702563632670",
 					"poolCoefficientExponent": 11,
 					"retentionPeriod": 384
 				},

--- a/api_test.go
+++ b/api_test.go
@@ -116,9 +116,9 @@ func TestProtocolParametersJSONMarshalling(t *testing.T) {
 	"rewardsParameters": {
 		"profitMarginExponent": 8,
 		"bootstrappingDuration": 1079,
-		"manaShareCoefficient": "2",
-		"decayBalancingConstantExponent": 8,
-		"decayBalancingConstant": "1",
+		"rewardToGenerationRatio": "2",
+		"initialRewardsRate": "1",
+		"finalRewardsRate": "1",
 		"poolCoefficientExponent": 11,
 		"retentionPeriod": 384
 	},

--- a/api_test.go
+++ b/api_test.go
@@ -116,9 +116,9 @@ func TestProtocolParametersJSONMarshalling(t *testing.T) {
 	"rewardsParameters": {
 		"profitMarginExponent": 8,
 		"bootstrappingDuration": 1079,
-		"rewardToGenerationRatio": "2",
-		"initialRewardsRate": "1",
-		"finalRewardsRate": "1",
+		"rewardToGenerationRatio": 2,
+		"initialTargetRewardsRate": "616067521149261",
+		"finalTargetRewardsRate": "226702563632670",
 		"poolCoefficientExponent": 11,
 		"retentionPeriod": 384
 	},

--- a/mana.go
+++ b/mana.go
@@ -42,14 +42,14 @@ func (m ManaParameters) Equals(other ManaParameters) bool {
 type RewardsParameters struct {
 	// ProfitMarginExponent is used for shift operation for calculation of profit margin.
 	ProfitMarginExponent uint8 `serix:""`
-	// BootstrappingDuration is the length in epochs of the bootstrapping phase, (approx 3 years).
+	// BootstrappingDuration is the length, in epochs, of the bootstrapping phase, (approx 3 years).
 	BootstrappingDuration EpochIndex `serix:""`
 	// RewardToGenerationRatio is the ratio of the final rewards rate to the generation rate of Mana.
 	RewardToGenerationRatio uint8 `serix:""`
-	// InitialRewardsRate is the rate of Mana rewards at the start of the bootstrapping phase.
-	InitialRewardsRate Mana `serix:""`
-	// FinalRewardsRate is the rate of Mana rewards after the bootstrapping phase.
-	FinalRewardsRate Mana `serix:""`
+	// InitialTargetRewardsRate is the rate of Mana rewards at the start of the bootstrapping phase.
+	InitialTargetRewardsRate Mana `serix:""`
+	// FinalTargetRewardsRate is the rate of Mana rewards after the bootstrapping phase.
+	FinalTargetRewardsRate Mana `serix:""`
 	// PoolCoefficientExponent is the exponent used for shifting operation in the pool rewards calculations.
 	PoolCoefficientExponent uint8 `serix:""`
 	// The number of epochs for which rewards are retained.
@@ -60,19 +60,19 @@ func (r RewardsParameters) Equals(other RewardsParameters) bool {
 	return r.ProfitMarginExponent == other.ProfitMarginExponent &&
 		r.BootstrappingDuration == other.BootstrappingDuration &&
 		r.RewardToGenerationRatio == other.RewardToGenerationRatio &&
-		r.InitialRewardsRate == other.InitialRewardsRate &&
-		r.FinalRewardsRate == other.FinalRewardsRate &&
+		r.InitialTargetRewardsRate == other.InitialTargetRewardsRate &&
+		r.FinalTargetRewardsRate == other.FinalTargetRewardsRate &&
 		r.PoolCoefficientExponent == other.PoolCoefficientExponent &&
 		r.RetentionPeriod == other.RetentionPeriod
 }
 
 func (r RewardsParameters) TargetReward(epoch EpochIndex, api API) (Mana, error) {
 	if epoch > r.BootstrappingDuration {
-		return api.ProtocolParameters().RewardsParameters().FinalRewardsRate, nil
+		return api.ProtocolParameters().RewardsParameters().FinalTargetRewardsRate, nil
 	}
 
 	// Rewards start at epoch 0.
-	decayedInitialReward, err := api.ManaDecayProvider().DecayManaByEpochs(api.ProtocolParameters().RewardsParameters().InitialRewardsRate, 0, epoch)
+	decayedInitialReward, err := api.ManaDecayProvider().DecayManaByEpochs(api.ProtocolParameters().RewardsParameters().InitialTargetRewardsRate, 0, epoch)
 	if err != nil {
 		return 0, ierrors.Errorf("failed to calculate decayed initial reward: %w", err)
 	}

--- a/mana.go
+++ b/mana.go
@@ -44,12 +44,12 @@ type RewardsParameters struct {
 	ProfitMarginExponent uint8 `serix:""`
 	// BootstrappingDuration is the length in epochs of the bootstrapping phase, (approx 3 years).
 	BootstrappingDuration EpochIndex `serix:""`
-	// ManaShareCoefficient is the coefficient used for calculation of initial rewards, relative to the term theta/(1-theta) from the Whitepaper, with theta = 2/3.
-	ManaShareCoefficient uint64 `serix:""`
-	// DecayBalancingConstantExponent is the exponent used for calculation of the initial reward.
-	DecayBalancingConstantExponent uint8 `serix:""`
-	// DecayBalancingConstant needs to be an integer approximation calculated based on chosen DecayBalancingConstantExponent.
-	DecayBalancingConstant uint64 `serix:""`
+	// RewardToGenerationRatio is the ratio of the final rewards rate to the generation rate of Mana.
+	RewardToGenerationRatio uint8 `serix:""`
+	// InitialRewardsRate is the rate of Mana rewards at the start of the bootstrapping phase.
+	InitialRewardsRate Mana `serix:""`
+	// FinalRewardsRate is the rate of Mana rewards after the bootstrapping phase.
+	FinalRewardsRate Mana `serix:""`
 	// PoolCoefficientExponent is the exponent used for shifting operation in the pool rewards calculations.
 	PoolCoefficientExponent uint8 `serix:""`
 	// The number of epochs for which rewards are retained.
@@ -57,21 +57,22 @@ type RewardsParameters struct {
 }
 
 func (r RewardsParameters) Equals(other RewardsParameters) bool {
-	return r.ProfitMarginExponent == other.ProfitMarginExponent && r.BootstrappingDuration == other.BootstrappingDuration &&
-		r.ManaShareCoefficient == other.ManaShareCoefficient &&
-		r.DecayBalancingConstantExponent == other.DecayBalancingConstantExponent &&
-		r.DecayBalancingConstant == other.DecayBalancingConstant &&
+	return r.ProfitMarginExponent == other.ProfitMarginExponent &&
+		r.BootstrappingDuration == other.BootstrappingDuration &&
+		r.RewardToGenerationRatio == other.RewardToGenerationRatio &&
+		r.InitialRewardsRate == other.InitialRewardsRate &&
+		r.FinalRewardsRate == other.FinalRewardsRate &&
 		r.PoolCoefficientExponent == other.PoolCoefficientExponent &&
 		r.RetentionPeriod == other.RetentionPeriod
 }
 
 func (r RewardsParameters) TargetReward(epoch EpochIndex, api API) (Mana, error) {
 	if epoch > r.BootstrappingDuration {
-		return api.ComputedFinalReward(), nil
+		return api.ProtocolParameters().RewardsParameters().FinalRewardsRate, nil
 	}
 
 	// Rewards start at epoch 0.
-	decayedInitialReward, err := api.ManaDecayProvider().DecayManaByEpochs(api.ComputedInitialReward(), 0, epoch)
+	decayedInitialReward, err := api.ManaDecayProvider().DecayManaByEpochs(api.ProtocolParameters().RewardsParameters().InitialRewardsRate, 0, epoch)
 	if err != nil {
 		return 0, ierrors.Errorf("failed to calculate decayed initial reward: %w", err)
 	}

--- a/tpkg/test_consts.go
+++ b/tpkg/test_consts.go
@@ -21,7 +21,7 @@ var ShimmerMainnetV3TestProtocolParameters = iotago.NewV3SnapshotProtocolParamet
 	iotago.WithCongestionControlOptions(1, 1, 1, 400_000_000, 250_000_000, 50_000_000, 1000, 100),
 	iotago.WithStakingOptions(10, 10, 10),
 	iotago.WithVersionSignalingOptions(7, 5, 7),
-	iotago.WithRewardsOptions(8, 8, 11, 2, 1, 384),
+	iotago.WithRewardsOptions(8, 11, 2, 384),
 	iotago.WithTargetCommitteeSize(32),
 )
 


### PR DESCRIPTION
Switch to deriving the initial and final target rewards rates using float arithmetic when creating the protocol params for snapshot/tests, then storing these target rewards rates in protocol params rather than the api.

We also remove the unnecessary parameters `DecayBalancingCoefficient` and `DecayBalancingExponent` which were integer approximations used for deriving the target rewards. However, we don't need integer approximations as we can just use float arithmetic as we only compute the initial and target rewards once upon initialisation of the protocol params. As with other derived parameters, this should only be done once for a given network as the float results may differ between machines. 

Companion PR in iota-core to update some tests https://github.com/iotaledger/iota-core/pull/742

closes https://github.com/iotaledger/iota-core/issues/636