### PR TITLE
Use same address key for implicit account address and ed25519 address from same pubkey

### DIFF
--- a/address_ed25519.gen.go
+++ b/address_ed25519.gen.go
@@ -43,7 +43,7 @@ func (addr *Ed25519Address) ID() []byte {
 }
 
 func (addr *Ed25519Address) Key() string {
-	return string(addr.ID())
+	return string(addr.ID()[serializer.SmallTypeDenotationByteSize:])
 }
 
 func (addr *Ed25519Address) Unlock(msg []byte, sig Signature) error {

--- a/address_implicit_account_creation.gen.go
+++ b/address_implicit_account_creation.gen.go
@@ -39,7 +39,7 @@ func (addr *ImplicitAccountCreationAddress) ID() []byte {
 }
 
 func (addr *ImplicitAccountCreationAddress) Key() string {
-	return string(addr.ID())
+	return string(addr.ID()[serializer.SmallTypeDenotationByteSize:])
 }
 
 func (addr *ImplicitAccountCreationAddress) Unlock(msg []byte, sig Signature) error {

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -681,25 +681,27 @@ func (b *TransactionBuilder) Build(signer iotago.AddressSigner) (*iotago.SignedT
 	for i, inputRef := range b.transaction.TransactionEssence.Inputs {
 		//nolint:forcetypeassert // we can safely assume that this is an UTXOInput
 		addr := b.inputOwner[inputRef.(*iotago.UTXOInput).OutputID()]
-		addrKey := addr.Key()
 
-		pos, unlocked := unlockPos[addrKey]
+		// produce signature
+		var signature iotago.Signature
+		signature, err = signer.Sign(addr, txEssenceData)
+		if err != nil {
+			return nil, ierrors.Wrapf(err, "failed to sign tx transaction: %s", txEssenceData)
+		}
+		ed25519Sig, is := signature.(*iotago.Ed25519Signature)
+		if !is {
+			return nil, ierrors.Errorf("signature is not an Ed25519Signature")
+		}
+		pubKeyString := string(ed25519Sig.PublicKey[:])
+		pos, unlocked := unlockPos[pubKeyString]
 		if !unlocked {
 			// the output's owning chain address must have been unlocked already
 			if _, is := addr.(iotago.ChainAddress); is {
 				return nil, ierrors.Errorf("input %d's owning chain is not unlocked, chainID %s, type %s", i, addr, addr.Type())
 			}
-
-			// produce signature
-			var signature iotago.Signature
-			signature, err = signer.Sign(addr, txEssenceData)
-			if err != nil {
-				return nil, ierrors.Wrapf(err, "failed to sign tx transaction: %s", txEssenceData)
-			}
-
 			unlocks = append(unlocks, &iotago.SignatureUnlock{Signature: signature})
 			addChainAsUnlocked(inputs[i], i, unlockPos)
-			unlockPos[addrKey] = i
+			unlockPos[pubKeyString] = i
 
 			continue
 		}


### PR DESCRIPTION
Use same address key for implicit account address and ed25519 address from same pubkey so both the address signer and the vm can recognise that a signature from the underlying pubkey is a valid unlock for either an implicit account address or an ed25519 address type.