### PR TITLE
Fix reference unlock by same public key but different address

### DIFF
--- a/address.go
+++ b/address.go
@@ -166,8 +166,6 @@ type ChainID interface {
 	ToAddress() ChainAddress
 	// Empty tells whether the ChainID is empty.
 	Empty() bool
-	// Key returns a key to use to index this ChainID.
-	Key() interface{}
 	// ToHex returns the hex representation of the ChainID.
 	ToHex() string
 }

--- a/block_test.go
+++ b/block_test.go
@@ -304,7 +304,7 @@ func TestBlock_TransactionCreationTime(t *testing.T) {
 			iotago.WithLivenessOptions(15, 30, 7, 21, 60),
 		), 0)
 
-	creationSlotTooRecent, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	creationSlotTooRecent, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -313,13 +313,13 @@ func TestBlock_TransactionCreationTime(t *testing.T) {
 		AddOutput(output).
 		SetCreationSlot(101).
 		AddCommitmentInput(&iotago.CommitmentInput{CommitmentID: iotago.NewCommitmentID(78, tpkg.Rand32ByteArray())}).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.ErrorIs(t, createBlockAtSlotWithPayload(t, 100, 79, creationSlotTooRecent, apiProvider), iotago.ErrTransactionCreationSlotTooRecent)
 
-	creationSlotCorrectEqual, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	creationSlotCorrectEqual, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -327,13 +327,13 @@ func TestBlock_TransactionCreationTime(t *testing.T) {
 		}).
 		AddOutput(output).
 		SetCreationSlot(100).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.NoError(t, createBlockAtSlotWithPayload(t, 100, 89, creationSlotCorrectEqual, apiProvider))
 
-	creationSlotCorrectSmallerThanCommitment, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	creationSlotCorrectSmallerThanCommitment, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -341,13 +341,13 @@ func TestBlock_TransactionCreationTime(t *testing.T) {
 		}).
 		AddOutput(output).
 		SetCreationSlot(1).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.NoError(t, createBlockAtSlotWithPayload(t, 100, 89, creationSlotCorrectSmallerThanCommitment, apiProvider))
 
-	creationSlotCorrectLargerThanCommitment, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	creationSlotCorrectLargerThanCommitment, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -355,7 +355,7 @@ func TestBlock_TransactionCreationTime(t *testing.T) {
 		}).
 		AddOutput(output).
 		SetCreationSlot(99).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
@@ -430,7 +430,7 @@ func TestBlock_TransactionCommitmentInput(t *testing.T) {
 			iotago.WithLivenessOptions(15, 30, 11, 21, 60),
 		), 0)
 
-	commitmentInputTooOld, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	commitmentInputTooOld, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -438,13 +438,13 @@ func TestBlock_TransactionCommitmentInput(t *testing.T) {
 		}).
 		AddOutput(output).
 		AddCommitmentInput(&iotago.CommitmentInput{CommitmentID: iotago.NewCommitmentID(78, tpkg.Rand32ByteArray())}).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.ErrorIs(t, createBlockAtSlotWithPayload(t, 100, 79, commitmentInputTooOld, apiProvider), iotago.ErrCommitmentInputTooOld)
 
-	commitmentInputTooRecent, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	commitmentInputTooRecent, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -452,13 +452,13 @@ func TestBlock_TransactionCommitmentInput(t *testing.T) {
 		}).
 		AddOutput(output).
 		AddCommitmentInput(&iotago.CommitmentInput{CommitmentID: iotago.NewCommitmentID(90, tpkg.Rand32ByteArray())}).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.ErrorIs(t, createBlockAtSlotWithPayload(t, 100, 89, commitmentInputTooRecent, apiProvider), iotago.ErrCommitmentInputTooRecent)
 
-	commitmentInputNewerThanBlockCommitment, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	commitmentInputNewerThanBlockCommitment, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -466,13 +466,13 @@ func TestBlock_TransactionCommitmentInput(t *testing.T) {
 		}).
 		AddOutput(output).
 		AddCommitmentInput(&iotago.CommitmentInput{CommitmentID: iotago.NewCommitmentID(85, tpkg.Rand32ByteArray())}).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.ErrorIs(t, createBlockAtSlotWithPayload(t, 100, 79, commitmentInputNewerThanBlockCommitment, apiProvider), iotago.ErrCommitmentInputNewerThanCommitment)
 
-	commitmentCorrect, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	commitmentCorrect, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -480,13 +480,13 @@ func TestBlock_TransactionCommitmentInput(t *testing.T) {
 		}).
 		AddOutput(output).
 		AddCommitmentInput(&iotago.CommitmentInput{CommitmentID: iotago.NewCommitmentID(79, tpkg.Rand32ByteArray())}).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.NoError(t, createBlockAtSlotWithPayload(t, 100, 89, commitmentCorrect, apiProvider))
 
-	commitmentCorrectOldest, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	commitmentCorrectOldest, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -494,13 +494,13 @@ func TestBlock_TransactionCommitmentInput(t *testing.T) {
 		}).
 		AddOutput(output).
 		AddCommitmentInput(&iotago.CommitmentInput{CommitmentID: iotago.NewCommitmentID(79, tpkg.Rand32ByteArray())}).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.NoError(t, createBlockAtSlotWithPayload(t, 100, 79, commitmentCorrectOldest, apiProvider))
 
-	commitmentCorrectNewest, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	commitmentCorrectNewest, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -508,13 +508,13 @@ func TestBlock_TransactionCommitmentInput(t *testing.T) {
 		}).
 		AddOutput(output).
 		AddCommitmentInput(&iotago.CommitmentInput{CommitmentID: iotago.NewCommitmentID(89, tpkg.Rand32ByteArray())}).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 
 	require.NoError(t, createBlockAtSlotWithPayload(t, 100, 89, commitmentCorrectNewest, apiProvider))
 
-	commitmentCorrectMiddle, err := builder.NewTransactionBuilder(apiProvider.LatestAPI()).
+	commitmentCorrectMiddle, err := builder.NewTransactionBuilder(apiProvider.LatestAPI(), iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -522,7 +522,7 @@ func TestBlock_TransactionCommitmentInput(t *testing.T) {
 		}).
 		AddOutput(output).
 		AddCommitmentInput(&iotago.CommitmentInput{CommitmentID: iotago.NewCommitmentID(85, tpkg.Rand32ByteArray())}).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 
 	require.NoError(t, err)
 

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -10,9 +10,10 @@ import (
 var ErrTransactionBuilder = ierrors.New("transaction builder error")
 
 // NewTransactionBuilder creates a new TransactionBuilder.
-func NewTransactionBuilder(api iotago.API) *TransactionBuilder {
+func NewTransactionBuilder(api iotago.API, signer iotago.AddressSigner) *TransactionBuilder {
 	return &TransactionBuilder{
-		api: api,
+		api:    api,
+		signer: signer,
 		transaction: &iotago.Transaction{
 			API: api,
 			TransactionEssence: &iotago.TransactionEssence{
@@ -33,6 +34,7 @@ func NewTransactionBuilder(api iotago.API) *TransactionBuilder {
 // TransactionBuilder is used to easily build up a SignedTransaction.
 type TransactionBuilder struct {
 	api              iotago.API
+	signer           iotago.AddressSigner
 	occurredBuildErr error
 	transaction      *iotago.Transaction
 	inputs           iotago.OutputSet
@@ -58,10 +60,12 @@ func (b *TransactionBuilder) Clone() *TransactionBuilder {
 
 	return &TransactionBuilder{
 		api:              b.api,
+		signer:           b.signer,
 		occurredBuildErr: b.occurredBuildErr,
 		transaction:      b.transaction.Clone(),
 		inputs:           b.inputs.Clone(),
 		inputOwner:       cpyInputOwner,
+		rewards:          b.rewards,
 	}
 }
 
@@ -458,9 +462,9 @@ func (b *TransactionBuilder) hasManalockCondition(output iotago.Output) (iotago.
 
 // BuildAndSwapToBlockBuilder builds the transaction and then swaps to a BasicBlockBuilder with
 // the transaction set as its payload. txFunc can be nil.
-func (b *TransactionBuilder) BuildAndSwapToBlockBuilder(signer iotago.AddressSigner, txFunc TransactionFunc) *BasicBlockBuilder {
+func (b *TransactionBuilder) BuildAndSwapToBlockBuilder(txFunc TransactionFunc) *BasicBlockBuilder {
 	blockBuilder := NewBasicBlockBuilder(b.api)
-	tx, err := b.Build(signer)
+	tx, err := b.Build()
 	if err != nil {
 		blockBuilder.err = err
 
@@ -636,26 +640,36 @@ func (b *TransactionBuilder) MinRequiredAllottedMana(rmc iotago.Mana, blockIssue
 	// add a dummy allotment to account for the later added allotment for the block issuer in case it does not exist yet
 	b.IncreaseAllotment(blockIssuerAccountID, 1074)
 
-	// create a dummy block builder with the transaction payload to get the correct workscore.
-	// the transaction is signed with an empty signer to get the correct workscore.
+	// the transaction is "signed" with empty signatures to get the correct workscore.
 	// later the transaction needs to be signed with the correct signer, after the allotted mana was set correctly.
-	dummyBlockBuilder := b.BuildAndSwapToBlockBuilder(&iotago.EmptyAddressSigner{}, nil)
+	tx, err := b.build(false)
+	if err != nil {
+		return 0, ierrors.Wrap(err, "failed to build the dummy tx payload for workscore calculation")
+	}
+
+	// create a dummy block builder with the transaction payload to get the correct workscore.
+	dummyBlockBuilder := NewBasicBlockBuilder(b.api).Payload(tx)
 
 	// normally the block should be build first to sort the parents, but we don't need the block itself, just the workscore
 	dummyBlock, err := dummyBlockBuilder.Build()
 	if err != nil {
-		return 0, ierrors.Wrap(err, "failed to build the dummy block")
+		return 0, ierrors.Wrap(err, "failed to build the dummy block for workscore calculation")
 	}
 
 	return dummyBlock.ManaCost(rmc)
 }
 
 // Build signs the inputs with the given signer and returns the built payload.
-func (b *TransactionBuilder) Build(signer iotago.AddressSigner) (*iotago.SignedTransaction, error) {
+func (b *TransactionBuilder) Build() (*iotago.SignedTransaction, error) {
+	return b.build(true)
+}
+
+// Build signs the inputs with the given signer and returns the built payload.
+func (b *TransactionBuilder) build(signEssence bool) (*iotago.SignedTransaction, error) {
 	switch {
 	case b.occurredBuildErr != nil:
 		return nil, b.occurredBuildErr
-	case signer == nil:
+	case b.signer == nil:
 		return nil, ierrors.Wrap(ErrTransactionBuilder, "must supply signer")
 	}
 
@@ -676,62 +690,127 @@ func (b *TransactionBuilder) Build(signer iotago.AddressSigner) (*iotago.SignedT
 		return nil, ierrors.Wrap(err, "failed to calculate tx transaction for signing message")
 	}
 
-	unlockPos := map[string]int{}
-	unlocks := iotago.Unlocks{}
-	for i, inputRef := range b.transaction.TransactionEssence.Inputs {
-		//nolint:forcetypeassert // we can safely assume that this is an UTXOInput
-		addr := b.inputOwner[inputRef.(*iotago.UTXOInput).OutputID()]
-		addrKey := addr.Key()
+	unlockedSet := &txBuilderUnlockedSet{
+		unlocks:        iotago.Unlocks{},
+		signerUIDs:     map[iotago.Identifier]int{},
+		unlockedChains: map[string]int{},
+	}
 
-		pos, unlocked := unlockPos[addrKey]
-		if !unlocked {
-			// the output's owning chain address must have been unlocked already
-			if _, is := addr.(iotago.ChainAddress); is {
-				return nil, ierrors.Errorf("input %d's owning chain is not unlocked, chainID %s, type %s", i, addr, addr.Type())
+	for inputIndex, inputRef := range b.transaction.TransactionEssence.Inputs {
+		//nolint:forcetypeassert // we can safely assume that this is an UTXOInput
+		owner := b.inputOwner[inputRef.(*iotago.UTXOInput).OutputID()]
+
+		chainAddr, isChainAddress := owner.(iotago.ChainAddress)
+		if isChainAddress {
+			// the inputs's owning chain address must have been unlocked already
+			unlockedAtIndex, isUnlocked := unlockedSet.isChainUnlocked(chainAddr)
+			if !isUnlocked {
+				return nil, ierrors.Errorf("input %d's owning chain is not unlocked, chainID %s, type %s", inputIndex, owner.Bech32(b.api.ProtocolParameters().Bech32HRP()), owner.Type())
 			}
 
-			// produce signature
+			// add a referential unlock to the former unlock position
+			unlockedSet.addReferentialUnlock(owner, unlockedAtIndex)
+
+			// always mark the chain as unlocked in case the output is a chain output
+			unlockedSet.addChainAsUnlocked(inputs[inputIndex], inputIndex)
+
+			// skip the rest of the input processing because we don't need to sign chain inputs
+			continue
+		}
+
+		// get the signer UID for the directly unlockable address
+		signerUID, err := b.signer.SignerUIDForAddress(owner)
+		if err != nil {
+			return nil, ierrors.Wrapf(err, "failed to get signer UID for address %s", owner.Bech32(b.api.ProtocolParameters().Bech32HRP()))
+		}
+
+		unlockedAtIndex, alreadyUnlocked := unlockedSet.signerUIDs[signerUID]
+		if !alreadyUnlocked {
+			// the output's owning chain address must have been unlocked already
+			if _, is := owner.(iotago.ChainAddress); is {
+				return nil, ierrors.Errorf("input %d's owning chain is not unlocked, chainID %s, type %s", inputIndex, owner.Bech32(b.api.ProtocolParameters().Bech32HRP()), owner.Type())
+			}
+
+			var err error
 			var signature iotago.Signature
-			signature, err = signer.Sign(addr, txEssenceData)
+			if signEssence {
+				// sign the tx essence data
+				signature, err = b.signer.Sign(owner, txEssenceData)
+			} else {
+				// sign with empty signature.
+				// this is used for example to calculate the workscore of the transaction before the actual signing.
+				signature, err = b.signer.EmptySignatureForAddress(owner)
+			}
 			if err != nil {
 				return nil, ierrors.Wrapf(err, "failed to sign tx transaction: %s", txEssenceData)
 			}
 
-			unlocks = append(unlocks, &iotago.SignatureUnlock{Signature: signature})
-			addChainAsUnlocked(inputs[i], i, unlockPos)
-			unlockPos[addrKey] = i
+			// add the new signature to the unlocks
+			unlockedSet.addUnlock(&iotago.SignatureUnlock{Signature: signature})
 
-			continue
+			// remember the unlock index for the new signer UID
+			unlockedSet.addSignerUID(signerUID, inputIndex)
+		} else {
+			// add a referential unlock to the former unlock position
+			unlockedSet.addReferentialUnlock(owner, unlockedAtIndex)
 		}
 
-		unlocks = addReferentialUnlock(addr, unlocks, pos)
-		addChainAsUnlocked(inputs[i], i, unlockPos)
+		// always mark the chain as unlocked in case the output is a chain output
+		unlockedSet.addChainAsUnlocked(inputs[inputIndex], inputIndex)
 	}
 
 	sigTxPayload := &iotago.SignedTransaction{
 		API:         b.api,
 		Transaction: b.transaction,
-		Unlocks:     unlocks,
+		Unlocks:     unlockedSet.unlocks,
 	}
 
 	return sigTxPayload, nil
 }
 
-func addReferentialUnlock(addr iotago.Address, unlocks iotago.Unlocks, pos int) iotago.Unlocks {
+// txBuilderUnlockedSet is a helper struct to keep track of the unlocked inputs and their positions.
+type txBuilderUnlockedSet struct {
+	// unlocks holds the unlocks for the tx inputs.
+	unlocks iotago.Unlocks
+	// signerUIDs maps unique signer UIDs to the position of the unlock in the unlocks slice.
+	signerUIDs map[iotago.Identifier]int
+	// unlockedChains maps the chain address key to the position of the unlock in the unlocks slice.
+	unlockedChains map[string]int
+}
+
+// addUnlock adds the given unlock to the set.
+func (u *txBuilderUnlockedSet) addUnlock(unlock iotago.Unlock) {
+	u.unlocks = append(u.unlocks, unlock)
+}
+
+// addReferentialUnlock adds a referential unlock to the set.
+func (u *txBuilderUnlockedSet) addReferentialUnlock(addr iotago.Address, referencedInputIndex int) {
 	switch addr.(type) {
 	case *iotago.AccountAddress:
-		return append(unlocks, &iotago.AccountUnlock{Reference: uint16(pos)})
+		u.addUnlock(&iotago.AccountUnlock{Reference: uint16(referencedInputIndex)})
 	case *iotago.AnchorAddress:
-		return append(unlocks, &iotago.AnchorUnlock{Reference: uint16(pos)})
+		u.addUnlock(&iotago.AnchorUnlock{Reference: uint16(referencedInputIndex)})
 	case *iotago.NFTAddress:
-		return append(unlocks, &iotago.NFTUnlock{Reference: uint16(pos)})
+		u.addUnlock(&iotago.NFTUnlock{Reference: uint16(referencedInputIndex)})
 	default:
-		return append(unlocks, &iotago.ReferenceUnlock{Reference: uint16(pos)})
+		u.addUnlock(&iotago.ReferenceUnlock{Reference: uint16(referencedInputIndex)})
 	}
 }
 
-func addChainAsUnlocked(input iotago.Output, posUnlocked int, prevUnlocked map[string]int) {
+// addSignerUID marks the given signer UID as unlocked at "unlockedAtIndex".
+func (u *txBuilderUnlockedSet) addSignerUID(signerUID iotago.Identifier, unlockedAtIndex int) {
+	u.signerUIDs[signerUID] = unlockedAtIndex
+}
+
+// addChainAsUnlocked marks the underlying chain address as unlocked at "unlockedAtIndex".
+func (u *txBuilderUnlockedSet) addChainAsUnlocked(input iotago.Output, unlockedAtIndex int) {
 	if chainInput, is := input.(iotago.ChainOutput); is && chainInput.ChainID().Addressable() {
-		prevUnlocked[chainInput.ChainID().ToAddress().Key()] = posUnlocked
+		u.unlockedChains[chainInput.ChainID().ToAddress().Key()] = unlockedAtIndex
 	}
+}
+
+// isChainUnlocked checks if the underlying chain address is unlocked and returns the unlock index.
+func (u *txBuilderUnlockedSet) isChainUnlocked(chainAddr iotago.ChainAddress) (int, bool) {
+	unlockedAtIndex, isUnlocked := u.unlockedChains[chainAddr.ChainID().ToAddress().Key()]
+	return unlockedAtIndex, isUnlocked
 }

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -711,7 +711,8 @@ func (b *TransactionBuilder) build(signEssence bool) (*iotago.SignedTransaction,
 			// add a referential unlock to the former unlock position
 			unlockedSet.addReferentialUnlock(owner, unlockedAtIndex)
 
-			// always mark the chain as unlocked in case the output is a chain output
+			// always mark the chain as unlocked in case the output is a chain output.
+			// e.g. "an NFT owns an NFT".
 			unlockedSet.addChainAsUnlocked(inputs[inputIndex], inputIndex)
 
 			// skip the rest of the input processing because we don't need to sign chain inputs
@@ -756,6 +757,7 @@ func (b *TransactionBuilder) build(signEssence bool) (*iotago.SignedTransaction,
 		}
 
 		// always mark the chain as unlocked in case the output is a chain output
+		// e.g. "an NFT owned by an ed25519 address".
 		unlockedSet.addChainAsUnlocked(inputs[inputIndex], inputIndex)
 	}
 
@@ -803,6 +805,8 @@ func (u *txBuilderUnlockedSet) addSignerUID(signerUID iotago.Identifier, unlocke
 }
 
 // addChainAsUnlocked marks the underlying chain address as unlocked at "unlockedAtIndex".
+// This is only done if the output is a chain output and the chain ID is addressable,
+// which is only valid for AccountOutput, AnchorOutput and NFTOutput.
 func (u *txBuilderUnlockedSet) addChainAsUnlocked(input iotago.Output, unlockedAtIndex int) {
 	if chainInput, is := input.(iotago.ChainOutput); is && chainInput.ChainID().Addressable() {
 		u.unlockedChains[chainInput.ChainID().ToAddress().Key()] = unlockedAtIndex

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -659,12 +659,13 @@ func (b *TransactionBuilder) MinRequiredAllottedMana(rmc iotago.Mana, blockIssue
 	return dummyBlock.ManaCost(rmc)
 }
 
-// Build signs the inputs with the given signer and returns the built payload.
+// Build signs the transaction essence and returns the built payload.
 func (b *TransactionBuilder) Build() (*iotago.SignedTransaction, error) {
 	return b.build(true)
 }
 
-// Build signs the inputs with the given signer and returns the built payload.
+// build adds a signature and returns the built payload.
+// Depending on the value of "signEssence" it either signs the essence or adds empty signatures.
 func (b *TransactionBuilder) build(signEssence bool) (*iotago.SignedTransaction, error) {
 	switch {
 	case b.occurredBuildErr != nil:

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -731,11 +731,6 @@ func (b *TransactionBuilder) build(signEssence bool) (*iotago.SignedTransaction,
 
 		unlockedAtIndex, alreadyUnlocked := unlockedSet.signerUIDs[signerUID]
 		if !alreadyUnlocked {
-			// the output's owning chain address must have been unlocked already
-			if _, is := owner.(iotago.ChainAddress); is {
-				return nil, ierrors.Errorf("input %d's owning chain is not unlocked, chainID %s, type %s", inputIndex, owner.Bech32(b.api.ProtocolParameters().Bech32HRP()), owner.Type())
-			}
-
 			var err error
 			var signature iotago.Signature
 			if signEssence {

--- a/builder/transaction_builder.go
+++ b/builder/transaction_builder.go
@@ -718,6 +718,11 @@ func (b *TransactionBuilder) build(signEssence bool) (*iotago.SignedTransaction,
 			continue
 		}
 
+		if _, isDirectUnlockable := owner.(iotago.DirectUnlockableAddress); !isDirectUnlockable {
+			// we only support directly unlockable addresses in the transaction builder for now
+			return nil, ierrors.Errorf("input %d's owning address is not directly unlockable, address %s, type %s", inputIndex, owner.Bech32(b.api.ProtocolParameters().Bech32HRP()), owner.Type())
+		}
+
 		// get the signer UID for the directly unlockable address
 		signerUID, err := b.signer.SignerUIDForAddress(owner)
 		if err != nil {

--- a/gen/address.tmpl
+++ b/gen/address.tmpl
@@ -29,7 +29,7 @@ type {{.Name}} [{{.Name}}BytesLength]byte
 
 func ({{.Receiver}} *{{.Name}}) Clone() Address {
 	cpy := &{{.Name}}{}
-	copy(cpy[:], addr[:])
+	copy(cpy[:], {{.Receiver}}[:])
 
 	return cpy
 }
@@ -40,11 +40,11 @@ func ({{.Receiver}} *{{.Name}}) StorageScore(_ *StorageScoreStructure, _ Storage
 }{{end}}
 
 func ({{.Receiver}} *{{.Name}}) ID() []byte {
-	return lo.PanicOnErr(CommonSerixAPI().Encode(context.TODO(), addr))
+	return lo.PanicOnErr(CommonSerixAPI().Encode(context.TODO(), {{.Receiver}}))
 }
 
 func ({{.Receiver}} *{{.Name}}) Key() string {
-	return string(addr.ID())
+	return string({{.Receiver}}.ID())
 }
 
 {{if index .Features "ed25519unlock"}}
@@ -54,16 +54,16 @@ func ({{.Receiver}} *{{.Name}}) Unlock(msg []byte, sig Signature) error {
 		return ierrors.Wrapf(ErrSignatureAndAddrIncompatible, "can not unlock {{.Name}} with signature of type %s", sig.Type())
 	}
 
-	return edSig.Valid(msg, (*Ed25519Address)(addr))
+	return edSig.Valid(msg, (*Ed25519Address)({{.Receiver}}))
 }{{end}}
 
 {{if index .Features "chainid"}}
 func ({{.Receiver}} *{{.Name}}) ChainID() ChainID {
-	return {{.IdentifierType}}(*addr)
+	return {{.IdentifierType}}(*{{.Receiver}})
 }
 
 func ({{.Receiver}} *{{.Name}}) {{.IdentifierType}}() {{.IdentifierType}} {
-	return {{.IdentifierType}}(*addr)
+	return {{.IdentifierType}}(*{{.Receiver}})
 }{{end}}
 
 func ({{.Receiver}} *{{.Name}}) Equal(other Address) bool {
@@ -72,7 +72,7 @@ func ({{.Receiver}} *{{.Name}}) Equal(other Address) bool {
 		return false
 	}
 
-	return *addr == *otherAddr
+	return *{{.Receiver}} == *otherAddr
 }
 
 func ({{.Receiver}} *{{.Name}}) Type() AddressType {
@@ -80,11 +80,11 @@ func ({{.Receiver}} *{{.Name}}) Type() AddressType {
 }
 
 func ({{.Receiver}} *{{.Name}}) Bech32(hrp NetworkPrefix) string {
-	return bech32StringBytes(hrp, addr.ID())
+	return bech32StringBytes(hrp, {{.Receiver}}.ID())
 }
 
 func ({{.Receiver}} *{{.Name}}) String() string {
-	return hexutil.EncodeHex(addr.ID())
+	return hexutil.EncodeHex({{.Receiver}}.ID())
 }
 
 func ({{.Receiver}} *{{.Name}}) Size() int {
@@ -114,14 +114,14 @@ func {{.Name}}FromReader(reader io.Reader) (*{{.Name}}, error) {
 		return nil, ierrors.Wrap(err, "unable to read address bytes")
 	}
 
-	addr, _, err := AddressFromBytes(addrBytes)
+	{{.Receiver}}, _, err := AddressFromBytes(addrBytes)
 	if err != nil {
 		return nil, ierrors.Wrap(err, "unable to parse address from bytes")
 	}
 
-	address, ok := addr.(*{{.Name}})
+	address, ok := {{.Receiver}}.(*{{.Name}})
 	if !ok {
-		return nil, ierrors.Errorf("invalid address type: %T", addr)
+		return nil, ierrors.Errorf("invalid address type: %T", {{.Receiver}})
 	}
 	
 	return address, nil

--- a/gen/identifier.tmpl
+++ b/gen/identifier.tmpl
@@ -165,11 +165,6 @@ func ({{.Receiver}} {{.Name}}) ToAddress() ChainAddress {
 	return &addr
 }
 
-// Key returns a key to use to index this ChainID.
-func ({{.Receiver}} {{.Name}}) Key() interface{} {
-	return a.String()
-}
-
 // FromOutputID returns the ChainID computed from a given OutputID.
 func ({{.Receiver}} {{.Name}}) FromOutputID(in OutputID) ChainID {
 	return {{.Name}}FromOutputID(in)

--- a/identifier_account.gen.go
+++ b/identifier_account.gen.go
@@ -164,11 +164,6 @@ func (a AccountID) ToAddress() ChainAddress {
 	return &addr
 }
 
-// Key returns a key to use to index this ChainID.
-func (a AccountID) Key() interface{} {
-	return a.String()
-}
-
 // FromOutputID returns the ChainID computed from a given OutputID.
 func (a AccountID) FromOutputID(in OutputID) ChainID {
 	return AccountIDFromOutputID(in)

--- a/identifier_anchor.gen.go
+++ b/identifier_anchor.gen.go
@@ -164,11 +164,6 @@ func (a AnchorID) ToAddress() ChainAddress {
 	return &addr
 }
 
-// Key returns a key to use to index this ChainID.
-func (a AnchorID) Key() interface{} {
-	return a.String()
-}
-
 // FromOutputID returns the ChainID computed from a given OutputID.
 func (a AnchorID) FromOutputID(in OutputID) ChainID {
 	return AnchorIDFromOutputID(in)

--- a/nodeclient/blockissuer_client.go
+++ b/nodeclient/blockissuer_client.go
@@ -21,7 +21,7 @@ type (
 		// SendPayload sends an ApplicationPayload to the block issuer.
 		SendPayload(ctx context.Context, payload iotago.ApplicationPayload, commitmentID iotago.CommitmentID, numPoWWorkers ...int) (*api.BlockCreatedResponse, error)
 		// SendPayloadWithTransactionBuilder automatically allots the needed mana and sends an ApplicationPayload to the block issuer.
-		SendPayloadWithTransactionBuilder(ctx context.Context, builder *builder.TransactionBuilder, signer iotago.AddressSigner, storedManaOutputIndex int, numPoWWorkers ...int) (iotago.ApplicationPayload, *api.BlockCreatedResponse, error)
+		SendPayloadWithTransactionBuilder(ctx context.Context, builder *builder.TransactionBuilder, storedManaOutputIndex int, numPoWWorkers ...int) (iotago.ApplicationPayload, *api.BlockCreatedResponse, error)
 	}
 
 	blockIssuerClient struct {
@@ -92,7 +92,7 @@ func (client *blockIssuerClient) SendPayload(ctx context.Context, payload iotago
 	return client.mineNonceAndSendPayload(ctx, payload, commitmentID, blockIssuerInfo.PowTargetTrailingZeros, numPoWWorkers...)
 }
 
-func (client *blockIssuerClient) SendPayloadWithTransactionBuilder(ctx context.Context, builder *builder.TransactionBuilder, signer iotago.AddressSigner, storedManaOutputIndex int, numPoWWorkers ...int) (iotago.ApplicationPayload, *api.BlockCreatedResponse, error) {
+func (client *blockIssuerClient) SendPayloadWithTransactionBuilder(ctx context.Context, builder *builder.TransactionBuilder, storedManaOutputIndex int, numPoWWorkers ...int) (iotago.ApplicationPayload, *api.BlockCreatedResponse, error) {
 	// get the info from the block issuer
 	blockIssuerInfo, err := client.Info(ctx)
 	if err != nil {
@@ -128,7 +128,7 @@ func (client *blockIssuerClient) SendPayloadWithTransactionBuilder(ctx context.C
 	builder.AllotMinRequiredManaAndStoreRemainingManaInOutput(builder.CreationSlot(), blockIssuance.LatestCommitment.ReferenceManaCost, blockIssuerAccountAddress.AccountID(), storedManaOutputIndex)
 
 	// sign the transaction
-	payload, err := builder.Build(signer)
+	payload, err := builder.Build()
 	if err != nil {
 		return nil, nil, ierrors.Wrap(err, "failed to build the signed transaction payload")
 	}

--- a/output_delegation.go
+++ b/output_delegation.go
@@ -56,10 +56,6 @@ func (delegationID DelegationID) Addressable() bool {
 	return false
 }
 
-func (delegationID DelegationID) Key() interface{} {
-	return delegationID.String()
-}
-
 func (delegationID DelegationID) Empty() bool {
 	return delegationID == emptyDelegationID
 }

--- a/output_foundry.go
+++ b/output_foundry.go
@@ -89,10 +89,6 @@ func (fID FoundryID) Empty() bool {
 	return fID == emptyFoundryID
 }
 
-func (fID FoundryID) Key() interface{} {
-	return fID.String()
-}
-
 func (fID FoundryID) String() string {
 	return hexutil.EncodeHex(fID[:])
 }

--- a/output_nft.go
+++ b/output_nft.go
@@ -41,10 +41,6 @@ func (nftID NFTID) Addressable() bool {
 	return true
 }
 
-func (nftID NFTID) Key() interface{} {
-	return nftID.String()
-}
-
 func (nftID NFTID) FromOutputID(id OutputID) ChainID {
 	addr := NFTAddressFromOutputID(id)
 

--- a/signature.go
+++ b/signature.go
@@ -15,6 +15,13 @@ type Signature interface {
 	ProcessableObject
 	constraints.Cloneable[Signature]
 
+	// MatchesAddress returns true if the Signature matches the given Address.
+	MatchesAddress(Address) bool
+
+	// SignerUID returns the signer unique identifier for the signature.
+	// This can be used to identify the uniqueness of the signer in the unlocks (e.g. unique public key).
+	SignerUID() Identifier
+
 	// Type returns the type of the Signature.
 	Type() SignatureType
 }

--- a/signature.go
+++ b/signature.go
@@ -18,7 +18,7 @@ type Signature interface {
 	// MatchesAddress returns true if the Signature matches the given Address.
 	MatchesAddress(Address) bool
 
-	// SignerUID returns the signer unique identifier for the signature.
+	// SignerUID returns the unique identifier of the signature's signer.
 	// This can be used to identify the uniqueness of the signer in the unlocks (e.g. unique public key).
 	SignerUID() Identifier
 

--- a/signature_ed25519.go
+++ b/signature_ed25519.go
@@ -72,7 +72,7 @@ func (e *Ed25519Signature) MatchesAddress(addr Address) bool {
 	}
 }
 
-// SignerUID returns the signer unique identifier for the signature.
+// SignerUID returns the unique identifier of the signature's signer.
 // This can be used to identify the uniqueness of the signer in the unlocks (e.g. unique public key).
 func (e *Ed25519Signature) SignerUID() Identifier {
 	return IdentifierFromData(e.PublicKey[:])

--- a/signature_ed25519.go
+++ b/signature_ed25519.go
@@ -60,6 +60,24 @@ func (e *Ed25519Signature) String() string {
 	return fmt.Sprintf("public key: %s, signature: %s", hexutil.EncodeHex(e.PublicKey[:]), hexutil.EncodeHex(e.Signature[:]))
 }
 
+// MatchesAddress checks whether the given address matches the public key of the signature.
+func (e *Ed25519Signature) MatchesAddress(addr Address) bool {
+	switch targetAddress := addr.(type) {
+	case *Ed25519Address:
+		return targetAddress.Equal(Ed25519AddressFromPubKey(ed25519.PublicKey(e.PublicKey[:])))
+	case *ImplicitAccountCreationAddress:
+		return targetAddress.Equal(ImplicitAccountCreationAddressFromPubKey(ed25519.PublicKey(e.PublicKey[:])))
+	default:
+		return false
+	}
+}
+
+// SignerUID returns the signer unique identifier for the signature.
+// This can be used to identify the uniqueness of the signer in the unlocks (e.g. unique public key).
+func (e *Ed25519Signature) SignerUID() Identifier {
+	return IdentifierFromData(e.PublicKey[:])
+}
+
 // Valid verifies whether given the message and Ed25519 address, the signature is valid.
 func (e *Ed25519Signature) Valid(msg []byte, addr *Ed25519Address) error {
 	// an address is the Blake2b 256 hash of the public key

--- a/signed_transaction.go
+++ b/signed_transaction.go
@@ -106,7 +106,7 @@ func (t *SignedTransaction) syntacticallyValidate() error {
 	}
 
 	if err := ValidateUnlocks(t.Unlocks,
-		SignatureUniqueAndReferenceUnlocksValidator(t.API),
+		SignaturesUniqueAndReferenceUnlocksValidator(t.API),
 	); err != nil {
 		return ierrors.Errorf("invalid unlocks: %w", err)
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -658,18 +658,22 @@ type transactionSerializeTest struct {
 }
 
 func (test *transactionSerializeTest) ToDeserializeTest() *frameworks.DeSerializeTest {
-	txBuilder := builder.NewTransactionBuilder(tpkg.ZeroCostTestAPI)
+	_, addr, addrKeys := tpkg.RandEd25519Identity()
+
+	txBuilder := builder.NewTransactionBuilder(tpkg.ZeroCostTestAPI, iotago.NewInMemoryAddressSigner(addrKeys))
 	txBuilder.WithTransactionCapabilities(
 		iotago.TransactionCapabilitiesBitMaskWithCapabilities(iotago.WithTransactionCanBurnNativeTokens(true)),
 	)
-	_, addr, addrKeys := tpkg.RandEd25519Identity()
+
 	txBuilder.AddInput(&builder.TxInput{
 		UnlockTarget: addr,
 		InputID:      tpkg.RandUTXOInput().OutputID(),
 		Input:        tpkg.RandBasicOutput(),
 	})
+
 	txBuilder.AddOutput(test.output)
-	tx := lo.PanicOnErr(txBuilder.Build(iotago.NewInMemoryAddressSigner(addrKeys)))
+
+	tx := lo.PanicOnErr(txBuilder.Build())
 
 	return &frameworks.DeSerializeTest{
 		Name:      test.name,

--- a/unlock.go
+++ b/unlock.go
@@ -135,7 +135,7 @@ type ReferentialUnlock interface {
 // UnlockValidatorFunc which given the index and the Unlock itself, runs validations and returns an error if any should fail.
 type UnlockValidatorFunc func(index int, unlock Unlock) error
 
-// SignatureUniqueAndReferenceUnlocksValidator returns a validator which checks that:
+// SignaturesUniqueAndReferenceUnlocksValidator returns a validator which checks that:
 //  1. SignatureUnlock(s) are unique (compared by signer UID)
 //     - SignatureUnlock(s) inside different MultiUnlock(s) don't need to be unique,
 //     as long as there is no equal SignatureUnlock(s) outside of a MultiUnlock(s).
@@ -145,7 +145,7 @@ type UnlockValidatorFunc func(index int, unlock Unlock) error
 //  5. MultiUnlock(s) are not nested
 //  6. MultiUnlock(s) are unique
 //  7. ReferenceUnlock(s) to MultiUnlock(s) are not nested in MultiUnlock(s)
-func SignatureUniqueAndReferenceUnlocksValidator(api API) UnlockValidatorFunc {
+func SignaturesUniqueAndReferenceUnlocksValidator(api API) UnlockValidatorFunc {
 	// seen signature unlocks and their unlock index
 	seenSignatureUnlocks := map[uint16]struct{}{}
 	// seen reference unlocks and their unlock index

--- a/unlock.go
+++ b/unlock.go
@@ -132,21 +132,11 @@ type ReferentialUnlock interface {
 	SourceAllowed(address Address) bool
 }
 
-// publicKeyBytesFromSignatureBlock returns the bytes of the public key in a signature.
-func publicKeyBytesFromSignatureBlock(signature Signature) ([]byte, error) {
-	switch sig := signature.(type) {
-	case *Ed25519Signature:
-		return sig.PublicKey[:], nil
-	default:
-		return nil, ErrUnknownSignatureType
-	}
-}
-
 // UnlockValidatorFunc which given the index and the Unlock itself, runs validations and returns an error if any should fail.
 type UnlockValidatorFunc func(index int, unlock Unlock) error
 
 // SignatureUniqueAndReferenceUnlocksValidator returns a validator which checks that:
-//  1. SignatureUnlock(s) are unique (compared by public key)
+//  1. SignatureUnlock(s) are unique (compared by signer UID)
 //     - SignatureUnlock(s) inside different MultiUnlock(s) don't need to be unique,
 //     as long as there is no equal SignatureUnlock(s) outside of a MultiUnlock(s).
 //  2. ReferenceUnlock(s) reference a previous SignatureUnlock or MultiUnlock
@@ -156,11 +146,17 @@ type UnlockValidatorFunc func(index int, unlock Unlock) error
 //  6. MultiUnlock(s) are unique
 //  7. ReferenceUnlock(s) to MultiUnlock(s) are not nested in MultiUnlock(s)
 func SignatureUniqueAndReferenceUnlocksValidator(api API) UnlockValidatorFunc {
+	// seen signature unlocks and their unlock index
 	seenSignatureUnlocks := map[uint16]struct{}{}
-	seenSigBlockPubkeyBytes := map[string]int{}
-	seenSigBlockPubkeyBytesInMultiUnlocks := map[string]int{}
+	// seen reference unlocks and their unlock index
 	seenReferentialUnlocks := map[uint16]ReferentialUnlock{}
+	// seen signerUIDs in the signature unlocks
+	seenSignerUIDs := map[Identifier]int{}
+	// seen signerUIDs in the signature unlocks inside of multi unlocks
+	seenSignerUIDsInMultiUnlocks := map[Identifier]int{}
+	// seen multi unlocks and their unlock index
 	seenMultiUnlocks := map[uint16]struct{}{}
+	// seen multi unlock bytes and their unlock index
 	seenMultiUnlockBytes := map[string]int{}
 
 	return func(index int, u Unlock) error {
@@ -170,23 +166,20 @@ func SignatureUniqueAndReferenceUnlocksValidator(api API) UnlockValidatorFunc {
 				return ierrors.Wrapf(ErrSignatureUnlockHasNilSignature, "at index %d is nil", index)
 			}
 
-			sigBlockPubKeyBytes, err := publicKeyBytesFromSignatureBlock(unlock.Signature)
-			if err != nil {
-				return ierrors.Wrapf(err, "unable to parse pubkey bytes from signature unlock block at index %d for dup check", index)
-			}
+			signerUID := unlock.Signature.SignerUID()
 
-			// we check for duplicated pubkeys in SignatureUnlock(s)
-			if existingIndex, exists := seenSigBlockPubkeyBytes[string(sigBlockPubKeyBytes)]; exists {
+			// we check for duplicated signer UIDs in SignatureUnlock(s)
+			if existingIndex, exists := seenSignerUIDs[signerUID]; exists {
 				return ierrors.Wrapf(ErrSignatureUnlockNotUnique, "signature unlock block at index %d is the same as %d", index, existingIndex)
 			}
 
-			// we also need to check for duplicated pubkeys in MultiUnlock(s)
-			if existingIndex, exists := seenSigBlockPubkeyBytesInMultiUnlocks[string(sigBlockPubKeyBytes)]; exists {
+			// we also need to check for duplicated signer UIDs in MultiUnlock(s)
+			if existingIndex, exists := seenSignerUIDsInMultiUnlocks[signerUID]; exists {
 				return ierrors.Wrapf(ErrSignatureUnlockNotUnique, "signature unlock block at index %d is the same as in multi unlock at index %d", index, existingIndex)
 			}
 
 			seenSignatureUnlocks[uint16(index)] = struct{}{}
-			seenSigBlockPubkeyBytes[string(sigBlockPubKeyBytes)] = index
+			seenSignerUIDs[signerUID] = index
 
 		case ReferentialUnlock:
 			if prevReferentialUnlock := seenReferentialUnlocks[unlock.ReferencedInputIndex()]; prevReferentialUnlock != nil {
@@ -223,20 +216,17 @@ func SignatureUniqueAndReferenceUnlocksValidator(api API) UnlockValidatorFunc {
 						return ierrors.Wrapf(ErrSignatureUnlockHasNilSignature, "at index %d.%d is nil", index, subIndex)
 					}
 
-					sigBlockPubKeyBytes, err := publicKeyBytesFromSignatureBlock(subUnlock.Signature)
-					if err != nil {
-						return ierrors.Wrapf(err, "unable to parse pubkey bytes from signature unlock block at index %d.%d for dup check", index, subIndex)
-					}
+					signerUID := subUnlock.Signature.SignerUID()
 
-					// we check for duplicated pubkeys in SignatureUnlock(s)
-					if existingIndex, exists := seenSigBlockPubkeyBytes[string(sigBlockPubKeyBytes)]; exists {
+					// we check for duplicated signer UIDs in SignatureUnlock(s)
+					if existingIndex, exists := seenSignerUIDs[signerUID]; exists {
 						return ierrors.Wrapf(ErrSignatureUnlockNotUnique, "signature unlock block at index %d.%d is the same as %d", index, subIndex, existingIndex)
 					}
 
 					// we don't set the index here in "seenSignatureUnlocks" because there is no concept of reference unlocks inside of multi unlocks
 
-					// add the pubkey to "seenSigBlockPubkeyBytesInMultiUnlocks", so we can check that pubkeys from a multi unlock are not reused in a normal SignatureUnlock
-					seenSigBlockPubkeyBytesInMultiUnlocks[string(sigBlockPubKeyBytes)] = index
+					// add the pubkey to "seenSignerUIDsInMultiUnlocks", so we can check that signer UIDs from a multi unlock are not reused in a normal SignatureUnlock
+					seenSignerUIDsInMultiUnlocks[signerUID] = index
 
 				case ReferentialUnlock:
 					if prevRef := seenReferentialUnlocks[subUnlock.ReferencedInputIndex()]; prevRef != nil {

--- a/unlock_test.go
+++ b/unlock_test.go
@@ -50,7 +50,7 @@ func TestUnlock_DeSerialize(t *testing.T) {
 	}
 }
 
-func TestSignatureUniqueAndReferenceUnlocksValidator(t *testing.T) {
+func TestSignaturesUniqueAndReferenceUnlocksValidator(t *testing.T) {
 	tests := []struct {
 		name    string
 		unlocks iotago.Unlocks
@@ -318,7 +318,7 @@ func TestSignatureUniqueAndReferenceUnlocksValidator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			valFunc := iotago.SignatureUniqueAndReferenceUnlocksValidator(tpkg.ZeroCostTestAPI)
+			valFunc := iotago.SignaturesUniqueAndReferenceUnlocksValidator(tpkg.ZeroCostTestAPI)
 			var runErr error
 			for index, unlock := range tt.unlocks {
 				if err := valFunc(index, unlock); err != nil {

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -8126,7 +8126,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			InputSet: vm.InputSet{},
 		}
 
-		txBuilder := builder.NewTransactionBuilder(testAPI)
+		txBuilder := builder.NewTransactionBuilder(testAPI, iotago.NewInMemoryAddressSigner(tt.keys...))
 		txBuilder.WithTransactionCapabilities(
 			iotago.TransactionCapabilitiesBitMaskWithCapabilities(iotago.WithTransactionCanBurnNativeTokens(true)),
 		)
@@ -8145,7 +8145,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 		for _, output := range tests[idx].outputs {
 			txBuilder.AddOutput(output)
 		}
-		tx := lo.PanicOnErr(txBuilder.Build(iotago.NewInMemoryAddressSigner(tt.keys...)))
+		tx := lo.PanicOnErr(txBuilder.Build())
 
 		resolvedInputs.BlockIssuanceCreditInputSet = tests[idx].resolvedBICInputSet
 		resolvedInputs.CommitmentInput = &tests[idx].resolvedCommitmentInput

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -196,19 +196,19 @@ func (s *unlockedAddressesSet) SignatureUnlock(addr iotago.DirectUnlockableAddre
 }
 
 // ReferentialUnlockNonDirectlyUnlockable expects a non-directly unlockable address and performs a check whether the given address
-// is unlocked at referenceInputIndex and if so, it adds the input index to the set of unlocked inputs by this address.
-func (s *unlockedAddressesSet) ReferentialUnlockNonDirectlyUnlockable(owner iotago.Address, inputIndex uint16, referenceInputIndex uint16, checkUnlockOnly bool) error {
+// is unlocked at referencedInputIndex and if so, it adds the input index to the set of unlocked inputs by this address.
+func (s *unlockedAddressesSet) ReferentialUnlockNonDirectlyUnlockable(owner iotago.Address, inputIndex uint16, referencedInputIndex uint16, checkUnlockOnly bool) error {
 	if _, isDirectUnlockable := owner.(iotago.DirectUnlockableAddress); isDirectUnlockable {
 		return ierrors.Errorf("input %d's address is a directly unlockable address, but a non-directly unlockable address was expected", inputIndex)
 	}
 
 	referencedAddr, referenceExists := s.UnlockedAddrsByAddrKey[owner.Key()]
 	if !referenceExists {
-		return ierrors.Errorf("input %d is not unlocked through input %d's unlock", inputIndex, referenceInputIndex)
+		return ierrors.Errorf("input %d is not unlocked through input %d's unlock", inputIndex, referencedInputIndex)
 	}
 
-	if referencedAddr.UnlockedAtInputIndex != referenceInputIndex {
-		return ierrors.Errorf("input %d is not unlocked through input %d's unlock", inputIndex, referenceInputIndex)
+	if referencedAddr.UnlockedAtInputIndex != referencedInputIndex {
+		return ierrors.Errorf("input %d is not unlocked through input %d's unlock", inputIndex, referencedInputIndex)
 	}
 
 	if checkUnlockOnly {
@@ -221,24 +221,24 @@ func (s *unlockedAddressesSet) ReferentialUnlockNonDirectlyUnlockable(owner iota
 }
 
 // ReferentialUnlockDirectlyUnlockable expects a directly unlockable address and performs a check whether the given address
-// is unlocked at referenceInputIndex and if the signature of the referenced unlock matches the given address.
+// is unlocked at referencedInputIndex and if the signature of the referenced unlock matches the given address.
 // If all checks are successful, it adds the input index to the set of unlocked inputs by this address.
 // In case the given address is not yet unlocked, it is added to the set of unlocked addresses.
 // This is necessary if for example the signature was used before to unlock another address (e.g. derived from the same public key).
-func (s *unlockedAddressesSet) ReferentialUnlockDirectlyUnlockable(owner iotago.DirectUnlockableAddress, inputIndex uint16, referenceInputIndex uint16, checkUnlockOnly bool) error {
-	referencedAddrWithSignature, referenceExists := s.SignatureUnlockedAddrsByIndex[referenceInputIndex]
+func (s *unlockedAddressesSet) ReferentialUnlockDirectlyUnlockable(owner iotago.DirectUnlockableAddress, inputIndex uint16, referencedInputIndex uint16, checkUnlockOnly bool) error {
+	referencedAddrWithSignature, referenceExists := s.SignatureUnlockedAddrsByIndex[referencedInputIndex]
 	if !referenceExists {
-		return ierrors.Errorf("input %d is not unlocked through input %d's unlock", inputIndex, referenceInputIndex)
+		return ierrors.Errorf("input %d is not unlocked through input %d's unlock", inputIndex, referencedInputIndex)
 	}
 
-	if referencedAddrWithSignature.UnlockedAtInputIndex != referenceInputIndex {
-		return ierrors.Errorf("input %d is not unlocked through input %d's unlock", inputIndex, referenceInputIndex)
+	if referencedAddrWithSignature.UnlockedAtInputIndex != referencedInputIndex {
+		return ierrors.Errorf("input %d is not unlocked through input %d's unlock", inputIndex, referencedInputIndex)
 	}
 
 	// the signature was already verified in another unlock, so we don't need to check it again,
 	// but we need to make sure that the signature fits the address.
 	if !referencedAddrWithSignature.Signature.MatchesAddress(owner) {
-		return ierrors.Errorf("input %d's address is not unlocked through input %d's unlock", inputIndex, referenceInputIndex)
+		return ierrors.Errorf("input %d's address is not unlocked through input %d's unlock", inputIndex, referencedInputIndex)
 	}
 
 	if checkUnlockOnly {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -185,7 +185,7 @@ func (s *unlockedAddressesSet) SignatureUnlock(addr iotago.DirectUnlockableAddre
 		ReferencedByInputIndex: map[uint16]struct{}{},
 	}
 
-	// we "unlock" the signature and the address itself by adding it to both maps
+	// we "unlock" the signature here, so it can be used for for "ReferentialUnlockDirect" referential unlocks
 	s.SignatureUnlockedAddrsByIndex[inputIndex] = &unlockedAddressWithSignature{
 		unlockedAddress: unlockedAddr,
 		Signature:       sig,
@@ -221,7 +221,7 @@ func (s *unlockedAddressesSet) ReferentialUnlockNonDirectlyUnlockable(owner iota
 }
 
 // ReferentialUnlockDirectlyUnlockable expects a directly unlockable address and performs a check whether the given address
-// is unlocked at referenceInputIndex and if the signature of the referenced unlock matches the given address
+// is unlocked at referenceInputIndex and if the signature of the referenced unlock matches the given address.
 // If all checks are successful, it adds the input index to the set of unlocked inputs by this address.
 // In case the given address is not yet unlocked, it is added to the set of unlocked addresses.
 // This is necessary if for example the signature was used before to unlock another address (e.g. derived from the same public key).
@@ -602,7 +602,7 @@ func unlockAddress(ownerAddr iotago.Address, unlock iotago.Unlock, inputIndex ui
 
 	case *iotago.MultiAddress:
 		switch uBlock := unlock.(type) {
-		// The MultiAddress can be unlocked by a MultiUnlock or a ReferenceUnlock (do not confuse with ReferentialUnlock).
+		// The MultiAddress can be unlocked by a MultiUnlock or a ReferentialUnlock.
 		case iotago.ReferentialUnlock:
 			// ReferentialUnlock for MultiAddress are only allowed if the unlock is not chainable, and the owner address is not a ChainAddress.
 			// This basically means that the ReferentialUnlock must be a ReferenceUnlock and the "ownerAddr" is a MultiAddress.

--- a/workscore_test.go
+++ b/workscore_test.go
@@ -56,7 +56,7 @@ func TestTransactionEssenceWorkScore(t *testing.T) {
 		),
 	)
 
-	tx, err := builder.NewTransactionBuilder(api).
+	tx, err := builder.NewTransactionBuilder(api, iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])})).
 		AddInput(&builder.TxInput{
 			UnlockTarget: addr,
 			InputID:      tpkg.RandOutputID(0),
@@ -74,7 +74,7 @@ func TestTransactionEssenceWorkScore(t *testing.T) {
 		AddRewardInput(&iotago.RewardInput{Index: 0}, 0).
 		IncreaseAllotment(tpkg.RandAccountID(), tpkg.RandMana(10000)+1).
 		IncreaseAllotment(tpkg.RandAccountID(), tpkg.RandMana(10000)+1).
-		Build(iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: addr, Keys: ed25519.PrivateKey(keyPair.PrivateKey[:])}))
+		Build()
 	require.NoError(t, err)
 
 	block, err := builder.NewBasicBlockBuilder(api).Payload(tx).Build()


### PR DESCRIPTION
My take on #697.

Currently it is impossible to unlock an implicit account creation address and an ed25519 address which are derived from the same public key in the same transaction. This is because we disallow to have the same public key in different signatures, but we also fail to check correctly for a valid reference unlock, if the underlying public key is the same, but the address is different.

This PR changes the logic in a way that the public key that unlocked the identity gets tracked, and in a reference unlock it is checked that the specific derived address for that public key matches.

The PR introduces the concept of a `SignerUID` in the `Signature` and `AddressSigner` interface to identify unique signatures signers (in out case public keys).

The `AddressSigner` for the `TransactionBuilder` now needs to be passed in the constructor instead of the `Build` method. This breaking change was necessary because otherwise the workscore for transaction payload was wrong in certain edge cases, because the formerly used `EmptyAddressSigner` had no knowledge about the `SignerUID`s and therefore didn't construct the `ReferentialUnlocks` properly. The `EmptyAddressSigner` was therefore removed.

The PR also removes the unused `Key` interface from the chain ID and other IDs, because the `Key` method of the underlying `Address` is used everywhere instead, which is more precise.