### PR TITLE
Make some Commitment Input checks syntactical

### DIFF
--- a/feat_test.go
+++ b/feat_test.go
@@ -428,6 +428,7 @@ func TestBlockIssuerFeatureSyntacticValidation(t *testing.T) {
 						bik3,
 					}),
 				}
+				t.TransactionEssence.ContextInputs = append(t.TransactionEssence.ContextInputs, tpkg.RandCommitmentInput())
 			},
 			),
 			Target: &iotago.SignedTransaction{},
@@ -442,6 +443,7 @@ func TestBlockIssuerFeatureSyntacticValidation(t *testing.T) {
 						bik3,
 					}),
 				}
+				t.TransactionEssence.ContextInputs = append(t.TransactionEssence.ContextInputs, tpkg.RandCommitmentInput())
 			}),
 			Target:    &iotago.SignedTransaction{},
 			SeriErr:   iotago.ErrArrayValidationOrderViolatesLexicalOrder,
@@ -458,6 +460,7 @@ func TestBlockIssuerFeatureSyntacticValidation(t *testing.T) {
 						bik2,
 					}),
 				}
+				t.TransactionEssence.ContextInputs = append(t.TransactionEssence.ContextInputs, tpkg.RandCommitmentInput())
 			}),
 			Target:    &iotago.SignedTransaction{},
 			SeriErr:   iotago.ErrArrayValidationViolatesUniqueness,
@@ -469,6 +472,7 @@ func TestBlockIssuerFeatureSyntacticValidation(t *testing.T) {
 				t.Outputs = iotago.TxEssenceOutputs{
 					accountWithKeys(iotago.BlockIssuerKeys{}),
 				}
+				t.TransactionEssence.ContextInputs = append(t.TransactionEssence.ContextInputs, tpkg.RandCommitmentInput())
 			}),
 			Target:    &iotago.SignedTransaction{},
 			SeriErr:   serializer.ErrArrayValidationMinElementsNotReached,
@@ -480,6 +484,7 @@ func TestBlockIssuerFeatureSyntacticValidation(t *testing.T) {
 				t.Outputs = iotago.TxEssenceOutputs{
 					accountWithKeys(tpkg.RandBlockIssuerKeys(iotago.MaxBlockIssuerKeysCount + 1)),
 				}
+				t.TransactionEssence.ContextInputs = append(t.TransactionEssence.ContextInputs, tpkg.RandCommitmentInput())
 			}),
 			Target:    &iotago.SignedTransaction{},
 			SeriErr:   serializer.ErrArrayValidationMaxElementsExceeded,

--- a/output.go
+++ b/output.go
@@ -886,3 +886,27 @@ func OutputsSyntacticalMetadataFeatureMaxSize() ElementValidationFunc[Output] {
 		return nil
 	}
 }
+
+// Checks that a Commitment Input is present for
+//   - Accounts with a Staking Feature.
+//   - Accounts with a Block Issuer Feature.
+//   - Delegation Outputs.
+func OutputsSyntacticalCommitmentInput(hasCommitmentInput bool) ElementValidationFunc[Output] {
+	return func(index int, output Output) error {
+		hasStakingFeature := output.FeatureSet().Staking() != nil
+		if hasStakingFeature && !hasCommitmentInput {
+			return ierrors.Wrapf(ErrStakingCommitmentInputMissing, "output %d", index)
+		}
+
+		hasBlockIssuerFeature := output.FeatureSet().BlockIssuer() != nil
+		if hasBlockIssuerFeature && !hasCommitmentInput {
+			return ierrors.Wrapf(ErrBlockIssuerCommitmentInputMissing, "output %d", index)
+		}
+
+		if output.Type() == OutputDelegation && !hasCommitmentInput {
+			return ierrors.Wrapf(ErrDelegationCommitmentInputMissing, "output %d", index)
+		}
+
+		return nil
+	}
+}

--- a/transaction.go
+++ b/transaction.go
@@ -259,6 +259,7 @@ func (t *Transaction) SyntacticallyValidate(api API) error {
 	}
 
 	var maxManaValue Mana = (1 << protoParams.ManaParameters().BitsCount) - 1
+	hasCommitmentInput := t.CommitmentInput() != nil
 
 	return SyntacticallyValidateOutputs(t.Outputs,
 		OutputsSyntacticalUnlockConditionLexicalOrderAndUniqueness(),
@@ -276,6 +277,7 @@ func (t *Transaction) SyntacticallyValidate(api API) error {
 		OutputsSyntacticalDelegation(),
 		OutputsSyntacticalAddressRestrictions(),
 		OutputsSyntacticalImplicitAccountCreationAddress(),
+		OutputsSyntacticalCommitmentInput(hasCommitmentInput),
 	)
 }
 

--- a/vm/nova/vm.go
+++ b/vm/nova/vm.go
@@ -293,7 +293,7 @@ func accountGenesisValid(vmParams *vm.Params, next *iotago.AccountOutput, accoun
 
 	if nextBlockIssuerFeat := next.FeatureSet().BlockIssuer(); nextBlockIssuerFeat != nil {
 		if vmParams.WorkingSet.Commitment == nil {
-			return ierrors.Join(iotago.ErrInvalidBlockIssuerTransition, iotago.ErrBlockIssuerCommitmentInputMissing)
+			panic("commitment input should be present for block issuer features on the output side which should be validated syntactically")
 		}
 
 		pastBoundedSlot := vmParams.PastBoundedSlotIndex(vmParams.WorkingSet.Commitment.Slot)
@@ -485,10 +485,9 @@ func accountStakingSTVF(vmParams *vm.Params, current *iotago.AccountOutput, next
 // or one which was effectively removed and added within the same transaction.
 // This is allowed as long as the epoch range of the old and new feature are disjoint.
 func accountStakingGenesisValidation(vmParams *vm.Params, next *iotago.AccountOutput, stakingFeat *iotago.StakingFeature) error {
-	// It should already never be nil here, but for 100% safety, we'll check again.
 	commitment := vmParams.WorkingSet.Commitment
 	if commitment == nil {
-		return iotago.ErrStakingCommitmentInputMissing
+		panic("commitment input should be present for staking features on the output side which should be validated syntactically")
 	}
 
 	pastBoundedSlot := vmParams.PastBoundedSlotIndex(commitment.Slot)

--- a/vm/nova/vm_test.go
+++ b/vm/nova/vm_test.go
@@ -7526,7 +7526,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 		name                    string
 		inputs                  []TestInput
 		keys                    []iotago.AddressKeys
-		resolvedCommitmentInput iotago.Commitment
+		resolvedCommitmentInput *iotago.Commitment
 		resolvedBICInputSet     vm.BlockIssuanceCreditInputSet
 		outputs                 []iotago.Output
 		wantErr                 error
@@ -7686,7 +7686,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			resolvedBICInputSet: vm.BlockIssuanceCreditInputSet{
 				accountID1: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -7735,7 +7735,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			resolvedBICInputSet: vm.BlockIssuanceCreditInputSet{
 				accountID1: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -7792,7 +7792,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			resolvedBICInputSet: vm.BlockIssuanceCreditInputSet{
 				accountID1: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -7829,7 +7829,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			resolvedBICInputSet: vm.BlockIssuanceCreditInputSet{
 				accountID1: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -7862,7 +7862,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			resolvedBICInputSet: vm.BlockIssuanceCreditInputSet{
 				accountID1: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -7909,7 +7909,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			resolvedBICInputSet: vm.BlockIssuanceCreditInputSet{
 				accountID1: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -7965,7 +7965,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			resolvedBICInputSet: vm.BlockIssuanceCreditInputSet{
 				accountID1: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -8022,7 +8022,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 				accountID1: iotago.BlockIssuanceCredits(0),
 				accountID2: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -8084,7 +8084,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			resolvedBICInputSet: vm.BlockIssuanceCreditInputSet{
 				accountID1: iotago.BlockIssuanceCredits(0),
 			},
-			resolvedCommitmentInput: iotago.Commitment{
+			resolvedCommitmentInput: &iotago.Commitment{
 				Slot: commitmentSlot,
 			},
 			outputs: []iotago.Output{
@@ -8131,6 +8131,19 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 			iotago.TransactionCapabilitiesBitMaskWithCapabilities(iotago.WithTransactionCanBurnNativeTokens(true)),
 		)
 
+		// Add the BIC and Commitment Inputs to the TX builder since they are required syntactically.
+		// Note that this has no effect on the actual test.
+		for accountID := range tests[idx].resolvedBICInputSet {
+			txBuilder.AddBlockIssuanceCreditInput(&iotago.BlockIssuanceCreditInput{
+				AccountID: accountID,
+			})
+		}
+		if tests[idx].resolvedCommitmentInput != nil {
+			txBuilder.AddCommitmentInput(&iotago.CommitmentInput{
+				CommitmentID: tests[idx].resolvedCommitmentInput.MustID(),
+			})
+		}
+
 		for _, input := range tests[idx].inputs {
 			txBuilder.AddInput(&builder.TxInput{
 				UnlockTarget: input.unlockTarget,
@@ -8148,7 +8161,7 @@ func TestTxSemanticImplicitAccountCreationAndTransition(t *testing.T) {
 		tx := lo.PanicOnErr(txBuilder.Build())
 
 		resolvedInputs.BlockIssuanceCreditInputSet = tests[idx].resolvedBICInputSet
-		resolvedInputs.CommitmentInput = &tests[idx].resolvedCommitmentInput
+		resolvedInputs.CommitmentInput = tests[idx].resolvedCommitmentInput
 
 		t.Run(tt.name, func(t *testing.T) {
 			var err error


### PR DESCRIPTION
# Description of change

Make some Commitment Input checks syntactical per the reasoning in [#693](https://github.com/iotaledger/iota.go/issues/693#issuecomment-1977954356).

See the TIPs for details on the updated rules:
- [TIP-40 (Delegation Output)](https://github.com/iotaledger/tips/blob/tip40/tips/TIP-0040/tip-0040.md#additional-transaction-syntactic-validation-rules)
- [TIP-42 (Block Issuer Feature)](https://github.com/iotaledger/tips/blob/tip42/tips/TIP-0042/tip-0042.md#additional-transaction-syntactic-validation-rules)
- [TIP-42 (Staking Feature)](https://github.com/iotaledger/tips/blob/tip42/tips/TIP-0042/tip-0042.md#additional-transaction-syntactic-validation-rules-1)

Fixes #693.

The checks that were previously semantic were made panics since we have to be able to assume at the semantic validation stage that the syntactic stage was passed successfully. Exception to this: Newly added Block Issuer Features still return an error, because we would have to specifically add a panic and make the code less nicely structured, so it seems fine to _not_ panic.

## How the change has been tested

New syntactical function covered 100% by test `TestCommitmentInputSyntacticalValidation`.
